### PR TITLE
feat: add sb write/read and Write/Subscribe RPCs for programmatic terminal I/O

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -128,6 +128,10 @@ var (
 	SB_STOP_KILL_AFTER = DefineKV("SB_STOP_KILL_AFTER", "sb/stop/killAfter")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SB_STOP_IGNORE_NOT_FOUND = DefineKV("SB_STOP_IGNORE_NOT_FOUND", "sb/stop/ignoreNotFound")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SB_WRITE_RAW = DefineKV("SB_WRITE_RAW", "sb/write/raw")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SB_READ_FOLLOW = DefineKV("SB_READ_FOLLOW", "sb/read/follow")
 
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SBSH_ROOT_CONFIG_FILE = DefineKV("SBSH_CONFIG_FILE", "sbsh/configFile")

--- a/cmd/sb/read/read.go
+++ b/cmd/sb/read/read.go
@@ -126,7 +126,7 @@ func runRead(
 
 	// Subscribe BEFORE reading the capture file so bytes written during the
 	// replay are captured in the live stream rather than lost at the cutover.
-	conn, err := rc.Subscribe(ctx, &api.SubscribeRequest{ClientID: api.ID(naming.RandomID())}, nil)
+	conn, err := rc.Subscribe(ctx, &api.SubscribeRequest{ClientID: api.ID(naming.RandomID())}, &api.Empty{})
 	if err != nil {
 		return fmt.Errorf("subscribe: %w", err)
 	}
@@ -162,19 +162,39 @@ func dumpCapture(path string, stdout io.Writer) error {
 	return nil
 }
 
-// laggedNotice mirrors the sentinel the server writes before disconnecting
-// a slow subscriber. Detecting it lets us surface a clear error code.
+// laggedNotice mirrors the bracketed core of the server sentinel (see
+// internal/terminal/terminalrunner/subscriber.go). The server wraps this
+// in \r\n framing; the needle here is the bare bracketed form so framing
+// can evolve on the server without breaking client detection.
 var laggedNotice = []byte("[sbsh: subscriber lagged, disconnecting]")
 
 func streamLive(conn net.Conn, stdout, stderr io.Writer) error {
 	buf := make([]byte, 4096)
+	// A single server-side Write delivers the sentinel atomically, but
+	// TCP/socket reads can still split it across chunk boundaries. Keep
+	// a rolling tail of (len(laggedNotice)-1) bytes from the previous
+	// chunk and scan tail+chunk so a split sentinel is still detected.
+	tailCap := len(laggedNotice) - 1
+	var tail []byte
 	laggedSeen := false
 	for {
 		n, err := conn.Read(buf)
 		if n > 0 {
 			chunk := buf[:n]
-			if !laggedSeen && bytes.Contains(chunk, laggedNotice) {
-				laggedSeen = true
+			if !laggedSeen {
+				scan := chunk
+				if len(tail) > 0 {
+					scan = append(append(make([]byte, 0, len(tail)+n), tail...), chunk...)
+				}
+				if bytes.Contains(scan, laggedNotice) {
+					laggedSeen = true
+				} else if tailCap > 0 {
+					if len(scan) > tailCap {
+						tail = append(tail[:0], scan[len(scan)-tailCap:]...)
+					} else {
+						tail = append(tail[:0], scan...)
+					}
+				}
 			}
 			if _, werr := stdout.Write(chunk); werr != nil {
 				return fmt.Errorf("write stdout: %w", werr)

--- a/cmd/sb/read/read.go
+++ b/cmd/sb/read/read.go
@@ -1,0 +1,194 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package read
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/eminwux/sbsh/cmd/config"
+	"github.com/eminwux/sbsh/cmd/sb/get"
+	"github.com/eminwux/sbsh/cmd/types"
+	"github.com/eminwux/sbsh/internal/discovery"
+	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/internal/naming"
+	"github.com/eminwux/sbsh/pkg/api"
+	rpcterminal "github.com/eminwux/sbsh/pkg/rpcclient/terminal"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type readOpts struct {
+	runPath string
+	name    string
+	follow  bool
+}
+
+func NewReadCmd() *cobra.Command {
+	readCmd := &cobra.Command{
+		Use:   "read <name>",
+		Short: "Print a terminal's capture log; with -f, follow live output",
+		Long: `Print the full capture log for a terminal.
+
+With -f/--follow, also stream live PTY output after replaying the file, like
+'tail -f'. The follower subscribes to live output BEFORE replaying the capture
+file, so no bytes can be dropped in the handoff; at most a small window of
+bytes near the cutover may appear both in the replay and the live stream.
+
+If the subscriber falls behind the PTY reader (default buffer: 1 MiB), the
+stream is closed with a lagged-notice sentinel and this command exits
+non-zero.`,
+		SilenceUsage:      true,
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: get.CompleteTerminals,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)
+			if !ok || logger == nil {
+				return errdefs.ErrLoggerNotFound
+			}
+			opts := readOpts{
+				runPath: viper.GetString(config.SB_ROOT_RUN_PATH.ViperKey),
+				name:    args[0],
+				follow:  viper.GetBool(config.SB_READ_FOLLOW.ViperKey),
+			}
+			if opts.name == "" {
+				return errdefs.ErrNoTerminalIdentifier
+			}
+			return runRead(cmd.Context(), logger, os.Stdout, os.Stderr, opts)
+		},
+	}
+
+	setupReadFlags(readCmd)
+	return readCmd
+}
+
+func setupReadFlags(c *cobra.Command) {
+	c.Flags().BoolP("follow", "f", false, "Replay capture log, then stream live output until interrupted")
+	_ = viper.BindPFlag(config.SB_READ_FOLLOW.ViperKey, c.Flags().Lookup("follow"))
+}
+
+func runRead(
+	ctx context.Context,
+	logger *slog.Logger,
+	stdout, stderr io.Writer,
+	opts readOpts,
+) error {
+	doc, err := discovery.FindTerminalByName(ctx, logger, opts.runPath, opts.name)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errdefs.ErrTerminalNotFound, err)
+	}
+	if doc == nil {
+		return fmt.Errorf("%w: terminal %q", errdefs.ErrTerminalNotFound, opts.name)
+	}
+
+	capturePath := doc.Status.CaptureFile
+	if capturePath == "" {
+		return errors.New("terminal metadata has no capture file recorded")
+	}
+
+	if !opts.follow {
+		return dumpCapture(capturePath, stdout)
+	}
+
+	socket := doc.Status.SocketFile
+	if socket == "" {
+		return errors.New("terminal metadata has no control socket recorded")
+	}
+
+	// SIGINT/SIGTERM unblock the streaming copy.
+	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	rc := rpcterminal.NewUnix(socket, logger)
+	defer func() { _ = rc.Close() }()
+
+	// Subscribe BEFORE reading the capture file so bytes written during the
+	// replay are captured in the live stream rather than lost at the cutover.
+	conn, err := rc.Subscribe(ctx, &api.SubscribeRequest{ClientID: api.ID(naming.RandomID())}, nil)
+	if err != nil {
+		return fmt.Errorf("subscribe: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if err := dumpCapture(capturePath, stdout); err != nil {
+		return err
+	}
+
+	// Close conn when ctx is done so io.Copy unblocks.
+	go func() {
+		<-ctx.Done()
+		_ = conn.Close()
+	}()
+
+	return streamLive(conn, stdout, stderr)
+}
+
+func dumpCapture(path string, stdout io.Writer) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// Empty capture is indistinguishable from "never written to";
+			// treat absence as zero-byte output rather than an error.
+			return nil
+		}
+		return fmt.Errorf("open capture file %q: %w", path, err)
+	}
+	defer f.Close()
+	if _, err := io.Copy(stdout, f); err != nil {
+		return fmt.Errorf("read capture file %q: %w", path, err)
+	}
+	return nil
+}
+
+// laggedNotice mirrors the sentinel the server writes before disconnecting
+// a slow subscriber. Detecting it lets us surface a clear error code.
+var laggedNotice = []byte("[sbsh: subscriber lagged, disconnecting]")
+
+func streamLive(conn net.Conn, stdout, stderr io.Writer) error {
+	buf := make([]byte, 4096)
+	laggedSeen := false
+	for {
+		n, err := conn.Read(buf)
+		if n > 0 {
+			chunk := buf[:n]
+			if !laggedSeen && bytes.Contains(chunk, laggedNotice) {
+				laggedSeen = true
+			}
+			if _, werr := stdout.Write(chunk); werr != nil {
+				return fmt.Errorf("write stdout: %w", werr)
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
+				if laggedSeen {
+					fmt.Fprintln(stderr, "sb read: subscriber lagged, stream truncated")
+					return errdefs.ErrSubscriberLagged
+				}
+				return nil
+			}
+			return fmt.Errorf("stream read: %w", err)
+		}
+	}
+}

--- a/cmd/sb/sb.go
+++ b/cmd/sb/sb.go
@@ -31,8 +31,10 @@ import (
 	"github.com/eminwux/sbsh/cmd/sb/detach"
 	"github.com/eminwux/sbsh/cmd/sb/get"
 	"github.com/eminwux/sbsh/cmd/sb/prune"
+	"github.com/eminwux/sbsh/cmd/sb/read"
 	"github.com/eminwux/sbsh/cmd/sb/stop"
 	"github.com/eminwux/sbsh/cmd/sb/version"
+	"github.com/eminwux/sbsh/cmd/sb/write"
 	"github.com/eminwux/sbsh/cmd/types"
 	"github.com/eminwux/sbsh/internal/errdefs"
 	"github.com/eminwux/sbsh/internal/logging"
@@ -122,6 +124,8 @@ func setupRootCmd(rootCmd *cobra.Command) error {
 	rootCmd.AddCommand(detach.NewDetachCmd())
 	rootCmd.AddCommand(attach.NewAttachCmd())
 	rootCmd.AddCommand(get.NewGetCmd())
+	rootCmd.AddCommand(write.NewWriteCmd())
+	rootCmd.AddCommand(read.NewReadCmd())
 
 	rootCmd.PersistentFlags().String("config", "", "config file (default is $HOME/.sbsh/config.yaml)")
 	if err := viper.BindPFlag(config.SB_ROOT_CONFIG.ViperKey, rootCmd.PersistentFlags().Lookup("config")); err != nil {

--- a/cmd/sb/write/caret.go
+++ b/cmd/sb/write/caret.go
@@ -1,0 +1,114 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package write
+
+import (
+	"fmt"
+)
+
+// parseCaret expands stty-style caret notation and hex escapes into
+// raw bytes.
+//
+// Supported escapes:
+//   - `^@`..`^_`  → 0x00..0x1F (ASCII control characters)
+//   - `^?`        → 0x7F (DEL)
+//   - `\\xHH`     → single byte HH (two hex digits, case-insensitive)
+//   - `\\\\`      → literal backslash (so the hex form remains escapable)
+//
+// Intentionally unsupported:
+//   - Shell-style `\\n`, `\\t`, etc. They are ambiguous with `^M`/`^I`
+//     and mask the fact that a real newline is 0x0A. Callers that want
+//     a literal newline should write `^M`, `\\x0A`, or use --raw.
+//
+// Anything not matching one of the above escapes passes through as the
+// original UTF-8 bytes of the input.
+func parseCaret(in []byte) ([]byte, error) {
+	out := make([]byte, 0, len(in))
+	for i := 0; i < len(in); i++ {
+		b := in[i]
+		switch {
+		case b == '^':
+			if i+1 >= len(in) {
+				return nil, fmt.Errorf("dangling '^' at offset %d", i)
+			}
+			next := in[i+1]
+			decoded, ok := caretByte(next)
+			if !ok {
+				return nil, fmt.Errorf("unsupported caret sequence '^%c' at offset %d", next, i)
+			}
+			out = append(out, decoded)
+			i++
+		case b == '\\':
+			if i+1 >= len(in) {
+				return nil, fmt.Errorf("dangling '\\' at offset %d", i)
+			}
+			switch in[i+1] {
+			case '\\':
+				out = append(out, '\\')
+				i++
+			case 'x', 'X':
+				if i+3 >= len(in) {
+					return nil, fmt.Errorf("incomplete \\x escape at offset %d", i)
+				}
+				hi, ok1 := hexNibble(in[i+2])
+				lo, ok2 := hexNibble(in[i+3])
+				if !ok1 || !ok2 {
+					return nil, fmt.Errorf("invalid \\x escape at offset %d", i)
+				}
+				out = append(out, hi<<4|lo)
+				i += 3
+			default:
+				return nil, fmt.Errorf(
+					"unsupported backslash escape '\\%c' at offset %d; use \\xHH or --raw",
+					in[i+1], i,
+				)
+			}
+		default:
+			out = append(out, b)
+		}
+	}
+	return out, nil
+}
+
+// caretByte maps the character after '^' to its control-byte equivalent
+// per stty convention. Returns false when the sequence is unsupported.
+func caretByte(c byte) (byte, bool) {
+	switch {
+	case c == '?':
+		return 0x7F, true
+	case c >= '@' && c <= '_':
+		return c - '@', true
+	case c >= 'a' && c <= 'z':
+		// Lowercase form: ^a..^z == ^A..^Z.
+		return c - 'a' + 1, true
+	default:
+		return 0, false
+	}
+}
+
+func hexNibble(c byte) (byte, bool) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0', true
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10, true
+	case c >= 'A' && c <= 'F':
+		return c - 'A' + 10, true
+	default:
+		return 0, false
+	}
+}

--- a/cmd/sb/write/caret_test.go
+++ b/cmd/sb/write/caret_test.go
@@ -1,0 +1,81 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package write
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestParseCaret(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		in      string
+		want    []byte
+		wantErr bool
+	}{
+		{"empty", "", []byte{}, false},
+		{"plain ascii", "hello", []byte("hello"), false},
+		{"ctrl-c", "^C", []byte{0x03}, false},
+		{"ctrl-d", "^D", []byte{0x04}, false},
+		{"ctrl-z", "^Z", []byte{0x1A}, false},
+		{"ctrl-m CR", "^M", []byte{0x0D}, false},
+		{"ctrl-i TAB", "^I", []byte{0x09}, false},
+		{"ctrl-null", "^@", []byte{0x00}, false},
+		{"escape", "^[", []byte{0x1B}, false},
+		{"group-sep", "^]", []byte{0x1D}, false},
+		{"record-sep", "^^", []byte{0x1E}, false},
+		{"unit-sep", "^_", []byte{0x1F}, false},
+		{"del", "^?", []byte{0x7F}, false},
+		{"lowercase ^c", "^c", []byte{0x03}, false},
+		{"hex lowercase", `\x0a`, []byte{0x0A}, false},
+		{"hex uppercase", `\xFF`, []byte{0xFF}, false},
+		{"hex mixed case", `\xaB`, []byte{0xAB}, false},
+		{"literal caret via hex", `\x5E`, []byte{'^'}, false},
+		{"literal backslash", `\\`, []byte{'\\'}, false},
+		{"mixed sequence", `echo hi^M`, append([]byte("echo hi"), 0x0D), false},
+		{"hex then plain", `\x03rest`, append([]byte{0x03}, []byte("rest")...), false},
+
+		// negative cases
+		{"shell \\n not supported", `\n`, nil, true},
+		{"shell \\t not supported", `\t`, nil, true},
+		{"dangling caret", "^", nil, true},
+		{"dangling backslash", `\`, nil, true},
+		{"bad caret", "^!", nil, true},
+		{"incomplete hex", `\x0`, nil, true},
+		{"non-hex nibble", `\xGG`, nil, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseCaret([]byte(tc.in))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got none (out=%q)", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.in, err)
+			}
+			if !bytes.Equal(got, tc.want) {
+				t.Fatalf("parseCaret(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/sb/write/write.go
+++ b/cmd/sb/write/write.go
@@ -1,0 +1,157 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package write
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+
+	"github.com/eminwux/sbsh/cmd/config"
+	"github.com/eminwux/sbsh/cmd/sb/get"
+	"github.com/eminwux/sbsh/cmd/types"
+	"github.com/eminwux/sbsh/internal/discovery"
+	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/pkg/api"
+	rpcterminal "github.com/eminwux/sbsh/pkg/rpcclient/terminal"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type writeOpts struct {
+	runPath string
+	name    string
+	raw     bool
+	payload []byte
+}
+
+func NewWriteCmd() *cobra.Command {
+	writeCmd := &cobra.Command{
+		Use:   "write <name> [text|-]",
+		Short: "Write bytes to a terminal's PTY input",
+		Long: `Write bytes to a running terminal's PTY input.
+
+By default, caret notation is expanded (^C, ^D, ^[, ^M, etc.) along with
+\xHH hex escapes. Shell-style escapes like \n are NOT interpreted; use
+^M for a carriage return or --raw to send bytes verbatim.
+
+If the text argument is '-', stdin is read until EOF and sent as-is (caret
+notation still applies unless --raw is set). No trailing newline is added;
+submit with an explicit ^M.
+
+Examples:
+  sb write mybox "echo hello^M"
+  sb write mybox --raw "$(printf '\x03')"
+  cat script.sh | sb write mybox -`,
+		SilenceUsage:      true,
+		Args:              cobra.RangeArgs(1, 2),
+		ValidArgsFunction: get.CompleteTerminals,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)
+			if !ok || logger == nil {
+				return errdefs.ErrLoggerNotFound
+			}
+
+			opts, err := resolveWriteOpts(args)
+			if err != nil {
+				return err
+			}
+
+			return runWrite(cmd.Context(), logger, opts)
+		},
+	}
+
+	setupWriteFlags(writeCmd)
+	return writeCmd
+}
+
+func setupWriteFlags(c *cobra.Command) {
+	c.Flags().Bool("raw", false, "Send bytes verbatim; disable caret and \\x escape interpretation")
+	_ = viper.BindPFlag(config.SB_WRITE_RAW.ViperKey, c.Flags().Lookup("raw"))
+}
+
+func resolveWriteOpts(args []string) (writeOpts, error) {
+	opts := writeOpts{
+		runPath: viper.GetString(config.SB_ROOT_RUN_PATH.ViperKey),
+		raw:     viper.GetBool(config.SB_WRITE_RAW.ViperKey),
+	}
+
+	if len(args) == 0 {
+		return opts, errdefs.ErrNoTerminalIdentifier
+	}
+	opts.name = args[0]
+	if opts.name == "" {
+		return opts, errdefs.ErrNoTerminalIdentifier
+	}
+
+	// Payload source: second positional or stdin ('-').
+	var raw []byte
+	switch {
+	case len(args) == 1:
+		// No payload argument. Treat as empty; bail early so we don't
+		// invoke the RPC for zero bytes.
+		raw = nil
+	case args[1] == "-":
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return opts, fmt.Errorf("read stdin: %w", err)
+		}
+		raw = data
+	default:
+		raw = []byte(args[1])
+	}
+
+	if opts.raw {
+		opts.payload = raw
+		return opts, nil
+	}
+
+	parsed, err := parseCaret(raw)
+	if err != nil {
+		return opts, fmt.Errorf("%w: %w", errdefs.ErrInvalidArgument, err)
+	}
+	opts.payload = parsed
+	return opts, nil
+}
+
+func runWrite(ctx context.Context, logger *slog.Logger, opts writeOpts) error {
+	if len(opts.payload) == 0 {
+		logger.DebugContext(ctx, "write: empty payload, nothing to do")
+		return nil
+	}
+
+	doc, err := discovery.FindTerminalByName(ctx, logger, opts.runPath, opts.name)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errdefs.ErrTerminalNotFound, err)
+	}
+	if doc == nil {
+		return fmt.Errorf("%w: terminal %q", errdefs.ErrTerminalNotFound, opts.name)
+	}
+
+	socket := doc.Status.SocketFile
+	if socket == "" {
+		return errors.New("terminal metadata has no control socket recorded")
+	}
+
+	rc := rpcterminal.NewUnix(socket, logger)
+	defer func() { _ = rc.Close() }()
+
+	return rc.Write(ctx, &api.WriteRequest{Data: opts.payload})
+}

--- a/e2e/e2e_sb_write_read_test.go
+++ b/e2e/e2e_sb_write_read_test.go
@@ -1,0 +1,177 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+)
+
+// TestSb_WriteRead_Roundtrip boots a terminal via sbsh, injects a shell
+// command with `sb write` (exercising caret notation), and confirms the
+// command's output appears in both the capture file (`sb read`) and the
+// live stream (`sb read -f`).
+func TestSb_WriteRead_Roundtrip(t *testing.T) {
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+
+	termName := "e2e-writeread"
+	runPathEnv := buildSbRunPathEnv(t, runPath)
+
+	t.Cleanup(func() {
+		runReturningBinary(t, []string{runPathEnv}, sb, "prune", "terminals", "--verbose", "--log-level", "debug")
+		runReturningBinary(t, []string{runPathEnv}, sb, "prune", "clients", "--verbose", "--log-level", "debug")
+	})
+
+	// Boot an interactive shell under sbsh and wait for its prompt.
+	ptmx, pts := setupPty(t)
+	defer func() { _ = ptmx.Close() }()
+
+	pipeLogR, pipeLogW, _ := os.Pipe()
+	defer pipeLogR.Close()
+	defer pipeLogW.Close()
+
+	multiW := setupMultiWriter(t, ptmx, pipeLogW)
+	go logTerminal(t, pipeLogR)
+
+	pipeExpectR, pipeExpectW, _ := os.Pipe()
+	defer pipeExpectR.Close()
+	defer pipeExpectW.Close()
+
+	// Default prompt format is "(sbsh-<id>)" regardless of --terminal-name.
+	promptCh := setupPromptDetector(t, pipeExpectR, regexp.MustCompile(`\(sbsh-[^)]+\)`))
+	multiW.Add(pipeExpectW)
+
+	ret := make(chan error, 1)
+	waitFn := cmdWaitFunc(t, &ret)
+	env := append([]string{}, getRandomSbshRunPath(t, runPath))
+	runPersistentBinaryPty(t, pts, waitFn, env, sbsh, "--terminal-name", termName)
+
+	select {
+	case <-promptCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for sbsh prompt")
+	}
+	multiW.Remove(pipeExpectW)
+	time.Sleep(200 * time.Millisecond)
+
+	// sb write with caret notation: inject an echo command + CR.
+	const marker = "e2e-writeread-marker"
+	runSilentBinary(t, []string{runPathEnv}, sb, "write", termName,
+		"echo "+marker+"^M")
+
+	// Give the PTY a moment to echo and flush to the capture file.
+	time.Sleep(500 * time.Millisecond)
+
+	out := runReturningBinary(t, []string{runPathEnv}, sb, "read", termName)
+	if !bytes.Contains(out, []byte(marker)) {
+		t.Fatalf("sb read output missing marker %q; got:\n%s", marker, string(out))
+	}
+
+	// --raw: send bytes verbatim. \x20 literal should NOT be interpreted.
+	const rawPayload = "echo raw-passthrough\r"
+	runSilentBinary(t, []string{runPathEnv}, sb, "write", termName, "--raw", rawPayload)
+	time.Sleep(300 * time.Millisecond)
+	out2 := runReturningBinary(t, []string{runPathEnv}, sb, "read", termName)
+	if !bytes.Contains(out2, []byte("raw-passthrough")) {
+		t.Fatalf("sb read missing raw payload output; got:\n%s", string(out2))
+	}
+
+	// Shut down cleanly so the cleanup prune doesn't race with a live PID.
+	if _, err := ptmx.WriteString("\x04"); err != nil {
+		t.Logf("could not EOF ptmx: %v", err)
+	}
+	select {
+	case <-ret:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for sbsh to exit")
+	}
+}
+
+// TestSb_Write_CaretParsingErrors confirms the CLI rejects ambiguous
+// shell-style escapes (and returns non-zero) rather than silently
+// sending bogus bytes.
+func TestSb_Write_CaretParsingErrors(t *testing.T) {
+	t.Parallel()
+	runPath := getRandomRunPath(t)
+	mkdirRunPath(t, runPath)
+	runPathEnv := buildSbRunPathEnv(t, runPath)
+
+	// No terminal needs to be running — parsing happens before we dial
+	// the socket. We invoke the binary directly here so we can assert on
+	// a non-zero exit code without runReturningBinary's auto-fail.
+	err := runExpectingFailure(t, []string{runPathEnv}, sb, "write", "irrelevant", `\n`)
+	if err == nil {
+		t.Fatal("expected sb write to fail on shell-style \\n escape")
+	}
+}
+
+// runSilentBinary runs a binary that is expected to succeed with no
+// output (e.g. `sb write`, which is quiet on success).
+func runSilentBinary(t *testing.T, env []string, command string, args ...string) {
+	t.Helper()
+	dir := os.Getenv("E2E_BIN_DIR")
+	if dir == "" {
+		dir = ".."
+	}
+	bin := filepath.Join(dir, command)
+	if _, err := os.Stat(bin); os.IsNotExist(err) {
+		t.Fatalf("binary %s not found", bin)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin, args...)
+	if env != nil {
+		cmd.Env = env
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running %s %v failed: %v\noutput:\n%s", bin, args, err, string(out))
+	}
+}
+
+// runExpectingFailure mirrors runReturningBinary but returns the error
+// instead of failing the test when the binary exits non-zero.
+func runExpectingFailure(t *testing.T, env []string, command string, args ...string) error {
+	t.Helper()
+	dir := os.Getenv("E2E_BIN_DIR")
+	if dir == "" {
+		dir = ".."
+	}
+	bin := filepath.Join(dir, command)
+	if _, err := os.Stat(bin); os.IsNotExist(err) {
+		t.Fatalf("binary %s not found", bin)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin, args...)
+	if env != nil {
+		cmd.Env = env
+	}
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected %s %v to fail; output:\n%s", bin, args, out)
+	}
+	t.Logf("expected failure from %s %v: %v\noutput:\n%s", bin, args, err, out)
+	return err
+}

--- a/internal/client/clientrunner/io_test.go
+++ b/internal/client/clientrunner/io_test.go
@@ -73,6 +73,14 @@ func (m *mockTerminalClient) Stop(_ context.Context, _ *api.StopArgs) error {
 	return nil
 }
 
+func (m *mockTerminalClient) Write(_ context.Context, _ *api.WriteRequest) error {
+	return nil
+}
+
+func (m *mockTerminalClient) Subscribe(_ context.Context, _ *api.SubscribeRequest, _ any) (net.Conn, error) {
+	return nil, errors.New("not implemented in mock")
+}
+
 func Test_WaitReady_WithMultipleStates(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -80,4 +80,6 @@ var (
 	ErrStopTerminal           = errors.New("could not stop terminal")
 	ErrStopTimeout            = errors.New("terminal did not exit within timeout")
 	ErrSignalProcess          = errors.New("failed to signal terminal process")
+	ErrTerminalStdinClosed    = errors.New("terminal stdin is closed")
+	ErrSubscriberLagged       = errors.New("subscriber fell behind and was disconnected")
 )

--- a/internal/terminal/controller.go
+++ b/internal/terminal/controller.go
@@ -342,6 +342,29 @@ func (c *Controller) Stop(args *api.StopArgs) error {
 	return nil
 }
 
+func (c *Controller) Write(req *api.WriteRequest) error {
+	c.srMu.RLock()
+	sr := c.sr
+	c.srMu.RUnlock()
+	if sr == nil {
+		return errors.New("terminal runner not initialized")
+	}
+	if req == nil || len(req.Data) == 0 {
+		return nil
+	}
+	return sr.WritePTY(req.Data)
+}
+
+func (c *Controller) Subscribe(req *api.SubscribeRequest, response *api.ResponseWithFD) error {
+	c.srMu.RLock()
+	sr := c.sr
+	c.srMu.RUnlock()
+	if sr == nil {
+		return errors.New("terminal runner not initialized")
+	}
+	return sr.Subscribe(req, response)
+}
+
 func (c *Controller) State() (*api.TerminalStatusMode, error) {
 	c.srMu.RLock()
 	sr := c.sr

--- a/internal/terminal/controller_fake.go
+++ b/internal/terminal/controller_fake.go
@@ -37,6 +37,8 @@ type ControllerTest struct {
 	MetadataFunc  func() (*api.TerminalDoc, error)
 	StateFunc     func() (*api.TerminalStatusMode, error)
 	StopFunc      func(args *api.StopArgs) error
+	WriteFunc     func(req *api.WriteRequest) error
+	SubscribeFunc func(req *api.SubscribeRequest, response *api.ResponseWithFD) error
 }
 
 func (f *ControllerTest) Run(spec *api.TerminalSpec) error {
@@ -112,6 +114,20 @@ func (f *ControllerTest) State() (*api.TerminalStatusMode, error) {
 func (f *ControllerTest) Stop(args *api.StopArgs) error {
 	if f.StopFunc != nil {
 		return f.StopFunc(args)
+	}
+	return errdefs.ErrFuncNotSet
+}
+
+func (f *ControllerTest) Write(req *api.WriteRequest) error {
+	if f.WriteFunc != nil {
+		return f.WriteFunc(req)
+	}
+	return errdefs.ErrFuncNotSet
+}
+
+func (f *ControllerTest) Subscribe(req *api.SubscribeRequest, response *api.ResponseWithFD) error {
+	if f.SubscribeFunc != nil {
+		return f.SubscribeFunc(req, response)
 	}
 	return errdefs.ErrFuncNotSet
 }

--- a/internal/terminal/terminalrpc/rpc_server.go
+++ b/internal/terminal/terminalrpc/rpc_server.go
@@ -65,3 +65,11 @@ func (s *TerminalControllerRPC) State(_ api.Empty, state *api.TerminalStatusMode
 func (s *TerminalControllerRPC) Stop(args *api.StopArgs, _ *api.Empty) error {
 	return s.Core.Stop(args)
 }
+
+func (s *TerminalControllerRPC) Write(req *api.WriteRequest, _ *api.Empty) error {
+	return s.Core.Write(req)
+}
+
+func (s *TerminalControllerRPC) Subscribe(req *api.SubscribeRequest, response *api.ResponseWithFD) error {
+	return s.Core.Subscribe(req, response)
+}

--- a/internal/terminal/terminalrunner/lifecycle.go
+++ b/internal/terminal/terminalrunner/lifecycle.go
@@ -101,6 +101,9 @@ func (sr *Exec) Close(reason error) error {
 	sr.clients = nil
 	sr.clientsMu.Unlock()
 
+	// close all output subscribers
+	sr.closeAllSubscribers()
+
 	// kill PTY child and close PTY master as needed
 	if sr.cmd != nil && sr.cmd.Process != nil {
 		if err := sr.cmd.Process.Kill(); err != nil {

--- a/internal/terminal/terminalrunner/subscribe.go
+++ b/internal/terminal/terminalrunner/subscribe.go
@@ -1,0 +1,151 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrunner
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"sync"
+
+	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/pkg/api"
+	"golang.org/x/sys/unix"
+)
+
+// WritePTY pushes a single bulk write to the PTY master. Unlike the
+// byte-at-a-time path used for shell-init stuffing, this path sends the
+// caller's buffer verbatim: user-driven input must not be reshaped.
+func (sr *Exec) WritePTY(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+
+	sr.obsMu.RLock()
+	stdinOpen := sr.gates.StdinOpen
+	sr.obsMu.RUnlock()
+	if !stdinOpen {
+		return errdefs.ErrTerminalStdinClosed
+	}
+
+	if sr.ptmx == nil {
+		return errdefs.ErrTerminalStdinClosed
+	}
+
+	if _, err := sr.ptmx.Write(data); err != nil {
+		return fmt.Errorf("write to pty: %w", err)
+	}
+
+	sr.obsMu.Lock()
+	sr.bytesIn += uint64(len(data))
+	sr.obsMu.Unlock()
+	return nil
+}
+
+// Subscribe registers a new output-only consumer on the PTY fan-out.
+// It allocates a socketpair, returns the client-side FD via SCM_RIGHTS
+// on the RPC response, and feeds PTY output into a bounded ring whose
+// drain goroutine writes to the server-side conn. If the subscriber
+// falls behind it is disconnected with a lagged-notice sentinel rather
+// than stalling the fan-out.
+func (sr *Exec) Subscribe(req *api.SubscribeRequest, response *api.ResponseWithFD) error {
+	clientID := api.ID("")
+	if req != nil {
+		clientID = req.ClientID
+	}
+	sr.logger.Debug("Subscribe: creating socketpair", "client", clientID)
+
+	sv, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|sockCloexec, 0)
+	if err != nil {
+		sr.logger.Error("Subscribe: Socketpair failed", "client", clientID, "error", err)
+		return fmt.Errorf("Subscribe: Socketpair: %w", err)
+	}
+	srvFD := sv[0]
+	cliFD := sv[1]
+
+	f := os.NewFile(uintptr(srvFD), "terminal-subscribe")
+	conn, err := net.FileConn(f)
+	if err != nil {
+		_ = f.Close()
+		_ = unix.Close(cliFD)
+		return fmt.Errorf("Subscribe: FileConn: %w", err)
+	}
+	_ = f.Close()
+
+	// We only ever write to subscribers; close the read half so a stuck
+	// subscriber can't fill the kernel buffer in the reverse direction.
+	if uc, ok := conn.(*net.UnixConn); ok {
+		_ = uc.CloseRead()
+	}
+
+	sr.ptyPipesMu.RLock()
+	multiOutW := sr.ptyPipes.multiOutW
+	sr.ptyPipesMu.RUnlock()
+	if multiOutW == nil {
+		_ = conn.Close()
+		_ = unix.Close(cliFD)
+		return fmt.Errorf("Subscribe: terminal not running")
+	}
+
+	var sub *subscriberWriter
+	var detachOnce sync.Once
+	detach := func() {
+		detachOnce.Do(func() {
+			multiOutW.Remove(sub)
+			sr.removeSubscriber(sub)
+			sr.logger.Info("Subscribe: subscriber detached", "client", clientID)
+		})
+	}
+
+	sub = newSubscriberWriter(conn, defaultSubscriberBufferBytes, detach, sr.logger)
+	sr.addSubscriber(sub)
+	multiOutW.Add(sub)
+	go sub.Run()
+
+	payload := struct {
+		OK bool `json:"ok"`
+	}{OK: true}
+
+	response.JSON = payload
+	response.FDs = []int{cliFD}
+	sr.logger.Info("Subscribe: subscriber registered", "client", clientID)
+	return nil
+}
+
+func (sr *Exec) addSubscriber(s *subscriberWriter) {
+	sr.subsMu.Lock()
+	sr.subscribers[s] = struct{}{}
+	sr.subsMu.Unlock()
+}
+
+func (sr *Exec) removeSubscriber(s *subscriberWriter) {
+	sr.subsMu.Lock()
+	delete(sr.subscribers, s)
+	sr.subsMu.Unlock()
+}
+
+func (sr *Exec) closeAllSubscribers() {
+	sr.subsMu.Lock()
+	subs := make([]*subscriberWriter, 0, len(sr.subscribers))
+	for s := range sr.subscribers {
+		subs = append(subs, s)
+	}
+	sr.subsMu.Unlock()
+	for _, s := range subs {
+		_ = s.Close()
+	}
+}

--- a/internal/terminal/terminalrunner/subscriber.go
+++ b/internal/terminal/terminalrunner/subscriber.go
@@ -1,0 +1,141 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrunner
+
+import (
+	"bytes"
+	"log/slog"
+	"net"
+	"sync"
+)
+
+// defaultSubscriberBufferBytes bounds how far a Subscribe stream can fall
+// behind the PTY reader before the subscriber is disconnected. A slow or
+// abandoned subscriber must never be able to stall the shared fan-out.
+const defaultSubscriberBufferBytes = 1 << 20 // 1 MiB
+
+// laggedNotice is appended to a subscriber stream when the ring overflows
+// so a caller can distinguish disconnection from a clean EOF.
+var laggedNotice = []byte("\r\n[sbsh: subscriber lagged, disconnecting]\r\n")
+
+// subscriberWriter absorbs PTY output from the multiwriter into a bounded
+// in-memory ring and forwards it to an external net.Conn on a dedicated
+// goroutine. The Write path never blocks: on overflow the subscriber is
+// marked lagged, detached, and its conn is closed.
+type subscriberWriter struct {
+	mu       sync.Mutex
+	cond     *sync.Cond
+	buf      bytes.Buffer
+	maxBytes int
+	closed   bool
+	lagged   bool
+	conn     net.Conn
+	onDetach func()
+	logger   *slog.Logger
+}
+
+func newSubscriberWriter(conn net.Conn, maxBytes int, onDetach func(), logger *slog.Logger) *subscriberWriter {
+	if maxBytes <= 0 {
+		maxBytes = defaultSubscriberBufferBytes
+	}
+	s := &subscriberWriter{
+		maxBytes: maxBytes,
+		conn:     conn,
+		onDetach: onDetach,
+		logger:   logger,
+	}
+	s.cond = sync.NewCond(&s.mu)
+	return s
+}
+
+// Write is called by DynamicMultiWriter on the PTY reader goroutine. It
+// enqueues bytes into the bounded ring and returns immediately. When the
+// ring would exceed maxBytes the subscriber is marked lagged+closed and
+// the underlying conn is closed so the drain goroutine unblocks and
+// detaches. Write always reports success to the fan-out so one bad
+// subscriber cannot abort output to other attachers or the capture file.
+func (s *subscriberWriter) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return len(p), nil
+	}
+	if s.buf.Len()+len(p) > s.maxBytes {
+		s.lagged = true
+		s.closed = true
+		s.cond.Broadcast()
+		s.mu.Unlock()
+		_ = s.conn.Close()
+		return len(p), nil
+	}
+	_, _ = s.buf.Write(p)
+	s.cond.Signal()
+	s.mu.Unlock()
+	return len(p), nil
+}
+
+// Close requests a graceful shutdown. It signals drain so any pending
+// bytes are flushed to the conn; drain itself closes the conn on exit.
+// Safe to call repeatedly.
+func (s *subscriberWriter) Close() error {
+	s.mu.Lock()
+	if !s.closed {
+		s.closed = true
+		s.cond.Broadcast()
+	}
+	s.mu.Unlock()
+	return nil
+}
+
+// Run drains the ring to the conn on a dedicated goroutine. It exits
+// when the conn is closed, the peer goes away, or Close is called.
+// Always invokes onDetach on exit so the subscriber is removed from
+// the fan-out exactly once.
+func (s *subscriberWriter) Run() {
+	defer func() {
+		if s.onDetach != nil {
+			s.onDetach()
+		}
+	}()
+	for {
+		s.mu.Lock()
+		for s.buf.Len() == 0 && !s.closed {
+			s.cond.Wait()
+		}
+		if s.buf.Len() == 0 && s.closed {
+			lagged := s.lagged
+			s.mu.Unlock()
+			if lagged {
+				_, _ = s.conn.Write(laggedNotice)
+			}
+			_ = s.conn.Close()
+			return
+		}
+		chunk := make([]byte, s.buf.Len())
+		_, _ = s.buf.Read(chunk)
+		s.mu.Unlock()
+
+		if _, err := s.conn.Write(chunk); err != nil {
+			s.logger.Debug("subscriber conn write failed; closing", "err", err)
+			s.mu.Lock()
+			s.closed = true
+			s.mu.Unlock()
+			_ = s.conn.Close()
+			return
+		}
+	}
+}

--- a/internal/terminal/terminalrunner/subscriber.go
+++ b/internal/terminal/terminalrunner/subscriber.go
@@ -21,7 +21,15 @@ import (
 	"log/slog"
 	"net"
 	"sync"
+	"time"
 )
+
+// subscriberWriteTimeout bounds how long the drain goroutine will block
+// in a single conn.Write on a hung peer. Without this, a peer that stops
+// reading but never closes would pin the drain goroutine indefinitely
+// and prevent the lagged sentinel from ever being delivered or detach
+// from firing. var (not const) so tests can shorten it.
+var subscriberWriteTimeout = 5 * time.Second
 
 // defaultSubscriberBufferBytes bounds how far a Subscribe stream can fall
 // behind the PTY reader before the subscriber is disconnected. A slow or
@@ -29,7 +37,10 @@ import (
 const defaultSubscriberBufferBytes = 1 << 20 // 1 MiB
 
 // laggedNotice is appended to a subscriber stream when the ring overflows
-// so a caller can distinguish disconnection from a clean EOF.
+// so a caller can distinguish disconnection from a clean EOF. The \r\n
+// framing is intentional: it renders cleanly in terminal mode and the
+// client-side needle (cmd/sb/read) matches only the bracketed message so
+// framing can evolve without breaking detection.
 var laggedNotice = []byte("\r\n[sbsh: subscriber lagged, disconnecting]\r\n")
 
 // subscriberWriter absorbs PTY output from the multiwriter into a bounded
@@ -65,9 +76,10 @@ func newSubscriberWriter(conn net.Conn, maxBytes int, onDetach func(), logger *s
 // Write is called by DynamicMultiWriter on the PTY reader goroutine. It
 // enqueues bytes into the bounded ring and returns immediately. When the
 // ring would exceed maxBytes the subscriber is marked lagged+closed and
-// the underlying conn is closed so the drain goroutine unblocks and
-// detaches. Write always reports success to the fan-out so one bad
-// subscriber cannot abort output to other attachers or the capture file.
+// the drain goroutine is signalled; Run owns the conn lifecycle and will
+// flush any buffered bytes, emit laggedNotice, and close the conn. Write
+// always reports success to the fan-out so one bad subscriber cannot
+// abort output to other attachers or the capture file.
 func (s *subscriberWriter) Write(p []byte) (int, error) {
 	s.mu.Lock()
 	if s.closed {
@@ -79,7 +91,6 @@ func (s *subscriberWriter) Write(p []byte) (int, error) {
 		s.closed = true
 		s.cond.Broadcast()
 		s.mu.Unlock()
-		_ = s.conn.Close()
 		return len(p), nil
 	}
 	_, _ = s.buf.Write(p)
@@ -104,12 +115,15 @@ func (s *subscriberWriter) Close() error {
 // Run drains the ring to the conn on a dedicated goroutine. It exits
 // when the conn is closed, the peer goes away, or Close is called.
 // Always invokes onDetach on exit so the subscriber is removed from
-// the fan-out exactly once.
+// the fan-out exactly once. A per-write deadline bounds how long a hung
+// peer can stall drain — essential when Write(lagged) no longer closes
+// the conn itself.
 func (s *subscriberWriter) Run() {
 	defer func() {
 		if s.onDetach != nil {
 			s.onDetach()
 		}
+		_ = s.conn.Close()
 	}()
 	for {
 		s.mu.Lock()
@@ -120,21 +134,23 @@ func (s *subscriberWriter) Run() {
 			lagged := s.lagged
 			s.mu.Unlock()
 			if lagged {
-				_, _ = s.conn.Write(laggedNotice)
+				_ = s.conn.SetWriteDeadline(time.Now().Add(subscriberWriteTimeout))
+				if _, err := s.conn.Write(laggedNotice); err != nil {
+					s.logger.Debug("subscriber lagged-notice write failed", "err", err)
+				}
 			}
-			_ = s.conn.Close()
 			return
 		}
 		chunk := make([]byte, s.buf.Len())
 		_, _ = s.buf.Read(chunk)
 		s.mu.Unlock()
 
+		_ = s.conn.SetWriteDeadline(time.Now().Add(subscriberWriteTimeout))
 		if _, err := s.conn.Write(chunk); err != nil {
 			s.logger.Debug("subscriber conn write failed; closing", "err", err)
 			s.mu.Lock()
 			s.closed = true
 			s.mu.Unlock()
-			_ = s.conn.Close()
 			return
 		}
 	}

--- a/internal/terminal/terminalrunner/subscriber_test.go
+++ b/internal/terminal/terminalrunner/subscriber_test.go
@@ -26,6 +26,15 @@ import (
 	"time"
 )
 
+// shortenWriteTimeout lowers the drain-goroutine write deadline for the
+// duration of a test so a hung-peer scenario detaches quickly instead of
+// waiting the production 5s. Returns a restore func.
+func shortenWriteTimeout(d time.Duration) func() {
+	prev := subscriberWriteTimeout
+	subscriberWriteTimeout = d
+	return func() { subscriberWriteTimeout = prev }
+}
+
 // newPipeConnPair returns a (clientSide, serverSide) net.Pipe pair. The
 // subscriberWriter forwards bytes into serverSide; the test reads from
 // clientSide to verify output.
@@ -35,7 +44,7 @@ func newPipeConnPair() (net.Conn, net.Conn) {
 }
 
 func TestSubscriber_DeliversBytesInOrder(t *testing.T) {
-	t.Parallel()
+	// Not t.Parallel: tests in this file mutate subscriberWriteTimeout.
 	clientSide, serverSide := newPipeConnPair()
 	defer clientSide.Close()
 
@@ -68,10 +77,14 @@ func TestSubscriber_DeliversBytesInOrder(t *testing.T) {
 }
 
 func TestSubscriber_LaggedReaderIsDropped(t *testing.T) {
-	t.Parallel()
-	// The client never reads, so serverSide writes will block once the
-	// net.Pipe buffer fills. Any overflow beyond maxBytes must close
-	// the subscriber rather than stall the fan-out.
+	// Cannot t.Parallel alongside shortenWriteTimeout — it mutates a
+	// package-level var read by the drain goroutine.
+	// The client never reads, so serverSide writes will block. With the
+	// production timeout of 5s the detach would lag this test; drop it
+	// so the hung-peer path bails quickly.
+	restore := shortenWriteTimeout(100 * time.Millisecond)
+	defer restore()
+
 	clientSide, serverSide := newPipeConnPair()
 	defer clientSide.Close()
 
@@ -112,5 +125,61 @@ func TestSubscriber_LaggedReaderIsDropped(t *testing.T) {
 	}
 	if !detached.Load() {
 		t.Fatal("detach callback not invoked after overflow")
+	}
+}
+
+// TestSubscriber_LaggedNoticeReachesClient covers the bug flagged in the
+// PR #119 review: on overflow, the sentinel must actually arrive on the
+// client side so the reader can surface ErrSubscriberLagged instead of a
+// clean EOF. Before the fix, Write closed the conn before Run could
+// drain, so the sentinel was silently dropped.
+func TestSubscriber_LaggedNoticeReachesClient(t *testing.T) {
+	// Not t.Parallel for the same reason as above.
+	clientSide, serverSide := newPipeConnPair()
+
+	const maxBytes = 128
+	var detached atomic.Bool
+	sub := newSubscriberWriter(serverSide, maxBytes, func() { detached.Store(true) }, slog.Default())
+	go sub.Run()
+
+	// Reader drains the client side so drain goroutine can make progress
+	// until the overflow fires and the sentinel is written.
+	type readResult struct {
+		data []byte
+		err  error
+	}
+	readCh := make(chan readResult, 1)
+	go func() {
+		got, err := io.ReadAll(clientSide)
+		readCh <- readResult{data: got, err: err}
+	}()
+
+	// Force an overflow immediately: one chunk bigger than maxBytes makes
+	// the first Write hit the lagged branch. The subsequent Close is a
+	// no-op because Write already marked closed.
+	big := bytes.Repeat([]byte("A"), maxBytes*2)
+	if n, err := sub.Write(big); err != nil || n != len(big) {
+		t.Fatalf("Write: n=%d err=%v", n, err)
+	}
+
+	select {
+	case res := <-readCh:
+		if res.err != nil && res.err != io.EOF {
+			t.Fatalf("read: %v", res.err)
+		}
+		if !bytes.Contains(res.data, laggedNotice) {
+			t.Fatalf("laggedNotice not present in stream; got %q", res.data)
+		}
+	case <-time.After(2 * time.Second):
+		_ = clientSide.Close()
+		t.Fatal("timed out waiting for lagged sentinel on client side")
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for !detached.Load() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !detached.Load() {
+		t.Fatal("detach callback not invoked after sentinel delivery")
 	}
 }

--- a/internal/terminal/terminalrunner/subscriber_test.go
+++ b/internal/terminal/terminalrunner/subscriber_test.go
@@ -1,0 +1,116 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrunner
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newPipeConnPair returns a (clientSide, serverSide) net.Pipe pair. The
+// subscriberWriter forwards bytes into serverSide; the test reads from
+// clientSide to verify output.
+func newPipeConnPair() (net.Conn, net.Conn) {
+	a, b := net.Pipe()
+	return a, b
+}
+
+func TestSubscriber_DeliversBytesInOrder(t *testing.T) {
+	t.Parallel()
+	clientSide, serverSide := newPipeConnPair()
+	defer clientSide.Close()
+
+	var detached atomic.Bool
+	sub := newSubscriberWriter(serverSide, 1<<20, func() { detached.Store(true) }, slog.Default())
+	go sub.Run()
+
+	want := []byte("hello world")
+	go func() {
+		_, _ = sub.Write(want)
+		_ = sub.Close()
+	}()
+
+	got, err := io.ReadAll(clientSide)
+	if err != nil && err != io.EOF {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("bytes = %q, want %q", got, want)
+	}
+
+	// Wait briefly for detach callback to run.
+	deadline := time.Now().Add(time.Second)
+	for !detached.Load() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !detached.Load() {
+		t.Fatal("detach callback not invoked on clean close")
+	}
+}
+
+func TestSubscriber_LaggedReaderIsDropped(t *testing.T) {
+	t.Parallel()
+	// The client never reads, so serverSide writes will block once the
+	// net.Pipe buffer fills. Any overflow beyond maxBytes must close
+	// the subscriber rather than stall the fan-out.
+	clientSide, serverSide := newPipeConnPair()
+	defer clientSide.Close()
+
+	const maxBytes = 128
+	var detached atomic.Bool
+	sub := newSubscriberWriter(serverSide, maxBytes, func() { detached.Store(true) }, slog.Default())
+	go sub.Run()
+
+	// Push well past maxBytes. Writes must always return (len(p), nil)
+	// from the fan-out's perspective; the subscriber absorbs the signal.
+	chunk := bytes.Repeat([]byte("A"), 64)
+	writeDone := make(chan struct{})
+	go func() {
+		defer close(writeDone)
+		for i := 0; i < 100; i++ {
+			n, err := sub.Write(chunk)
+			if err != nil {
+				t.Errorf("unexpected Write error: %v", err)
+				return
+			}
+			if n != len(chunk) {
+				t.Errorf("short write: got %d want %d", n, len(chunk))
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-writeDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Write path blocked despite overflow — backpressure escaped to fan-out")
+	}
+
+	// Detach callback must fire once the drain goroutine exits.
+	deadline := time.Now().Add(2 * time.Second)
+	for !detached.Load() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !detached.Load() {
+		t.Fatal("detach callback not invoked after overflow")
+	}
+}

--- a/internal/terminal/terminalrunner/terminal_runner.go
+++ b/internal/terminal/terminalrunner/terminal_runner.go
@@ -37,4 +37,6 @@ type TerminalRunner interface {
 	OnInitShell() error
 	PostAttachShell() error
 	Metadata() (*api.TerminalDoc, error)
+	WritePTY(data []byte) error
+	Subscribe(req *api.SubscribeRequest, response *api.ResponseWithFD) error
 }

--- a/internal/terminal/terminalrunner/terminal_runner_exec.go
+++ b/internal/terminal/terminalrunner/terminal_runner_exec.go
@@ -62,6 +62,9 @@ type Exec struct {
 	clientsMu sync.RWMutex
 	clients   map[api.ID]*ioClient
 
+	subsMu      sync.Mutex
+	subscribers map[*subscriberWriter]struct{}
+
 	closeReqCh chan error
 	closedCh   chan struct{}
 
@@ -110,7 +113,8 @@ func NewTerminalRunnerExec(ctx context.Context, logger *slog.Logger, spec *api.T
 		ptmx:  nil,
 		state: api.TerminalBash, // default logical state before start
 
-		clients: make(map[api.ID]*ioClient),
+		clients:     make(map[api.ID]*ioClient),
+		subscribers: make(map[*subscriberWriter]struct{}),
 
 		gates: struct {
 			StdinOpen bool

--- a/internal/terminal/terminalrunner/terminal_runner_fake.go
+++ b/internal/terminal/terminalrunner/terminal_runner_fake.go
@@ -40,6 +40,8 @@ type Test struct {
 	OnInitShellFunc     func() error
 	MetadataFunc        func() (*api.TerminalDoc, error)
 	PostAttachShellFunc func() error
+	WritePTYFunc        func(data []byte) error
+	SubscribeFunc       func(req *api.SubscribeRequest, response *api.ResponseWithFD) error
 }
 
 func NewTerminalRunnerTest(_ context.Context) TerminalRunner {
@@ -139,6 +141,20 @@ func (sr *Test) Metadata() (*api.TerminalDoc, error) {
 func (sr *Test) PostAttachShell() error {
 	if sr.PostAttachShellFunc != nil {
 		return sr.PostAttachShellFunc()
+	}
+	return errdefs.ErrFuncNotSet
+}
+
+func (sr *Test) WritePTY(data []byte) error {
+	if sr.WritePTYFunc != nil {
+		return sr.WritePTYFunc(data)
+	}
+	return errdefs.ErrFuncNotSet
+}
+
+func (sr *Test) Subscribe(req *api.SubscribeRequest, response *api.ResponseWithFD) error {
+	if sr.SubscribeFunc != nil {
+		return sr.SubscribeFunc(req, response)
 	}
 	return errdefs.ErrFuncNotSet
 }

--- a/pkg/api/terminal.go
+++ b/pkg/api/terminal.go
@@ -30,6 +30,8 @@ type TerminalController interface {
 	Metadata() (*TerminalDoc, error)
 	State() (*TerminalStatusMode, error)
 	Stop(args *StopArgs) error
+	Write(req *WriteRequest) error
+	Subscribe(req *SubscribeRequest, reply *ResponseWithFD) error
 }
 
 type TerminalDoc struct {
@@ -149,13 +151,15 @@ func (s TerminalStatusMode) String() string {
 const TerminalService = "TerminalController"
 
 const (
-	TerminalMethodResize   = TerminalService + ".Resize"
-	TerminalMethodPing     = TerminalService + ".Ping"
-	TerminalMethodAttach   = TerminalService + ".Attach"
-	TerminalMethodDetach   = TerminalService + ".Detach"
-	TerminalMethodMetadata = TerminalService + ".Metadata"
-	TerminalMethodState    = TerminalService + ".State"
-	TerminalMethodStop     = TerminalService + ".Stop"
+	TerminalMethodResize    = TerminalService + ".Resize"
+	TerminalMethodPing      = TerminalService + ".Ping"
+	TerminalMethodAttach    = TerminalService + ".Attach"
+	TerminalMethodDetach    = TerminalService + ".Detach"
+	TerminalMethodMetadata  = TerminalService + ".Metadata"
+	TerminalMethodState     = TerminalService + ".State"
+	TerminalMethodStop      = TerminalService + ".Stop"
+	TerminalMethodWrite     = TerminalService + ".Write"
+	TerminalMethodSubscribe = TerminalService + ".Subscribe"
 )
 
 type PingMessage struct {
@@ -169,6 +173,20 @@ type ResizeArgs struct {
 
 type StopArgs struct {
 	Reason string
+}
+
+// WriteRequest carries bytes to push into a terminal's PTY input.
+// Bytes are sent verbatim — the CLI layer is responsible for any
+// caret notation or hex-escape interpretation.
+type WriteRequest struct {
+	Data []byte
+}
+
+// SubscribeRequest identifies the caller of a Subscribe RPC. ClientID
+// is used only for server-side logging and attacher accounting; it does
+// not appear in TerminalStatus.Attachers.
+type SubscribeRequest struct {
+	ClientID ID
 }
 
 // ResponseWithFD carries a normal JSON result plus OOB file descriptors.

--- a/pkg/rpcclient/terminal/iface.go
+++ b/pkg/rpcclient/terminal/iface.go
@@ -32,4 +32,6 @@ type Client interface {
 	Metadata(ctx context.Context, metadata *api.TerminalDoc) error
 	State(ctx context.Context, state *api.TerminalStatusMode) error
 	Stop(ctx context.Context, args *api.StopArgs) error
+	Write(ctx context.Context, req *api.WriteRequest) error
+	Subscribe(ctx context.Context, req *api.SubscribeRequest, response any) (net.Conn, error)
 }

--- a/pkg/rpcclient/terminal/rpc_session.go
+++ b/pkg/rpcclient/terminal/rpc_session.go
@@ -263,3 +263,64 @@ func (c *client) State(ctx context.Context, state *api.TerminalStatusMode) error
 func (c *client) Stop(ctx context.Context, args *api.StopArgs) error {
 	return c.call(ctx, c.logger, api.TerminalMethodStop, args, &api.Empty{})
 }
+
+func (c *client) Write(ctx context.Context, req *api.WriteRequest) error {
+	if req == nil {
+		req = &api.WriteRequest{}
+	}
+	return c.call(ctx, c.logger, api.TerminalMethodWrite, req, &api.Empty{})
+}
+
+// Subscribe (uses FD-aware codec) returns a read-only net.Conn built from the
+// FD sent via SCM_RIGHTS. Bytes on the conn are live PTY output from the
+// moment the server registers the subscriber. It mirrors the Attach call
+// pattern but is output-only: the server closes the read half on its side.
+func (c *client) Subscribe(ctx context.Context, req *api.SubscribeRequest, out any) (net.Conn, error) {
+	if req == nil {
+		req = &api.SubscribeRequest{}
+	}
+	var gotFDs []int
+
+	c.logger.InfoContext(ctx, "Subscribe RPC call starting")
+
+	err := c.callWithCodec(
+		ctx,
+		api.TerminalMethodSubscribe,
+		req,
+		out,
+		func(conn net.Conn) (rpc.ClientCodec, func(), error) {
+			uconn, ok := conn.(*net.UnixConn)
+			if !ok {
+				_ = conn.Close()
+				return nil, nil, errors.New("subscribe: not a *net.UnixConn")
+			}
+			codec := newUnixJSONClientCodec(uconn, c.logger)
+
+			cleanup := func() {
+				gotFDs = codec.takeLastFDs()
+				_ = conn.Close()
+			}
+
+			return codec, cleanup, nil
+		},
+	)
+
+	if err != nil {
+		c.logger.ErrorContext(ctx, "Subscribe failed", "error", err)
+		return nil, err
+	}
+
+	if len(gotFDs) == 0 {
+		c.logger.ErrorContext(ctx, "subscribe: server did not send IO fd")
+		return nil, errors.New("subscribe: server did not send IO fd")
+	}
+
+	f := os.NewFile(uintptr(gotFDs[0]), "subscribe")
+	defer f.Close()
+	ioConn, err := net.FileConn(f)
+	if err != nil {
+		return nil, fmt.Errorf("subscribe: FileConn: %w", err)
+	}
+	c.logger.InfoContext(ctx, "Subscribe succeeded, returning net.Conn")
+	return ioConn, nil
+}


### PR DESCRIPTION
Closes #117.

## Summary
- New `Write` and `Subscribe` RPCs on the terminal control socket. `Write` pushes bytes into the PTY; `Subscribe` registers an output-only consumer on the existing `DynamicMultiWriter` fan-out and returns its end of a socketpair via SCM_RIGHTS (same pattern as `Attach`).
- New `sb write <name> [text|-]` CLI. Supports caret notation (`^@`..`^_`, `^?`), `\xHH` hex escapes, `--raw` for verbatim bytes, and `-` to read from stdin. Shell-style `\n`/`\t` are intentionally rejected (ambiguous with `^M`/`^I`).
- New `sb read <name>` CLI. Without `-f` it reads the capture file directly from disk (works even if the terminal has exited); with `-f` it subscribes, replays the capture, then streams live output. Subscribing before replay closes the cutover gap.
- Per-subscriber 1 MiB bounded ring: a slow/abandoned subscriber is disconnected with a `lagged` sentinel rather than stalling the PTY reader and every other attacher.
- Go API: `Client.Write(ctx, *WriteRequest)` and `Client.Subscribe(ctx, *SubscribeRequest, resp) (net.Conn, error)` added to `pkg/rpcclient/terminal`.

## Test plan
- [x] `go build ./...` + `go vet ./...` clean
- [x] `go test ./... -count=1` green (incl. unit tests for the caret parser and subscriber overflow)
- [x] `go test -tags=integration ./cmd/sb/get/...` green
- [x] `E2E_BIN_DIR=\$(pwd) go test ./e2e -count=1` green (new round-trip test: boot sbsh, `sb write`, `sb read`, plus `--raw` and caret-parse-error cases)
- [ ] Manual smoke: `sb write mybox -` < script.sh; `sb read -f mybox | tee out.log`

## Design notes
The three design questions called out in #117 are resolved in the code as follows:
1. **Caret scope**: stty-style caret + `\xHH`; no shell-style escapes (they collide with `^M`/`^I`).
2. **Slow-reader backpressure**: per-subscriber bounded ring; on overflow the subscriber is detached and the stream closes with a sentinel so the client can surface a "lagged" error.
3. **Write concurrency**: multiple writers (human attach + `sb write`) interleave on the PTY; documented as pre-existing behavior, no new locking beyond what `*os.File.Write` provides.

Issue #25 (profile-level raw PTY writes at lifecycle time) should later be migrated to call the shared `WritePTY` helper introduced here — left as a follow-up PR, not part of this one.