### PR TITLE
feat: add sb stop terminal command

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -118,6 +118,16 @@ var (
 	SB_DETACH_ID = DefineKV("SB_DETACH_ID", "sb/detach/id")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SB_DETACH_SOCKET = DefineKV("SB_DETACH_SOCKET", "sb/detach/socket")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SB_STOP_ALL = DefineKV("SB_STOP_ALL", "sb/stop/all")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SB_STOP_FORCE = DefineKV("SB_STOP_FORCE", "sb/stop/force")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SB_STOP_TIMEOUT = DefineKV("SB_STOP_TIMEOUT", "sb/stop/timeout")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SB_STOP_KILL_AFTER = DefineKV("SB_STOP_KILL_AFTER", "sb/stop/killAfter")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SB_STOP_IGNORE_NOT_FOUND = DefineKV("SB_STOP_IGNORE_NOT_FOUND", "sb/stop/ignoreNotFound")
 
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SBSH_ROOT_CONFIG_FILE = DefineKV("SBSH_CONFIG_FILE", "sbsh/configFile")

--- a/cmd/sb/sb.go
+++ b/cmd/sb/sb.go
@@ -31,6 +31,7 @@ import (
 	"github.com/eminwux/sbsh/cmd/sb/detach"
 	"github.com/eminwux/sbsh/cmd/sb/get"
 	"github.com/eminwux/sbsh/cmd/sb/prune"
+	"github.com/eminwux/sbsh/cmd/sb/stop"
 	"github.com/eminwux/sbsh/cmd/sb/version"
 	"github.com/eminwux/sbsh/cmd/types"
 	"github.com/eminwux/sbsh/internal/errdefs"
@@ -117,6 +118,7 @@ func setupRootCmd(rootCmd *cobra.Command) error {
 	rootCmd.AddCommand(version.NewVersionCmd())
 	rootCmd.AddCommand(autocomplete.NewAutoCompleteCmd(rootCmd))
 	rootCmd.AddCommand(prune.NewPruneCmd())
+	rootCmd.AddCommand(stop.NewStopCmd())
 	rootCmd.AddCommand(detach.NewDetachCmd())
 	rootCmd.AddCommand(attach.NewAttachCmd())
 	rootCmd.AddCommand(get.NewGetCmd())

--- a/cmd/sb/stop/stop.go
+++ b/cmd/sb/stop/stop.go
@@ -14,22 +14,29 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package terminal
+package stop
 
 import (
-	"context"
-	"net"
-
-	"github.com/eminwux/sbsh/pkg/api"
+	"github.com/spf13/cobra"
 )
 
-type Client interface {
-	Ping(ctx context.Context, ping *api.PingMessage, pong *api.PingMessage) error
-	Resize(ctx context.Context, args *api.ResizeArgs) error
-	Detach(ctx context.Context, id *api.ID) error
-	Attach(ctx context.Context, clientID *api.ID, response any) (net.Conn, error)
-	Close() error
-	Metadata(ctx context.Context, metadata *api.TerminalDoc) error
-	State(ctx context.Context, state *api.TerminalStatusMode) error
-	Stop(ctx context.Context, args *api.StopArgs) error
+func NewStopCmd() *cobra.Command {
+	stopCmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop running terminals",
+		Long: `Stop running terminals.
+
+Signals a live terminal to shut down via the terminal's control RPC, with a
+SIGTERM fallback if the RPC is unreachable. Stale or already-exited terminals
+are reported idempotently. Metadata is left behind for 'sb prune terminals'.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	setupStopCmd(stopCmd)
+	return stopCmd
+}
+
+func setupStopCmd(stopCmd *cobra.Command) {
+	stopCmd.AddCommand(NewStopTerminalsCmd())
 }

--- a/cmd/sb/stop/terminals.go
+++ b/cmd/sb/stop/terminals.go
@@ -31,6 +31,7 @@ import (
 	"github.com/eminwux/sbsh/cmd/types"
 	"github.com/eminwux/sbsh/internal/discovery"
 	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/internal/pidutil"
 	"github.com/eminwux/sbsh/pkg/api"
 	rpcterminal "github.com/eminwux/sbsh/pkg/rpcclient/terminal"
 	"github.com/spf13/cobra"
@@ -43,6 +44,8 @@ const (
 	stopPollInterval = 100 * time.Millisecond
 	//nolint:mnd // short RPC dial deadline (network is a Unix socket)
 	stopRPCDialTimeout = 3 * time.Second
+	//nolint:mnd // short fixed grace after SIGKILL; the kernel reaps almost immediately
+	sigkillGrace = 2 * time.Second
 )
 
 type stopOpts struct {
@@ -57,7 +60,7 @@ type stopOpts struct {
 
 func NewStopTerminalsCmd() *cobra.Command {
 	stopTerminalsCmd := &cobra.Command{
-		Use:     "terminal [name]",
+		Use:     "terminal [name|--all]",
 		Aliases: []string{"terminals", "terms", "term", "t"},
 		Short:   "Stop a running terminal",
 		Long: `Stop a running terminal by name.
@@ -77,7 +80,7 @@ Metadata is left in place so 'sb prune terminals' can clean it up.`,
 				return errdefs.ErrLoggerNotFound
 			}
 
-			opts, err := resolveStopOpts(cmd, args)
+			opts, err := resolveStopOpts(args)
 			if err != nil {
 				return err
 			}
@@ -111,7 +114,7 @@ func setupStopTerminalsCmd(c *cobra.Command) {
 	_ = viper.BindPFlag(config.SB_STOP_IGNORE_NOT_FOUND.ViperKey, c.Flags().Lookup("ignore-not-found"))
 }
 
-func resolveStopOpts(cmd *cobra.Command, args []string) (stopOpts, error) {
+func resolveStopOpts(args []string) (stopOpts, error) {
 	opts := stopOpts{
 		runPath:        viper.GetString(config.SB_ROOT_RUN_PATH.ViperKey),
 		all:            viper.GetBool(config.SB_STOP_ALL.ViperKey),
@@ -138,9 +141,6 @@ func resolveStopOpts(cmd *cobra.Command, args []string) (stopOpts, error) {
 		return opts, fmt.Errorf("%w: --timeout must be greater than zero", errdefs.ErrInvalidFlag)
 	}
 
-	// cmd is only needed to keep a parallel signature with other commands
-	// that read flags directly; viper already has everything we need.
-	_ = cmd
 	return opts, nil
 }
 
@@ -246,20 +246,22 @@ func stopOneTerminal(
 	}
 
 	// Refresh liveness: ReconcileTerminals mutates state, but when called
-	// through FindTerminalByName we only see the on-disk snapshot. Check PID
-	// directly.
-	if doc.Status.State == api.Exited || !processAlive(doc.Status.Pid) {
+	// through FindTerminalByName we only see the on-disk snapshot. Verify
+	// the PID still belongs to the same process we recorded — a recycled
+	// PID looks "alive" but is some unrelated stranger.
+	if doc.Status.State == api.Exited || !processIsOurs(doc.Status.Pid, doc.Status.PidStart) {
 		fmt.Fprintf(stdout, "terminal %q already exited\n", name)
 		return resultAlreadyExited
 	}
 
 	if opts.force {
-		if err := sendSignal(doc.Status.Pid, syscall.SIGKILL); err != nil {
+		if err := sendSignal(doc.Status.Pid, doc.Status.PidStart, syscall.SIGKILL); err != nil {
 			fmt.Fprintf(stderr, "failed to SIGKILL terminal %q: %v\n", name, err)
 			return resultFailed
 		}
-		if !waitForExit(ctx, doc.Status.Pid, opts.timeout) {
-			fmt.Fprintf(stderr, "terminal %q did not exit after SIGKILL within %s\n", name, opts.timeout)
+		if !waitForExit(ctx, doc.Status.Pid, doc.Status.PidStart, sigkillGrace) {
+			fmt.Fprintf(stderr, "terminal %q did not exit after SIGKILL within %s: %v\n",
+				name, sigkillGrace, errdefs.ErrStopTimeout)
 			return resultFailed
 		}
 		fmt.Fprintf(stdout, "terminal %q stopped (SIGKILL)\n", name)
@@ -270,30 +272,31 @@ func stopOneTerminal(
 	if err := stopViaRPC(ctx, logger, doc); err != nil {
 		logger.DebugContext(ctx, "Stop RPC failed, falling back to SIGTERM",
 			"name", name, "error", err)
-		if errSig := sendSignal(doc.Status.Pid, syscall.SIGTERM); errSig != nil {
+		if errSig := sendSignal(doc.Status.Pid, doc.Status.PidStart, syscall.SIGTERM); errSig != nil {
 			fmt.Fprintf(stderr, "failed to signal terminal %q: %v\n", name, errSig)
 			return resultFailed
 		}
 	}
 
-	if waitForExit(ctx, doc.Status.Pid, opts.timeout) {
+	if waitForExit(ctx, doc.Status.Pid, doc.Status.PidStart, opts.timeout) {
 		fmt.Fprintf(stdout, "terminal %q stopped\n", name)
 		return resultStopped
 	}
 
 	if !opts.killAfter {
-		fmt.Fprintf(stderr, "terminal %q did not exit within %s (use --kill-after to escalate)\n",
-			name, opts.timeout)
+		fmt.Fprintf(stderr, "terminal %q did not exit within %s (use --kill-after to escalate): %v\n",
+			name, opts.timeout, errdefs.ErrStopTimeout)
 		return resultFailed
 	}
 
 	fmt.Fprintf(stdout, "terminal %q did not exit within %s; escalating to SIGKILL\n", name, opts.timeout)
-	if err := sendSignal(doc.Status.Pid, syscall.SIGKILL); err != nil {
+	if err := sendSignal(doc.Status.Pid, doc.Status.PidStart, syscall.SIGKILL); err != nil {
 		fmt.Fprintf(stderr, "failed to SIGKILL terminal %q: %v\n", name, err)
 		return resultFailed
 	}
-	if !waitForExit(ctx, doc.Status.Pid, opts.timeout) {
-		fmt.Fprintf(stderr, "terminal %q did not exit after SIGKILL within %s\n", name, opts.timeout)
+	if !waitForExit(ctx, doc.Status.Pid, doc.Status.PidStart, sigkillGrace) {
+		fmt.Fprintf(stderr, "terminal %q did not exit after SIGKILL within %s: %v\n",
+			name, sigkillGrace, errdefs.ErrStopTimeout)
 		return resultFailed
 	}
 	fmt.Fprintf(stdout, "terminal %q stopped (SIGKILL)\n", name)
@@ -310,19 +313,33 @@ func stopViaRPC(
 		return errors.New("terminal metadata has no control socket recorded")
 	}
 
-	dialCtx, cancel := context.WithTimeout(ctx, stopRPCDialTimeout)
-	defer cancel()
-
 	rc := rpcterminal.NewUnix(socket, logger, rpcterminal.WithDialTimeout(stopRPCDialTimeout))
 	defer func() { _ = rc.Close() }()
 
-	return rc.Stop(dialCtx, &api.StopArgs{Reason: "sb stop"})
+	return rc.Stop(ctx, &api.StopArgs{Reason: "sb stop"})
 }
 
-func sendSignal(pid int, sig syscall.Signal) error {
+// sendSignal delivers sig to pid, but only after confirming pid still maps
+// to the recorded process instance (pidStart). Without that check a SIGKILL
+// after PID reuse would target an unrelated process.
+func sendSignal(pid int, pidStart uint64, sig syscall.Signal) error {
 	if pid <= 0 {
 		return fmt.Errorf("%w: invalid pid %d", errdefs.ErrSignalProcess, pid)
 	}
+
+	ok, err := pidutil.Match(pid, pidStart)
+	if err != nil {
+		// /proc entry vanished while we were looking — process is gone.
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("%w: %w", errdefs.ErrSignalProcess, err)
+	}
+	if !ok {
+		// PID has been recycled by an unrelated process; refuse to signal.
+		return nil
+	}
+
 	proc, err := os.FindProcess(pid)
 	if err != nil {
 		return fmt.Errorf("%w: %w", errdefs.ErrSignalProcess, err)
@@ -335,6 +352,22 @@ func sendSignal(pid int, sig syscall.Signal) error {
 		return fmt.Errorf("%w: %w", errdefs.ErrSignalProcess, err)
 	}
 	return nil
+}
+
+// processIsOurs reports whether pid is alive AND matches the recorded
+// pidStart token. A live but mismatched PID counts as "not ours" so callers
+// treat the original process as gone.
+func processIsOurs(pid int, pidStart uint64) bool {
+	if pid <= 0 {
+		return false
+	}
+	if pidStart != 0 {
+		ok, err := pidutil.Match(pid, pidStart)
+		if err != nil || !ok {
+			return false
+		}
+	}
+	return processAlive(pid)
 }
 
 func processAlive(pid int) bool {
@@ -356,13 +389,13 @@ func processAlive(pid int) bool {
 	return errors.Is(err, syscall.EPERM)
 }
 
-func waitForExit(ctx context.Context, pid int, timeout time.Duration) bool {
+func waitForExit(ctx context.Context, pid int, pidStart uint64, timeout time.Duration) bool {
 	if pid <= 0 {
 		return true
 	}
 	deadline := time.Now().Add(timeout)
 	for {
-		if !processAlive(pid) {
+		if !processIsOurs(pid, pidStart) {
 			return true
 		}
 		if time.Now().After(deadline) {
@@ -370,7 +403,7 @@ func waitForExit(ctx context.Context, pid int, timeout time.Duration) bool {
 		}
 		select {
 		case <-ctx.Done():
-			return !processAlive(pid)
+			return !processIsOurs(pid, pidStart)
 		case <-time.After(stopPollInterval):
 		}
 	}

--- a/cmd/sb/stop/terminals.go
+++ b/cmd/sb/stop/terminals.go
@@ -1,0 +1,377 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package stop
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/eminwux/sbsh/cmd/config"
+	"github.com/eminwux/sbsh/cmd/sb/get"
+	"github.com/eminwux/sbsh/cmd/types"
+	"github.com/eminwux/sbsh/internal/discovery"
+	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/pkg/api"
+	rpcterminal "github.com/eminwux/sbsh/pkg/rpcclient/terminal"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	defaultStopTimeout = 10 * time.Second
+	//nolint:mnd // poll interval while waiting for the process to exit
+	stopPollInterval = 100 * time.Millisecond
+	//nolint:mnd // short RPC dial deadline (network is a Unix socket)
+	stopRPCDialTimeout = 3 * time.Second
+)
+
+type stopOpts struct {
+	runPath        string
+	name           string
+	all            bool
+	force          bool
+	timeout        time.Duration
+	killAfter      bool
+	ignoreNotFound bool
+}
+
+func NewStopTerminalsCmd() *cobra.Command {
+	stopTerminalsCmd := &cobra.Command{
+		Use:     "terminal [name]",
+		Aliases: []string{"terminals", "terms", "term", "t"},
+		Short:   "Stop a running terminal",
+		Long: `Stop a running terminal by name.
+
+By default, sends a Stop RPC to the terminal controller (graceful). If the RPC
+is unreachable, falls back to SIGTERM on the recorded PID. After signalling,
+waits up to --timeout for the process to exit. With --force, sends SIGKILL
+immediately. With --kill-after, escalates to SIGKILL when the timeout elapses.
+
+Metadata is left in place so 'sb prune terminals' can clean it up.`,
+		SilenceUsage:      true,
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: get.CompleteTerminals,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)
+			if !ok || logger == nil {
+				return errdefs.ErrLoggerNotFound
+			}
+
+			opts, err := resolveStopOpts(cmd, args)
+			if err != nil {
+				return err
+			}
+
+			if err := runStopTerminals(cmd.Context(), logger, os.Stdout, os.Stderr, opts); err != nil {
+				logger.DebugContext(cmd.Context(), "stop terminals failed", "error", err)
+				return err
+			}
+			return nil
+		},
+	}
+
+	setupStopTerminalsCmd(stopTerminalsCmd)
+	return stopTerminalsCmd
+}
+
+func setupStopTerminalsCmd(c *cobra.Command) {
+	c.Flags().Bool("all", false, "Stop every active terminal")
+	_ = viper.BindPFlag(config.SB_STOP_ALL.ViperKey, c.Flags().Lookup("all"))
+
+	c.Flags().Bool("force", false, "Send SIGKILL immediately instead of a graceful stop")
+	_ = viper.BindPFlag(config.SB_STOP_FORCE.ViperKey, c.Flags().Lookup("force"))
+
+	c.Flags().Duration("timeout", defaultStopTimeout, "How long to wait for the terminal to exit")
+	_ = viper.BindPFlag(config.SB_STOP_TIMEOUT.ViperKey, c.Flags().Lookup("timeout"))
+
+	c.Flags().Bool("kill-after", false, "Escalate to SIGKILL if the terminal is still alive after --timeout")
+	_ = viper.BindPFlag(config.SB_STOP_KILL_AFTER.ViperKey, c.Flags().Lookup("kill-after"))
+
+	c.Flags().Bool("ignore-not-found", false, "Exit 0 if the terminal cannot be found")
+	_ = viper.BindPFlag(config.SB_STOP_IGNORE_NOT_FOUND.ViperKey, c.Flags().Lookup("ignore-not-found"))
+}
+
+func resolveStopOpts(cmd *cobra.Command, args []string) (stopOpts, error) {
+	opts := stopOpts{
+		runPath:        viper.GetString(config.SB_ROOT_RUN_PATH.ViperKey),
+		all:            viper.GetBool(config.SB_STOP_ALL.ViperKey),
+		force:          viper.GetBool(config.SB_STOP_FORCE.ViperKey),
+		timeout:        viper.GetDuration(config.SB_STOP_TIMEOUT.ViperKey),
+		killAfter:      viper.GetBool(config.SB_STOP_KILL_AFTER.ViperKey),
+		ignoreNotFound: viper.GetBool(config.SB_STOP_IGNORE_NOT_FOUND.ViperKey),
+	}
+
+	if len(args) == 1 {
+		opts.name = args[0]
+	}
+
+	if opts.name == "" && !opts.all {
+		return opts, errdefs.ErrNoTerminalIdentifier
+	}
+	if opts.name != "" && opts.all {
+		return opts, fmt.Errorf(
+			"%w: --all cannot be combined with a positional terminal name",
+			errdefs.ErrInvalidFlag,
+		)
+	}
+	if opts.timeout <= 0 {
+		return opts, fmt.Errorf("%w: --timeout must be greater than zero", errdefs.ErrInvalidFlag)
+	}
+
+	// cmd is only needed to keep a parallel signature with other commands
+	// that read flags directly; viper already has everything we need.
+	_ = cmd
+	return opts, nil
+}
+
+func runStopTerminals(
+	ctx context.Context,
+	logger *slog.Logger,
+	stdout, stderr io.Writer,
+	opts stopOpts,
+) error {
+	targets, err := resolveTargets(ctx, logger, opts)
+	if err != nil {
+		if errors.Is(err, errdefs.ErrTerminalNotFound) && opts.ignoreNotFound {
+			fmt.Fprintf(stdout, "terminal %q not found (ignored)\n", opts.name)
+			return nil
+		}
+		return err
+	}
+
+	if len(targets) == 0 {
+		fmt.Fprintln(stdout, "no active terminals found")
+		return nil
+	}
+
+	var stopped, alreadyExited, failed int
+	for i := range targets {
+		doc := &targets[i]
+		res := stopOneTerminal(ctx, logger, stdout, stderr, doc, opts)
+		switch res {
+		case resultStopped:
+			stopped++
+		case resultAlreadyExited:
+			alreadyExited++
+		case resultFailed:
+			failed++
+		}
+	}
+
+	if opts.all || len(targets) > 1 {
+		fmt.Fprintf(stdout,
+			"stopped %d terminal(s), %d already exited, %d error(s)\n",
+			stopped, alreadyExited, failed)
+	}
+	if failed > 0 {
+		return fmt.Errorf("%w: %d terminal(s) failed to stop", errdefs.ErrStopTerminal, failed)
+	}
+	return nil
+}
+
+type stopResult int
+
+const (
+	resultStopped stopResult = iota
+	resultAlreadyExited
+	resultFailed
+)
+
+func resolveTargets(
+	ctx context.Context,
+	logger *slog.Logger,
+	opts stopOpts,
+) ([]api.TerminalDoc, error) {
+	if opts.all {
+		terminals, err := discovery.ScanTerminals(ctx, logger, opts.runPath)
+		if err != nil {
+			return nil, err
+		}
+		discovery.ReconcileTerminals(ctx, logger, opts.runPath, terminals)
+		active := make([]api.TerminalDoc, 0, len(terminals))
+		for _, t := range terminals {
+			if t.Status.State != api.Exited {
+				active = append(active, t)
+			}
+		}
+		return active, nil
+	}
+
+	doc, err := discovery.FindTerminalByName(ctx, logger, opts.runPath, opts.name)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errdefs.ErrTerminalNotFound, err)
+	}
+	if doc == nil {
+		return nil, fmt.Errorf("%w: terminal %q", errdefs.ErrTerminalNotFound, opts.name)
+	}
+	return []api.TerminalDoc{*doc}, nil
+}
+
+func stopOneTerminal(
+	ctx context.Context,
+	logger *slog.Logger,
+	stdout, stderr io.Writer,
+	doc *api.TerminalDoc,
+	opts stopOpts,
+) stopResult {
+	name := doc.Spec.Name
+	if name == "" {
+		name = string(doc.Spec.ID)
+	}
+
+	if len(doc.Status.Attachers) > 0 {
+		fmt.Fprintf(stderr,
+			"warning: terminal %q currently has %d attacher(s); they will be disconnected\n",
+			name, len(doc.Status.Attachers))
+	}
+
+	// Refresh liveness: ReconcileTerminals mutates state, but when called
+	// through FindTerminalByName we only see the on-disk snapshot. Check PID
+	// directly.
+	if doc.Status.State == api.Exited || !processAlive(doc.Status.Pid) {
+		fmt.Fprintf(stdout, "terminal %q already exited\n", name)
+		return resultAlreadyExited
+	}
+
+	if opts.force {
+		if err := sendSignal(doc.Status.Pid, syscall.SIGKILL); err != nil {
+			fmt.Fprintf(stderr, "failed to SIGKILL terminal %q: %v\n", name, err)
+			return resultFailed
+		}
+		if !waitForExit(ctx, doc.Status.Pid, opts.timeout) {
+			fmt.Fprintf(stderr, "terminal %q did not exit after SIGKILL within %s\n", name, opts.timeout)
+			return resultFailed
+		}
+		fmt.Fprintf(stdout, "terminal %q stopped (SIGKILL)\n", name)
+		return resultStopped
+	}
+
+	// Graceful path: try RPC first, fall back to SIGTERM.
+	if err := stopViaRPC(ctx, logger, doc); err != nil {
+		logger.DebugContext(ctx, "Stop RPC failed, falling back to SIGTERM",
+			"name", name, "error", err)
+		if errSig := sendSignal(doc.Status.Pid, syscall.SIGTERM); errSig != nil {
+			fmt.Fprintf(stderr, "failed to signal terminal %q: %v\n", name, errSig)
+			return resultFailed
+		}
+	}
+
+	if waitForExit(ctx, doc.Status.Pid, opts.timeout) {
+		fmt.Fprintf(stdout, "terminal %q stopped\n", name)
+		return resultStopped
+	}
+
+	if !opts.killAfter {
+		fmt.Fprintf(stderr, "terminal %q did not exit within %s (use --kill-after to escalate)\n",
+			name, opts.timeout)
+		return resultFailed
+	}
+
+	fmt.Fprintf(stdout, "terminal %q did not exit within %s; escalating to SIGKILL\n", name, opts.timeout)
+	if err := sendSignal(doc.Status.Pid, syscall.SIGKILL); err != nil {
+		fmt.Fprintf(stderr, "failed to SIGKILL terminal %q: %v\n", name, err)
+		return resultFailed
+	}
+	if !waitForExit(ctx, doc.Status.Pid, opts.timeout) {
+		fmt.Fprintf(stderr, "terminal %q did not exit after SIGKILL within %s\n", name, opts.timeout)
+		return resultFailed
+	}
+	fmt.Fprintf(stdout, "terminal %q stopped (SIGKILL)\n", name)
+	return resultStopped
+}
+
+func stopViaRPC(
+	ctx context.Context,
+	logger *slog.Logger,
+	doc *api.TerminalDoc,
+) error {
+	socket := doc.Status.SocketFile
+	if socket == "" {
+		return errors.New("terminal metadata has no control socket recorded")
+	}
+
+	dialCtx, cancel := context.WithTimeout(ctx, stopRPCDialTimeout)
+	defer cancel()
+
+	rc := rpcterminal.NewUnix(socket, logger, rpcterminal.WithDialTimeout(stopRPCDialTimeout))
+	defer func() { _ = rc.Close() }()
+
+	return rc.Stop(dialCtx, &api.StopArgs{Reason: "sb stop"})
+}
+
+func sendSignal(pid int, sig syscall.Signal) error {
+	if pid <= 0 {
+		return fmt.Errorf("%w: invalid pid %d", errdefs.ErrSignalProcess, pid)
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errdefs.ErrSignalProcess, err)
+	}
+	if err := proc.Signal(sig); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			// Process is already gone — not an error for our purposes.
+			return nil
+		}
+		return fmt.Errorf("%w: %w", errdefs.ErrSignalProcess, err)
+	}
+	return nil
+}
+
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = proc.Signal(syscall.Signal(0))
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, syscall.ESRCH) {
+		return false
+	}
+	// EPERM: process exists but we lack permission. Treat as alive.
+	return errors.Is(err, syscall.EPERM)
+}
+
+func waitForExit(ctx context.Context, pid int, timeout time.Duration) bool {
+	if pid <= 0 {
+		return true
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		if !processAlive(pid) {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		select {
+		case <-ctx.Done():
+			return !processAlive(pid)
+		case <-time.After(stopPollInterval):
+		}
+	}
+}

--- a/cmd/sb/stop/terminals_test.go
+++ b/cmd/sb/stop/terminals_test.go
@@ -19,6 +19,7 @@ package stop
 import (
 	"context"
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/eminwux/sbsh/cmd/config"
@@ -92,8 +93,8 @@ func Test_ResolveStopOpts(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			viper.Reset()
 			c.setup()
-			cmd := NewStopTerminalsCmd()
-			_, err := resolveStopOpts(cmd, c.args)
+			_ = NewStopTerminalsCmd() // build flag bindings into viper
+			_, err := resolveStopOpts(c.args)
 			if c.wantErr == nil {
 				if err != nil {
 					t.Fatalf("expected no error, got %v", err)
@@ -113,5 +114,25 @@ func Test_ProcessAlive_InvalidPid(t *testing.T) {
 	}
 	if processAlive(-1) {
 		t.Fatal("expected pid -1 to be reported dead")
+	}
+}
+
+func Test_ProcessIsOurs_DifferentToken(t *testing.T) {
+	pid := os.Getpid()
+	// any non-zero token that won't match self's actual start time forces
+	// pidutil.Match to return false, proving processIsOurs rejects mismatches
+	// even when the pid is alive.
+	if processIsOurs(pid, 1) {
+		t.Fatal("expected processIsOurs to reject a live pid with a mismatching pidStart token")
+	}
+}
+
+func Test_ProcessIsOurs_ZeroTokenFallsBack(t *testing.T) {
+	// Zero pidStart means metadata predates the token; fall back to liveness.
+	if !processIsOurs(os.Getpid(), 0) {
+		t.Fatal("expected processIsOurs(self, 0) to be true (liveness fallback)")
+	}
+	if processIsOurs(0, 0) {
+		t.Fatal("expected processIsOurs(0, 0) to be false")
 	}
 }

--- a/cmd/sb/stop/terminals_test.go
+++ b/cmd/sb/stop/terminals_test.go
@@ -1,0 +1,117 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package stop
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/eminwux/sbsh/cmd/config"
+	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/spf13/viper"
+)
+
+func Test_ErrLoggerNotFound_Terminal_RunE(t *testing.T) {
+	cmd := NewStopTerminalsCmd()
+	ctx := context.Background()
+	cmd.SetContext(ctx)
+
+	err := cmd.RunE(cmd, []string{"foo"})
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+	if !errors.Is(err, errdefs.ErrLoggerNotFound) {
+		t.Fatalf("expected '%v'; got: '%v'", errdefs.ErrLoggerNotFound, err)
+	}
+}
+
+func Test_ResolveStopOpts(t *testing.T) {
+	type tc struct {
+		name    string
+		args    []string
+		setup   func()
+		wantErr error
+	}
+	cases := []tc{
+		{
+			name:    "no name and not --all errors",
+			args:    []string{},
+			setup:   func() {},
+			wantErr: errdefs.ErrNoTerminalIdentifier,
+		},
+		{
+			name: "name with --all errors",
+			args: []string{"foo"},
+			setup: func() {
+				viper.Set(config.SB_STOP_ALL.ViperKey, true)
+			},
+			wantErr: errdefs.ErrInvalidFlag,
+		},
+		{
+			name: "zero timeout errors",
+			args: []string{"foo"},
+			setup: func() {
+				viper.Set(config.SB_STOP_TIMEOUT.ViperKey, 0)
+			},
+			wantErr: errdefs.ErrInvalidFlag,
+		},
+		{
+			name: "name only succeeds",
+			args: []string{"foo"},
+			setup: func() {
+				viper.Set(config.SB_STOP_TIMEOUT.ViperKey, "5s")
+			},
+			wantErr: nil,
+		},
+		{
+			name: "--all with no name succeeds",
+			args: []string{},
+			setup: func() {
+				viper.Set(config.SB_STOP_ALL.ViperKey, true)
+				viper.Set(config.SB_STOP_TIMEOUT.ViperKey, "5s")
+			},
+			wantErr: nil,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			viper.Reset()
+			c.setup()
+			cmd := NewStopTerminalsCmd()
+			_, err := resolveStopOpts(cmd, c.args)
+			if c.wantErr == nil {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, c.wantErr) {
+				t.Fatalf("expected %v, got %v", c.wantErr, err)
+			}
+		})
+	}
+}
+
+func Test_ProcessAlive_InvalidPid(t *testing.T) {
+	if processAlive(0) {
+		t.Fatal("expected pid 0 to be reported dead")
+	}
+	if processAlive(-1) {
+		t.Fatal("expected pid -1 to be reported dead")
+	}
+}

--- a/docs/gap-analysis.md
+++ b/docs/gap-analysis.md
@@ -1,0 +1,192 @@
+# sbsh / sb Gap Analysis
+
+Gaps observed while authoring and testing two new profiles (`sbsh-dev`, `kukeon-dev`)
+that launch `/bin/bash` and invoke `claude` from `onInit`. Each gap lists the
+observed behavior, the impact, a suggested fix, and a rough implementation
+complexity. Items are ordered by priority.
+
+## Priority list (highest first)
+
+1. ~~**P0** — `sb get profile <name>` detail view~~ **(DONE in `e09b45e`)**.
+2. **P0** — Profile validation / lint command (`sb validate profiles`).
+3. ~~**P1** — `sb delete terminal <name>` / `sb stop <name>` for live terminals~~ **(DONE)**.
+4. **P1** — Expose terminal PID and cwd in `sb get terminals`.
+5. **P1** — `sb logs <name>` with ANSI-stripping option, instead of relying on `--capture-file`.
+6. **P2** — Directory-based profile discovery (`~/.sbsh/profiles.d/*.yaml`).
+7. **P2** — Document `onInit` semantics (typed into PTY, not exec'd).
+8. **P2** — JSON/YAML output mode for `sb get` (`-o yaml`, `-o json`).
+9. **P3** — Published JSON Schema for `TerminalProfile`.
+10. **P3** — Name-collision handling on `--terminal-name`.
+11. **P3** — Clarify `CREATED` column showing `-` for some terminals.
+12. **P3** — Help text tautology: `sbsh --help` says "see sbsh help".
+
+---
+
+## Gaps in detail
+
+### 1. No `sb get profile <name>` detail view  (P0) — **DONE**
+
+Closed by commit `e09b45e` (`feat: wide output for sb get`). At HEAD:
+- `sb get profile <name>` works via single-arg dispatch in
+  `cmd/sb/get/profiles.go:42-50`; aliases `profile|prof|pro|p`.
+- `-o yaml|json` honored at `cmd/sb/get/profiles.go:60` and validated at
+  `profiles.go:145-147`; shared marshaler in
+  `internal/discovery/terminals.go:399-422`.
+- Unit tests in `cmd/sb/get/profiles_test.go`; integration round-trip in
+  `cmd/sb/get/get_integration_test.go:431-575`.
+
+Residual polish (tracked informally): `printTerminalMetadata` duplicates
+output in the empty-format branch (`%+v` + `PrintHuman`);
+`FindProfileByName` returns a plain `fmt.Errorf` rather than a sentinel.
+
+### 2. No profile validation / lint command  (P0)
+
+- **Observed:** An invalid profile (bad YAML, unknown field, invalid
+  `runTarget`, malformed `prompt` escape) is only discovered when you try
+  to launch it with `sbsh -p <name>`. `sb get profiles` will list it even
+  if the spec is nonsense, because it only needs `metadata.name` and `cmd`.
+- **Impact:** Errors surface at launch time inside a PTY, making them hard
+  to notice (e.g. mis-quoted prompt strings).
+- **Fix:** `sb validate profiles [path]` that unmarshals strictly
+  (`yaml.UnmarshalStrict` or equivalent), checks enum fields
+  (`runTarget`, `restartPolicy`), and verifies `cmd` resolves in PATH when
+  `runTarget: local`.
+- **Complexity:** Low–medium.
+
+### 3. No way to stop a live terminal  (P1) — **DONE**
+
+Implemented via a new `sb stop terminal <name>` command.
+
+- Command lives in `cmd/sb/stop/` (`stop.go`, `terminals.go`), wired into
+  the root at `cmd/sb/sb.go` alongside `prune`.
+- Graceful path: new `TerminalController.Stop` RPC (added in
+  `pkg/api/terminal.go`, server handler in
+  `internal/terminal/terminalrpc/rpc_server.go`, client method in
+  `pkg/rpcclient/terminal/rpc_session.go`) triggers
+  `controller.Close(…)` asynchronously so the RPC reply can flush
+  before teardown.
+- Fallback: SIGTERM on `Status.Pid` if the control socket is
+  unreachable; `--force` sends SIGKILL immediately;
+  `--kill-after` escalates after `--timeout` (default 10s).
+- `--all` stops every active terminal; `--ignore-not-found` makes the
+  command idempotent. Attached clients are warned then disconnected.
+- Metadata is left in place — `sb prune terminals` still owns cleanup.
+
+### 4. `sb get terminals` lacks PID and cwd  (P1)
+
+- **Observed:** Columns are `NAME PROFILE TTY CREATED`. PID only appears in
+  the launch output. `cwd` is not shown anywhere post-launch.
+- **Impact:** Can't match a terminal row to a running process without extra
+  steps. Agents working with many terminals cannot tell them apart if
+  profiles/names are similar.
+- **Fix:** Add `PID` and `CWD` columns; optionally behind `-o wide` (you
+  already do this for `sb get`, per commit `e09b45e`).
+- **Complexity:** Low.
+
+### 5. No `sb logs` command; relying on `--capture-file`  (P1)
+
+- **Observed:** To observe a detached terminal I had to pass
+  `--capture-file /tmp/foo.log` at launch. The file contains raw ANSI
+  escapes, control sequences, and bracketed-paste markers, which are hard
+  to read.
+- **Impact:** Post-hoc debugging of a terminal you didn't start with
+  `--capture-file` is impossible. ANSI noise makes even captured logs
+  unreadable without external tooling.
+- **Fix:** `sb logs <name> [--follow] [--strip-ansi] [--since <dur>]`.
+  Always capture to a per-terminal buffer/file under `run-path`; expose
+  via this command.
+- **Complexity:** Medium. Requires always-on capture (small buffer or
+  on-disk ring).
+
+### 6. Profiles must live in one file  (P2)
+
+- **Observed:** `~/.sbsh/profiles.yaml` holds all profiles separated by
+  `---`. Editing one profile touches the shared file; concurrent edits by
+  agents/tools risk corruption.
+- **Impact:** Hard to manage when profile count grows (user already has
+  `aleph`, `bernard`, `sbsh-dev`, `kukeon-dev`, and planned
+  `*-dev0/1/2`, `*-reviewer0/1`).
+- **Fix:** Support a `~/.sbsh/profiles.d/*.yaml` overlay directory (in
+  addition to the single file for backward compat). Load, validate, and
+  merge by `metadata.name`.
+- **Complexity:** Low–medium.
+
+### 7. `onInit` semantics undocumented  (P2)
+
+- **Observed:** `internal/terminal/terminalrunner/lifecycle.go:259-282`
+  shows `onInit` steps are typed into the PTY via `sr.Write(...)`. They are
+  **not** exec'd as subprocesses. `docs/site/concepts/profiles.md` and the
+  example profiles don't make this explicit.
+- **Impact:** Users expect shell-level semantics (env from `step.Env`
+  exported to the parent shell; script runs before prompt). In reality,
+  env key/value pairs are prefixed inline (`FOO="bar" script`), and the
+  script inherits whatever the shell's state is at that instant.
+  Side-effect: if `onInit` launches a long-lived process like `claude`,
+  the terminal state transitions to `Ready` immediately after writing the
+  line — it is not "blocked" on the command finishing.
+- **Fix:** Add a dedicated section to
+  `docs/site/concepts/profiles.md` explaining:
+  - `onInit` / `postAttach` are typed into the shell stdin, not exec'd.
+  - Foreground vs background behavior.
+  - Caveats: multi-line scripts, here-docs, and env scoping.
+- **Complexity:** Trivial (docs only).
+
+### 8. No structured output from `sb get`  (P2)
+
+- **Observed:** `sb get profiles` and `sb get terminals` emit a table only.
+- **Impact:** Agents cannot reliably parse output; must regex column widths.
+- **Fix:** Add `-o json` and `-o yaml` for both commands.
+- **Complexity:** Low.
+
+### 9. No published JSON Schema for `TerminalProfile`  (P3)
+
+- **Observed:** I had to cross-reference example profiles
+  (`docs/profiles/*.yaml`) and the Go struct to confirm which fields exist
+  (e.g., `restartPolicy` enum values: saw `exit`, `restart-on-error`,
+  `restart-unlimited` in docs and `on-failure` in user's file — are both
+  valid?).
+- **Impact:** IDE/editor validation and agent reasoning both suffer.
+- **Fix:** Emit JSON Schema from the Go struct (e.g. `invopop/jsonschema`)
+  and publish at `docs/schema/terminal-profile.json`.
+- **Complexity:** Medium.
+
+### 10. `--terminal-name` collision behavior  (P3)
+
+- **Observed:** Behavior undocumented if a terminal with the same name
+  already exists.
+- **Impact:** Agents running scripted launches can't predict outcomes.
+- **Fix:** Document + either fail fast or append a suffix.
+- **Complexity:** Low.
+
+### 11. `CREATED` column sometimes shows `-`  (P3)
+
+- **Observed:** `sb get terminals` showed `CREATED: -` for
+  `farseeing_smeagol` while others had `7m`.
+- **Impact:** Ambiguous — is it stale? not yet initialized? missing field?
+- **Fix:** Either populate reliably or replace `-` with an explicit state
+  (`unknown`, `stale`). Consider adding a `STATE` column derived from
+  `api.State`.
+- **Complexity:** Low.
+
+### 12. Help text tautology  (P3)
+
+- **Observed:** `sbsh --help` prints `You can see available options and
+  commands with: sbsh help`.
+- **Impact:** Confusing — `sbsh --help` already did that.
+- **Fix:** Replace with useful guidance (e.g. link to docs, or list
+  example flows).
+- **Complexity:** Trivial.
+
+---
+
+## Notes for agents picking this up
+
+- Run `make test` at the repo root before/after any change.
+- Profile parsing lives under `pkg/api` and `internal/` (search for
+  `TerminalProfile`).
+- Table renderers for `sb get` are under `cmd/sb` (commit `e09b45e`
+  already introduced wide output — follow the same pattern).
+- Lifecycle code (`OnInit`, `PostAttach`, `Close`) is in
+  `internal/terminal/terminalrunner/lifecycle.go`.
+- Do not delete `~/.sbsh/profiles.yaml` parsing when adding
+  `profiles.d/` — merge both sources.

--- a/internal/client/clientrunner/io_test.go
+++ b/internal/client/clientrunner/io_test.go
@@ -69,6 +69,10 @@ func (m *mockTerminalClient) State(ctx context.Context, state *api.TerminalStatu
 	return errors.New("stateFunc not set")
 }
 
+func (m *mockTerminalClient) Stop(_ context.Context, _ *api.StopArgs) error {
+	return nil
+}
+
 func Test_WaitReady_WithMultipleStates(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/client/clientrunner/metadata.go
+++ b/internal/client/clientrunner/metadata.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/internal/pidutil"
 	"github.com/eminwux/sbsh/internal/shared"
 	"github.com/eminwux/sbsh/pkg/api"
 )
@@ -39,9 +40,16 @@ func (sr *Exec) CreateMetadata() error {
 		return fmt.Errorf("mkdir terminal dir: %w", err)
 	}
 
+	pid := os.Getpid()
+	pidStart, startErr := pidutil.StartTime(pid)
+	if startErr != nil {
+		sr.logger.Warn("CreateMetadata: failed to capture pid start-time token", "pid", pid, "error", startErr)
+	}
+
 	sr.metadataMu.Lock()
 	sr.metadata.Status.State = api.ClientInitializing
-	sr.metadata.Status.Pid = os.Getpid()
+	sr.metadata.Status.Pid = pid
+	sr.metadata.Status.PidStart = pidStart
 	sr.metadata.Status.BaseRunPath = runPath
 	sr.metadata.Status.ClientRunPath = dir
 

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -77,4 +77,7 @@ var (
 	ErrNoClientsFound         = errors.New("no clients found")
 	ErrTerminalNotFound       = errors.New("terminal not found")
 	ErrClientNotFound         = errors.New("client not found")
+	ErrStopTerminal           = errors.New("could not stop terminal")
+	ErrStopTimeout            = errors.New("terminal did not exit within timeout")
+	ErrSignalProcess          = errors.New("failed to signal terminal process")
 )

--- a/internal/pidutil/pidutil.go
+++ b/internal/pidutil/pidutil.go
@@ -1,0 +1,62 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package pidutil exposes a stable per-process identifier used to detect PID
+// reuse: after a process exits, the kernel may recycle its PID for an
+// unrelated process, so callers that persist PIDs and later signal them must
+// reconfirm identity before delivering the signal.
+//
+// On Linux the identifier is the kernel-reported start time
+// (/proc/<pid>/stat field 22 — clock ticks since boot); on platforms without
+// an equivalent zero-cost source the identifier is 0 ("unknown") and
+// identity checks degrade to "trust the PID". Stored alongside the PID in
+// metadata, the identifier lets callers reject stale PIDs before signalling.
+package pidutil
+
+// StartTime returns an opaque identifier for the running instance with the
+// given PID. Two calls for the same live process return the same value;
+// calls separated by a process exit (and PID recycle) return different
+// values. A return of (0, nil) means the platform does not expose a usable
+// per-process identifier and callers should skip the identity check.
+func StartTime(pid int) (uint64, error) {
+	if pid <= 0 {
+		return 0, nil
+	}
+	return readStartTime(pid)
+}
+
+// Match reports whether the process currently holding pid is the same one
+// that produced expected. An expected value of 0 means "no token recorded"
+// (e.g. metadata written before this check existed, or a platform that does
+// not support it) and Match returns true so callers fall back to the raw
+// PID. Errors from the platform reader (most notably ESRCH/"no such file")
+// are surfaced as (false, err) so callers can distinguish "process gone"
+// from "unable to determine".
+func Match(pid int, expected uint64) (bool, error) {
+	if expected == 0 {
+		return true, nil
+	}
+	got, err := StartTime(pid)
+	if err != nil {
+		return false, err
+	}
+	if got == 0 {
+		// Platform doesn't expose the token but the metadata recorded one;
+		// can't verify, so refuse to confirm a match.
+		return false, nil
+	}
+	return got == expected, nil
+}

--- a/internal/pidutil/pidutil_linux.go
+++ b/internal/pidutil/pidutil_linux.go
@@ -1,0 +1,48 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+// +build linux
+
+package pidutil
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// readStartTime returns field 22 of /proc/<pid>/stat (starttime: clock ticks
+// after boot when the process started). The comm field is wrapped in parens
+// and may itself contain spaces or parens, so we split after the LAST ')'.
+func readStartTime(pid int) (uint64, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return 0, err
+	}
+	rparen := strings.LastIndexByte(string(data), ')')
+	if rparen < 0 || rparen+1 >= len(data) {
+		return 0, fmt.Errorf("pidutil: malformed /proc/%d/stat", pid)
+	}
+	fields := strings.Fields(string(data[rparen+1:]))
+	// After the closing ')' the next field is #3 (state), so #22 is index 19.
+	const startTimeIdx = 19
+	if len(fields) <= startTimeIdx {
+		return 0, fmt.Errorf("pidutil: /proc/%d/stat: only %d fields after comm", pid, len(fields))
+	}
+	return strconv.ParseUint(fields[startTimeIdx], 10, 64)
+}

--- a/internal/pidutil/pidutil_other.go
+++ b/internal/pidutil/pidutil_other.go
@@ -1,0 +1,27 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+// +build !linux
+
+package pidutil
+
+// readStartTime is a no-op on platforms without a per-process start-time
+// counter we can read cheaply. Callers see (0, nil), interpreted as "no
+// token available" by Match.
+func readStartTime(_ int) (uint64, error) {
+	return 0, nil
+}

--- a/internal/pidutil/pidutil_test.go
+++ b/internal/pidutil/pidutil_test.go
@@ -1,0 +1,92 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package pidutil
+
+import (
+	"os"
+	"runtime"
+	"testing"
+)
+
+func TestStartTime_SelfStable(t *testing.T) {
+	a, err := StartTime(os.Getpid())
+	if err != nil {
+		t.Fatalf("StartTime(self) error: %v", err)
+	}
+	b, err := StartTime(os.Getpid())
+	if err != nil {
+		t.Fatalf("StartTime(self) second call error: %v", err)
+	}
+	if a != b {
+		t.Fatalf("StartTime(self) is not stable: %d vs %d", a, b)
+	}
+	if runtime.GOOS == "linux" && a == 0 {
+		t.Fatalf("StartTime(self) on linux returned 0; expected a non-zero token")
+	}
+}
+
+func TestStartTime_NonPositivePid(t *testing.T) {
+	got, err := StartTime(0)
+	if err != nil || got != 0 {
+		t.Fatalf("StartTime(0) = (%d, %v); want (0, nil)", got, err)
+	}
+	got, err = StartTime(-1)
+	if err != nil || got != 0 {
+		t.Fatalf("StartTime(-1) = (%d, %v); want (0, nil)", got, err)
+	}
+}
+
+func TestMatch_ZeroExpectedAlwaysTrue(t *testing.T) {
+	ok, err := Match(os.Getpid(), 0)
+	if err != nil || !ok {
+		t.Fatalf("Match(self, 0) = (%v, %v); want (true, nil)", ok, err)
+	}
+}
+
+func TestMatch_SelfMatches(t *testing.T) {
+	tok, err := StartTime(os.Getpid())
+	if err != nil {
+		t.Fatalf("StartTime(self) error: %v", err)
+	}
+	if tok == 0 {
+		t.Skip("platform exposes no start-time token; nothing to match")
+	}
+	ok, err := Match(os.Getpid(), tok)
+	if err != nil {
+		t.Fatalf("Match(self, tok) error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("Match(self, tok) = false; want true")
+	}
+}
+
+func TestMatch_DifferentToken(t *testing.T) {
+	tok, err := StartTime(os.Getpid())
+	if err != nil {
+		t.Fatalf("StartTime(self) error: %v", err)
+	}
+	if tok == 0 {
+		t.Skip("platform exposes no start-time token; mismatch is unreachable")
+	}
+	ok, err := Match(os.Getpid(), tok+1)
+	if err != nil {
+		t.Fatalf("Match(self, tok+1) error: %v", err)
+	}
+	if ok {
+		t.Fatalf("Match(self, tok+1) = true; want false")
+	}
+}

--- a/internal/terminal/controller.go
+++ b/internal/terminal/controller.go
@@ -328,6 +328,20 @@ func (c *Controller) Metadata() (*api.TerminalDoc, error) {
 	return sr.Metadata()
 }
 
+func (c *Controller) Stop(args *api.StopArgs) error {
+	reason := "stop requested"
+	if args != nil && args.Reason != "" {
+		reason = args.Reason
+	}
+	c.logger.InfoContext(c.ctx, "Stop RPC invoked", "reason", reason)
+	// Close asynchronously so the RPC reply can be written before the
+	// server socket is torn down.
+	go func() {
+		_ = c.Close(fmt.Errorf("stop: %s", reason))
+	}()
+	return nil
+}
+
 func (c *Controller) State() (*api.TerminalStatusMode, error) {
 	c.srMu.RLock()
 	sr := c.sr

--- a/internal/terminal/controller_fake.go
+++ b/internal/terminal/controller_fake.go
@@ -36,6 +36,7 @@ type ControllerTest struct {
 	DetachFunc    func(id *api.ID) error
 	MetadataFunc  func() (*api.TerminalDoc, error)
 	StateFunc     func() (*api.TerminalStatusMode, error)
+	StopFunc      func(args *api.StopArgs) error
 }
 
 func (f *ControllerTest) Run(spec *api.TerminalSpec) error {
@@ -106,4 +107,11 @@ func (f *ControllerTest) State() (*api.TerminalStatusMode, error) {
 		return f.StateFunc()
 	}
 	return nil, errdefs.ErrFuncNotSet
+}
+
+func (f *ControllerTest) Stop(args *api.StopArgs) error {
+	if f.StopFunc != nil {
+		return f.StopFunc(args)
+	}
+	return errdefs.ErrFuncNotSet
 }

--- a/internal/terminal/terminalrpc/rpc_server.go
+++ b/internal/terminal/terminalrpc/rpc_server.go
@@ -61,3 +61,7 @@ func (s *TerminalControllerRPC) State(_ api.Empty, state *api.TerminalStatusMode
 	*state = *st
 	return nil
 }
+
+func (s *TerminalControllerRPC) Stop(args *api.StopArgs, _ *api.Empty) error {
+	return s.Core.Stop(args)
+}

--- a/internal/terminal/terminalrunner/metadata.go
+++ b/internal/terminal/terminalrunner/metadata.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/internal/pidutil"
 	"github.com/eminwux/sbsh/internal/shared"
 	"github.com/eminwux/sbsh/pkg/api"
 )
@@ -39,8 +40,15 @@ func (sr *Exec) CreateMetadata() error {
 		return fmt.Errorf("mkdir terminal dir: %w", err)
 	}
 
+	pid := os.Getpid()
+	pidStart, startErr := pidutil.StartTime(pid)
+	if startErr != nil {
+		sr.logger.Warn("CreateMetadata: failed to capture pid start-time token", "pid", pid, "error", startErr)
+	}
+
 	sr.metadataMu.Lock()
-	sr.metadata.Status.Pid = os.Getpid()
+	sr.metadata.Status.Pid = pid
+	sr.metadata.Status.PidStart = pidStart
 	sr.metadata.Status.BaseRunPath = runPath
 	sr.metadata.Status.TerminalRunPath = dir
 	sr.metadata.Status.LogFile = sr.metadata.Spec.LogFile

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -42,7 +42,10 @@ type ClientSpec struct {
 }
 
 type ClientStatus struct {
-	Pid           int              `json:"pid"`
+	Pid int `json:"pid"`
+	// PidStart mirrors TerminalStatus.PidStart: an opaque per-process
+	// identifier so signal-based teardown can detect PID reuse.
+	PidStart      uint64           `json:"pidStart,omitempty"`
 	BaseRunPath   string           `json:"baseRunPath"`
 	ClientRunPath string           `json:"clientRunPath"`
 	State         ClientStatusMode `json:"state"`

--- a/pkg/api/terminal.go
+++ b/pkg/api/terminal.go
@@ -73,7 +73,12 @@ type TerminalSpec struct {
 }
 
 type TerminalStatus struct {
-	Pid             int                `json:"pid"`
+	Pid int `json:"pid"`
+	// PidStart is an opaque per-process identifier captured at metadata
+	// write time so callers that later signal Pid can reject a recycled
+	// PID. Zero means "no token recorded" and consumers should treat the
+	// PID as unverifiable. See internal/pidutil.
+	PidStart        uint64             `json:"pidStart,omitempty"`
 	Tty             string             `json:"tty"`
 	State           TerminalStatusMode `json:"state"`
 	SocketFile      string             `json:"socketCtrl"`

--- a/pkg/api/terminal.go
+++ b/pkg/api/terminal.go
@@ -29,6 +29,7 @@ type TerminalController interface {
 	Attach(id *ID, reply *ResponseWithFD) error
 	Metadata() (*TerminalDoc, error)
 	State() (*TerminalStatusMode, error)
+	Stop(args *StopArgs) error
 }
 
 type TerminalDoc struct {
@@ -149,6 +150,7 @@ const (
 	TerminalMethodDetach   = TerminalService + ".Detach"
 	TerminalMethodMetadata = TerminalService + ".Metadata"
 	TerminalMethodState    = TerminalService + ".State"
+	TerminalMethodStop     = TerminalService + ".Stop"
 )
 
 type PingMessage struct {
@@ -158,6 +160,10 @@ type PingMessage struct {
 type ResizeArgs struct {
 	Cols int
 	Rows int
+}
+
+type StopArgs struct {
+	Reason string
 }
 
 // ResponseWithFD carries a normal JSON result plus OOB file descriptors.

--- a/pkg/rpcclient/terminal/rpc_session.go
+++ b/pkg/rpcclient/terminal/rpc_session.go
@@ -259,3 +259,7 @@ func (c *client) State(ctx context.Context, state *api.TerminalStatusMode) error
 	}
 	return nil
 }
+
+func (c *client) Stop(ctx context.Context, args *api.StopArgs) error {
+	return c.call(ctx, c.logger, api.TerminalMethodStop, args, &api.Empty{})
+}


### PR DESCRIPTION
## Summary
- New `sb stop terminal <name>` command (plus `--all`, `--force`, `--timeout`, `--kill-after`, `--ignore-not-found`) to shut down live terminals previously started with `sbsh -d`.
- Adds a `TerminalController.Stop` RPC (api + server + client + controller) that triggers `Close` asynchronously so the reply can flush before teardown; falls back to SIGTERM on the recorded PID if the control socket is unreachable.
- Closes gap #3 in docs/gap-analysis.md. Metadata is left in place for `sb prune terminals`.

## Test plan
- [ ] `go test ./cmd/... ./pkg/...`
- [ ] `sbsh -d -p <profile>` then `sb stop terminal <name>` — terminal exits gracefully, metadata visible in `sb get terminals --all` as Exited.
- [ ] `sb stop terminal <name> --force` — SIGKILL path.
- [ ] `sb stop terminal <name> --kill-after --timeout 2s` against a process that ignores SIGTERM — escalates to SIGKILL.
- [ ] `sb stop terminal <name> --ignore-not-found` — exits 0 when name missing.
- [ ] `sb stop terminal --all` — stops every active terminal, summary line shown.

Note: `internal/terminal/controller_test.go:Test_HandleEvent_EvCmdExited` hangs when run with `-count>1` or after clearing the test cache; reproduces on `main` with this branch stashed, so unrelated to this change.