### PR TITLE
feat: add android binary to release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,7 @@ jobs:
           ./sbsh-linux-amd64 ./sbsh-linux-arm64 \
           ./sbsh-darwin-amd64 ./sbsh-darwin-arm64 \
           ./sbsh-freebsd-amd64 ./sbsh-freebsd-arm64 \
+          ./sbsh-android-arm64 \
           --title "${GITHUB_REF#refs/tags/}" \
           --generate-notes \
           --notes "Docker images available at:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Get sbsh up and running in minutes.
 
 ```bash
 # Set your platform (defaults shown)
-export OS=linux        # Options: linux, darwin, freebsd
+export OS=linux        # Options: linux, darwin, freebsd, android(arm64 only)
 export ARCH=amd64      # Options: amd64, arm64
 
 # Install sbsh


### PR DESCRIPTION
## Add Android Build Support

### Overview
This PR adds Android (arm64) build support to sbsh. Android builds are compiled exclusively for arm64 architecture and use Position-Independent Executable (PIE) build mode, which is required for Android compatibility.

### Changes

#### 1. Makefile (`Makefile`)
- Added `android` to the `OS` build matrix
- Added conditional build logic:
  - Skips non-arm64 Android builds (android-amd64) with informative comment
  - Sets `BUILD_MODE="-buildmode=pie"` for Android builds (required for Android)
  - Sets `BUILD_MODE=""` for all other operating systems
- Added `-trimpath` flag to all release builds for reproducible builds

#### 2. GitHub Actions (`.github/workflows/release.yaml`)
- Added `./sbsh-android-arm64` to the list of release artifacts
- Android binary is now included in GitHub releases alongside other platform binaries

#### 3. Documentation (`README.md`)
- Updated install instructions to include `android` as an OS option
- Added note: `android(arm64 only)` in the OS options comment to indicate architecture limitation

### Technical Details

**Build Configuration:**
- Android builds require `-buildmode=pie` (Position Independent Executable) for Android compatibility
- Android builds are restricted to `arm64` architecture only
- All other platforms (linux, darwin, freebsd) continue to support both `amd64` and `arm64`

**Build Process:**
- The Makefile automatically skips `android-amd64` builds with a descriptive comment
- Only `android-arm64` binaries are built and released

### Files Changed
- `.github/workflows/release.yaml` - Added android-arm64 binary to release artifacts
- `Makefile` - Added Android OS support with arm64-only restriction and PIE build mode
- `README.md` - Updated install instructions with Android support note

### Impact
✅ Enables Android (arm64) support for sbsh users
✅ Release workflow now includes Android binary in GitHub releases
✅ Documentation updated with installation instructions for Android
✅ Build process properly handles Android-specific requirements

### Testing
- ✅ Verify `make release-build` builds `sbsh-android-arm64` successfully
- ✅ Verify `android-amd64` build is skipped correctly
- ✅ Verify GitHub release includes `sbsh-android-arm64` binary