### PR TITLE
feat(profile): require explicit RunPath in BuildTerminalSpec

### DIFF
--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -69,6 +69,7 @@ var (
 	ErrConflictingFlags       = errors.New("conflicting flags provided; only one flag option can be used")
 	ErrBuildSocketPath        = errors.New("cannot build socket path")
 	ErrDetermineRunPath       = errors.New("cannot determine run path")
+	ErrRunPathRequired        = errors.New("run path is required")
 	ErrNoClientIdentification = errors.New("no client identification method provided, cannot detach")
 	ErrPositionalWithFlags    = errors.New("positional argument cannot be used with flags")
 	ErrInvalidOutputFormat    = errors.New("invalid output format")

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -24,9 +24,9 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/eminwux/sbsh/cmd/config"
 	"github.com/eminwux/sbsh/internal/defaults"
 	"github.com/eminwux/sbsh/internal/discovery"
+	"github.com/eminwux/sbsh/internal/errdefs"
 	"github.com/eminwux/sbsh/internal/naming"
 	"github.com/eminwux/sbsh/pkg/api"
 )
@@ -131,12 +131,20 @@ type BuildTerminalSpecParams struct {
 // the profiles file and merges the profile into the spec.
 // The returned TerminalSpec is ready to be used to spawn a terminal.
 //
+// RunPath is required. Callers (CLI or library consumers) must resolve their own
+// state-root default before invoking this function; an empty RunPath returns
+// errdefs.ErrRunPathRequired.
+//
 //nolint:funlen // For understandability, this function is long but straightforward.
 func BuildTerminalSpec(
 	ctx context.Context,
 	logger *slog.Logger,
 	input *BuildTerminalSpecParams,
 ) (*api.TerminalSpec, error) {
+	if input.RunPath == "" {
+		return nil, errdefs.ErrRunPathRequired
+	}
+
 	if input.TerminalID == "" {
 		// Default terminal ID to a random one
 		input.TerminalID = naming.RandomID()
@@ -149,11 +157,6 @@ func BuildTerminalSpec(
 	if input.ProfilesFile == "" {
 		// Default profilesFilename to $RUN_PATH/profiles.yaml
 		input.ProfilesFile = filepath.Join(input.RunPath, ".sbsh", "profiles.yaml")
-	}
-
-	if input.RunPath == "" {
-		// Default runPath to $HOME/.sbsh
-		input.RunPath = config.DefaultRunPath()
 	}
 
 	if input.TerminalCmd == "" {

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -1,0 +1,36 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package profile
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/eminwux/sbsh/internal/errdefs"
+)
+
+func TestBuildTerminalSpec_EmptyRunPath_ReturnsErrRunPathRequired(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	_, err := BuildTerminalSpec(context.Background(), logger, &BuildTerminalSpecParams{})
+	if !errors.Is(err, errdefs.ErrRunPathRequired) {
+		t.Fatalf("expected errdefs.ErrRunPathRequired, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

PR-A of the umbrella #118 (consume sbsh as a Go library, driven by `kukeon` integration). This PR closes the *parametrize state root* gap from the scope table by making `internal/profile.BuildTerminalSpec` refuse to silently default `RunPath` to `~/.sbsh`.

- `internal/profile.BuildTerminalSpec` now returns `errdefs.ErrRunPathRequired` when `RunPath` is empty, instead of falling back to `config.DefaultRunPath()`. Library consumers (e.g. `kukeon`) can now run the stack under an arbitrary `StateRoot` (e.g. `/opt/kukeon/sbsh`) without any risk of silent writes into the current user's home directory.
- CLI behavior is unchanged: `cmd/sbsh/sbsh.go:LoadConfig` and `cmd/sbsh/terminal/terminal.go:PreRunE` already pre-fill `RunPath` via `viper.SetDefault(config.DefaultRunPath())`, so `sb` / `sbsh` continue to default to `~/.sbsh` when the user doesn't pass `--run-path`.
- Also reorders the `ProfilesFile` derivation so it runs *after* the new `RunPath` check — previously it was constructed from an empty `RunPath` before the fallback ran (latent bug, now unreachable).

Refs #118. Does **not** `Closes #118` — the umbrella stays open until PR-G lands.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/profile/...` — new `TestBuildTerminalSpec_EmptyRunPath_ReturnsErrRunPathRequired` passes
- [x] `go test ./...` (non-e2e) — no regressions
- [x] `make sbsh-sb && make test-e2e` — full e2e suite passes (binaries exercise the CLI-side default path, confirming no regression)

## Out-of-scope (flagged for later sub-PRs)

- `cmd/sbsh/terminal/terminal.go:88` reads `SB_ROOT_RUN_PATH` rather than `SBSH_ROOT_RUN_PATH`. May or may not be intentional; untouched here.
- The duplicated `LoadConfig` defaulting pattern across `cmd/sb/sb.go`, `cmd/sbsh/sbsh.go`, and `cmd/sbsh/terminal/terminal.go` would benefit from a shared `ResolveRunPath` helper — CLI-layer refactor, out of scope for PR-A.