### PR TITLE
feat(discovery): promote terminal/client/profile discovery to pkg/discovery

### DIFF
--- a/internal/discovery/clients.go
+++ b/internal/discovery/clients.go
@@ -90,8 +90,8 @@ func ScanAndPruneClients(ctx context.Context, logger *slog.Logger, runPath strin
 		"client",
 		func(s api.ClientDoc) bool { return s.Status.State == api.ClientExited },
 		PruneClient,
-		clientID,
-		clientName,
+		pkgdiscovery.ClientID,
+		pkgdiscovery.ClientName,
 	)
 	return err
 }
@@ -122,15 +122,6 @@ func PruneClient(logger *slog.Logger, metadata *api.ClientDoc) error {
 		logger.InfoContext(context.Background(), "PruneClient: client folder removed", "path", metadata.Status.ClientRunPath)
 	}
 	return err
-}
-
-func clientID(s api.ClientDoc) string {
-	// If your type uses Id instead of ID, change to: return s.Id
-	return string(s.Spec.ID)
-}
-
-func clientName(s api.ClientDoc) string {
-	return s.Metadata.Name
 }
 
 func clientLabels(s api.ClientDoc) map[string]string {
@@ -171,14 +162,14 @@ func printClients(w io.Writer, clients []api.ClientDoc, printAll, wide bool) err
 		}
 		if wide {
 			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
-				clientID(s),
-				clientName(s),
+				pkgdiscovery.ClientID(s),
+				pkgdiscovery.ClientName(s),
 				s.Status.State.String(),
 				joinLabels(clientLabels(s)),
 			)
 		} else {
 			fmt.Fprintf(tw, "%s\t%s\n",
-				clientName(s),
+				pkgdiscovery.ClientName(s),
 				s.Status.State.String(),
 			)
 		}
@@ -203,11 +194,11 @@ func FindAndPrintClientMetadata(
 	logger *slog.Logger,
 	runPath string,
 	w io.Writer,
-	terminalName string,
+	clientName string,
 	format string,
 ) error {
 	logger.DebugContext(ctx, "FindAndPrintClientMetadata: scanning clients", "runPath", runPath)
-	clients, err := FindClientByName(ctx, logger, runPath, terminalName)
+	clients, err := FindClientByName(ctx, logger, runPath, clientName)
 	if err != nil {
 		logger.ErrorContext(ctx, "FindAndPrintClientMetadata: failed to scan clients", "error", err)
 		return err

--- a/internal/discovery/clients.go
+++ b/internal/discovery/clients.go
@@ -22,11 +22,10 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"sort"
 	"text/tabwriter"
 
-	"github.com/eminwux/sbsh/internal/defaults"
 	"github.com/eminwux/sbsh/pkg/api"
+	pkgdiscovery "github.com/eminwux/sbsh/pkg/discovery"
 )
 
 // ScanAndPrintClients finds all metadata.json under runPath/clients/*,
@@ -97,30 +96,9 @@ func ScanAndPruneClients(ctx context.Context, logger *slog.Logger, runPath strin
 	return err
 }
 
+// ScanClients is a thin wrapper around [pkgdiscovery.ScanClients].
 func ScanClients(ctx context.Context, logger *slog.Logger, runPath string) ([]api.ClientDoc, error) {
-	out, err := scanMetadataFiles(
-		ctx,
-		logger,
-		runPath,
-		defaults.ClientsRunPath,
-		"ScanClients",
-		clientID,
-		clientName,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	// Optional: stable order by ID (fallback to Name if ID empty)
-	sort.Slice(out, func(i, j int) bool {
-		idi, idj := clientID(out[i]), clientID(out[j])
-		if idi != idj {
-			return idi < idj
-		}
-		return clientName(out[i]) < clientName(out[j])
-	})
-
-	return out, nil
+	return pkgdiscovery.ScanClients(ctx, logger, runPath)
 }
 
 func PruneClient(logger *slog.Logger, metadata *api.ClientDoc) error {
@@ -208,23 +186,14 @@ func printClients(w io.Writer, clients []api.ClientDoc, printAll, wide bool) err
 	return tw.Flush()
 }
 
-// FindClientByName scans runPath/clients/*/metadata.json and returns
-// the client whose Metadata.Name matches the given name. If not found, returns nil.
+// FindClientByName is a thin wrapper around [pkgdiscovery.FindClientByName].
 func FindClientByName(
 	ctx context.Context,
 	logger *slog.Logger,
 	runPath string,
 	name string,
 ) (*api.ClientDoc, error) {
-	clients, err := ScanClients(ctx, logger, runPath)
-	if err != nil {
-		return nil, err
-	}
-	return findMetadataBy(
-		clients,
-		func(s api.ClientDoc) bool { return clientName(s) == name },
-		fmt.Sprintf("client with name %q not found", name),
-	)
+	return pkgdiscovery.FindClientByName(ctx, logger, runPath, name)
 }
 
 // FindAndPrintClientMetadata finds all metadata.json under runPath/clients/*,

--- a/internal/discovery/profiles.go
+++ b/internal/discovery/profiles.go
@@ -18,16 +18,14 @@ package discovery
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
-	"os"
 	"strings"
 	"text/tabwriter"
 
 	"github.com/eminwux/sbsh/pkg/api"
-	"gopkg.in/yaml.v3"
+	pkgdiscovery "github.com/eminwux/sbsh/pkg/discovery"
 )
 
 // ScanAndPrintProfiles loads all profiles from a YAML file (supports multiple '---' documents)
@@ -58,63 +56,23 @@ func ScanAndPrintProfiles(
 	}
 }
 
-// LoadProfilesFromPath reads a multi-document YAML file into []api.TerminalProfileDoc.
+// LoadProfilesFromPath is a thin wrapper around [pkgdiscovery.LoadProfilesFromPath].
 func LoadProfilesFromPath(
 	ctx context.Context,
 	logger *slog.Logger,
 	profilesFile string,
 ) ([]api.TerminalProfileDoc, error) {
-	logger.DebugContext(ctx, "LoadProfilesFromPath: opening file", "path", profilesFile)
-	f, err := os.Open(profilesFile)
-	if err != nil {
-		logger.ErrorContext(ctx, "LoadProfilesFromPath: failed to open file", "path", profilesFile, "error", err)
-		return nil, fmt.Errorf("open profiles file %q: %w", profilesFile, err)
-	}
-	defer f.Close()
-	logger.InfoContext(ctx, "LoadProfilesFromPath: file opened", "path", profilesFile)
-	return LoadProfilesFromReaderWithContext(ctx, logger, f)
+	return pkgdiscovery.LoadProfilesFromPath(ctx, logger, profilesFile)
 }
 
-// LoadProfilesFromReaderWithContext decodes one or more YAML documents from r.
+// LoadProfilesFromReaderWithContext is a thin wrapper around
+// [pkgdiscovery.LoadProfilesFromReaderWithContext].
 func LoadProfilesFromReaderWithContext(
 	ctx context.Context,
 	logger *slog.Logger,
 	r io.Reader,
 ) ([]api.TerminalProfileDoc, error) {
-	logger.DebugContext(ctx, "LoadProfilesFromReader: decoding YAML documents")
-	dec := yaml.NewDecoder(r)
-
-	var out []api.TerminalProfileDoc
-	docCount := 0
-	for {
-		var p api.TerminalProfileDoc
-		if err := dec.Decode(&p); err != nil {
-			if errors.Is(err, io.EOF) {
-				logger.InfoContext(ctx, "LoadProfilesFromReader: reached EOF", "count", docCount)
-				break
-			}
-			logger.ErrorContext(ctx, "LoadProfilesFromReader: decode error", "error", err)
-			return nil, fmt.Errorf("decode profile: %w", err)
-		}
-		docCount++
-
-		// Basic sanity checks; skip empty docs.
-		if p.Metadata.Name == "" || string(p.APIVersion) == "" || string(p.Kind) == "" {
-			logger.WarnContext(ctx,
-				"LoadProfilesFromReader: skipping empty/invalid profile document",
-				"doc",
-				docCount,
-				"name",
-				p.Metadata.Name,
-			)
-			continue
-		}
-		logger.DebugContext(ctx, "LoadProfilesFromReader: loaded profile", "name", p.Metadata.Name)
-		out = append(out, p)
-	}
-
-	logger.InfoContext(ctx, "LoadProfilesFromReader: finished loading profiles", "count", len(out))
-	return out, nil
+	return pkgdiscovery.LoadProfilesFromReaderWithContext(ctx, logger, r)
 }
 
 func PrintProfilesTable(w io.Writer, profiles []api.TerminalProfileDoc, wide bool) error {
@@ -158,25 +116,9 @@ func PrintProfilesTable(w io.Writer, profiles []api.TerminalProfileDoc, wide boo
 	return tw.Flush()
 }
 
-// FindProfileByName scans the YAML file at path and returns the profile whose metadata.name matches.
-// The match is case-sensitive; use strings.EqualFold if you prefer case-insensitive lookup.
+// FindProfileByName is a thin wrapper around [pkgdiscovery.FindProfileByName].
 func FindProfileByName(ctx context.Context, logger *slog.Logger, path, name string) (*api.TerminalProfileDoc, error) {
-	logger.DebugContext(ctx, "FindProfileByName: searching for profile", "name", name, "path", path)
-	profiles, err := LoadProfilesFromPath(ctx, logger, path)
-	if err != nil {
-		logger.ErrorContext(ctx, "FindProfileByName: failed to load profiles", "error", err)
-		return nil, err
-	}
-
-	for _, p := range profiles {
-		if p.Metadata.Name == name {
-			logger.InfoContext(ctx, "FindProfileByName: found profile", "name", name)
-			return &p, nil
-		}
-	}
-
-	logger.WarnContext(ctx, "FindProfileByName: profile not found", "name", name, "path", path)
-	return nil, fmt.Errorf("profile %q not found in %s", name, path)
+	return pkgdiscovery.FindProfileByName(ctx, logger, path, name)
 }
 
 // FindAndPrintProfileMetadata finds all metadata.json under profiles file,

--- a/internal/discovery/scan.go
+++ b/internal/discovery/scan.go
@@ -18,91 +18,10 @@ package discovery
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
-	"os"
-	"path/filepath"
 )
-
-// scanMetadataFiles reads all metadata.json files matching the pattern and unmarshals them.
-// It returns a slice of unmarshaled metadata structs of type T.
-func scanMetadataFiles[T any](
-	ctx context.Context,
-	logger *slog.Logger,
-	runPath string,
-	subDir string,
-	logPrefix string,
-	idGetter func(T) string,
-	nameGetter func(T) string,
-) ([]T, error) {
-	pattern := filepath.Join(runPath, subDir, "*", "metadata.json")
-	logger.DebugContext(ctx, fmt.Sprintf("%s: globbing for metadata", logPrefix), "pattern", pattern)
-	paths, err := filepath.Glob(pattern)
-	if err != nil {
-		logger.ErrorContext(ctx, fmt.Sprintf("%s: glob failed", logPrefix), "error", err)
-		return nil, fmt.Errorf("glob %q: %w", pattern, err)
-	}
-
-	out := make([]T, 0, len(paths))
-	for _, p := range paths {
-		select {
-		case <-ctx.Done():
-			logger.WarnContext(ctx, fmt.Sprintf("%s: context done while reading", logPrefix))
-			return nil, ctx.Err()
-		default:
-		}
-		b, errRead := os.ReadFile(p)
-		if errRead != nil {
-			logger.ErrorContext(ctx, fmt.Sprintf("%s: failed to read file", logPrefix), "file", p, "error", errRead)
-			return nil, fmt.Errorf("read %s: %w", p, errRead)
-		}
-		var s T
-		if errUnmarshal := json.Unmarshal(b, &s); errUnmarshal != nil {
-			logger.ErrorContext(
-				ctx,
-				fmt.Sprintf("%s: failed to decode file", logPrefix),
-				"file",
-				p,
-				"error",
-				errUnmarshal,
-			)
-			return nil, fmt.Errorf("decode %s: %w", p, errUnmarshal)
-		}
-		logger.DebugContext(
-			ctx,
-			fmt.Sprintf("%s: loaded metadata", logPrefix),
-			"id",
-			idGetter(s),
-			"name",
-			nameGetter(s),
-		)
-		out = append(out, s)
-	}
-
-	logger.InfoContext(ctx, fmt.Sprintf("%s: finished scanning", logPrefix), "count", len(out))
-	return out, nil
-}
-
-// findMetadataBy searches through a slice of metadata items and returns the first one that matches the predicate.
-// It returns a copy of the item to avoid referencing the loop variable.
-func findMetadataBy[T any](
-	items []T,
-	predicate func(T) bool,
-	notFoundErrMsg string,
-) (*T, error) {
-	for _, item := range items {
-		if predicate(item) {
-			// return a copy to avoid referencing the loop variable
-			result := item
-			return &result, nil
-		}
-	}
-	//nolint:goerr113 // error message is constructed from parameter
-	return nil, errors.New(notFoundErrMsg)
-}
 
 // scanAndPruneMetadata scans metadata items and prunes those that match the isExited predicate.
 // It returns the number of items pruned and any error encountered.

--- a/internal/discovery/terminals.go
+++ b/internal/discovery/terminals.go
@@ -95,8 +95,8 @@ func ScanAndPruneTerminals(ctx context.Context, logger *slog.Logger, runPath str
 		"terminal",
 		func(t api.TerminalDoc) bool { return t.Status.State == api.Exited },
 		PruneTerminal,
-		terminalID,
-		terminalName,
+		pkgdiscovery.TerminalID,
+		pkgdiscovery.TerminalName,
 	)
 	return err
 }
@@ -162,8 +162,8 @@ func printTerminals(w io.Writer, terminals []api.TerminalDoc, printAll, wide boo
 		}
 		if wide {
 			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-				terminalID(s),
-				terminalName(s),
+				pkgdiscovery.TerminalID(s),
+				pkgdiscovery.TerminalName(s),
 				terminalProfile(s),
 				terminalCmd(s),
 				terminalPty(s),
@@ -175,7 +175,7 @@ func printTerminals(w io.Writer, terminals []api.TerminalDoc, printAll, wide boo
 			)
 		} else {
 			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
-				terminalName(s),
+				pkgdiscovery.TerminalName(s),
 				terminalProfile(s),
 				terminalPty(s),
 				formatAge(s.Metadata.CreatedAt),
@@ -212,15 +212,6 @@ func terminalAttachers(s api.TerminalDoc) string {
 		attachers = strings.Join(s.Status.Attachers, ",")
 	}
 	return attachers
-}
-
-func terminalID(s api.TerminalDoc) string {
-	// If your type uses Id instead of ID, change to: return s.Id
-	return string(s.Spec.ID)
-}
-
-func terminalName(s api.TerminalDoc) string {
-	return s.Spec.Name
 }
 
 func terminalCmd(s api.TerminalDoc) string {

--- a/internal/discovery/terminals.go
+++ b/internal/discovery/terminals.go
@@ -28,8 +28,8 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/eminwux/sbsh/internal/defaults"
 	"github.com/eminwux/sbsh/pkg/api"
+	pkgdiscovery "github.com/eminwux/sbsh/pkg/discovery"
 	"go.yaml.in/yaml/v3"
 )
 
@@ -124,30 +124,11 @@ func PruneTerminal(logger *slog.Logger, metadata *api.TerminalDoc) error {
 	return err
 }
 
+// ScanTerminals is a thin wrapper around [pkgdiscovery.ScanTerminals].
+// Kept here so in-tree internal callers do not need to import pkg/discovery
+// directly; new external consumers should use pkg/discovery.
 func ScanTerminals(ctx context.Context, logger *slog.Logger, runPath string) ([]api.TerminalDoc, error) {
-	out, err := scanMetadataFiles(
-		ctx,
-		logger,
-		runPath,
-		defaults.TerminalsRunPath,
-		"ScanTerminals",
-		terminalID,
-		terminalName,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	// Optional: stable order by ID (fallback to Name if ID empty)
-	sort.Slice(out, func(i, j int) bool {
-		idi, idj := terminalID(out[i]), terminalID(out[j])
-		if idi != idj {
-			return idi < idj
-		}
-		return terminalName(out[i]) < terminalName(out[j])
-	})
-
-	return out, nil
+	return pkgdiscovery.ScanTerminals(ctx, logger, runPath)
 }
 
 func printTerminals(w io.Writer, terminals []api.TerminalDoc, printAll, wide bool) error {
@@ -282,42 +263,24 @@ func joinLabels(m map[string]string) string {
 	return strings.Join(parts, ",")
 }
 
-// FindTerminalByID scans runPath/terminals/*/metadata.json and returns
-// the terminal whose Spec.ID matches the given id. If not found, returns nil.
+// FindTerminalByID is a thin wrapper around [pkgdiscovery.FindTerminalByID].
 func FindTerminalByID(
 	ctx context.Context,
 	logger *slog.Logger,
 	runPath string,
 	id string,
 ) (*api.TerminalDoc, error) {
-	terminals, err := ScanTerminals(ctx, logger, runPath)
-	if err != nil {
-		return nil, err
-	}
-	return findMetadataBy(
-		terminals,
-		func(t api.TerminalDoc) bool { return string(t.Spec.ID) == id },
-		fmt.Sprintf("terminal %q not found", id),
-	)
+	return pkgdiscovery.FindTerminalByID(ctx, logger, runPath, id)
 }
 
-// FindTerminalByName scans runPath/terminals/*/metadata.json and returns
-// the terminal whose Spec.Name matches the given name. If not found, returns nil.
+// FindTerminalByName is a thin wrapper around [pkgdiscovery.FindTerminalByName].
 func FindTerminalByName(
 	ctx context.Context,
 	logger *slog.Logger,
 	runPath string,
 	name string,
 ) (*api.TerminalDoc, error) {
-	terminals, err := ScanTerminals(ctx, logger, runPath)
-	if err != nil {
-		return nil, err
-	}
-	return findMetadataBy(
-		terminals,
-		func(t api.TerminalDoc) bool { return terminalName(t) == name },
-		fmt.Sprintf("terminal with name %q not found", name),
-	)
+	return pkgdiscovery.FindTerminalByName(ctx, logger, runPath, name)
 }
 
 func PrintTerminalSpec(s *api.TerminalSpec, logger *slog.Logger) error {

--- a/pkg/discovery/clients.go
+++ b/pkg/discovery/clients.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"sort"
+	"slices"
 
 	"github.com/eminwux/sbsh/internal/defaults"
 	"github.com/eminwux/sbsh/pkg/api"
@@ -36,19 +36,18 @@ func ScanClients(ctx context.Context, logger *slog.Logger, runPath string) ([]ap
 		runPath,
 		defaults.ClientsRunPath,
 		"ScanClients",
-		clientID,
-		clientName,
+		ClientID,
+		ClientName,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	sort.Slice(out, func(i, j int) bool {
-		idi, idj := clientID(out[i]), clientID(out[j])
-		if idi != idj {
-			return idi < idj
+	slices.SortStableFunc(out, func(a, b api.ClientDoc) int {
+		if c := cmpString(ClientID(a), ClientID(b)); c != 0 {
+			return c
 		}
-		return clientName(out[i]) < clientName(out[j])
+		return cmpString(ClientName(a), ClientName(b))
 	})
 
 	return out, nil
@@ -69,15 +68,17 @@ func FindClientByName(
 	}
 	return findMetadataBy(
 		clients,
-		func(s api.ClientDoc) bool { return clientName(s) == name },
+		func(s api.ClientDoc) bool { return ClientName(s) == name },
 		fmt.Sprintf("client with name %q not found", name),
 	)
 }
 
-func clientID(s api.ClientDoc) string {
+// ClientID returns the canonical ID (Spec.ID) of a client document.
+func ClientID(s api.ClientDoc) string {
 	return string(s.Spec.ID)
 }
 
-func clientName(s api.ClientDoc) string {
+// ClientName returns the canonical name (Metadata.Name) of a client document.
+func ClientName(s api.ClientDoc) string {
 	return s.Metadata.Name
 }

--- a/pkg/discovery/clients.go
+++ b/pkg/discovery/clients.go
@@ -1,0 +1,83 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+
+	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// ScanClients enumerates every client metadata.json under
+// runPath/clients/*. Results are sorted by Spec.ID (then Metadata.Name
+// for ties) so consecutive scans produce stable output.
+func ScanClients(ctx context.Context, logger *slog.Logger, runPath string) ([]api.ClientDoc, error) {
+	out, err := scanMetadataFiles(
+		ctx,
+		logger,
+		runPath,
+		defaults.ClientsRunPath,
+		"ScanClients",
+		clientID,
+		clientName,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		idi, idj := clientID(out[i]), clientID(out[j])
+		if idi != idj {
+			return idi < idj
+		}
+		return clientName(out[i]) < clientName(out[j])
+	})
+
+	return out, nil
+}
+
+// FindClientByName scans runPath/clients/*/metadata.json and returns
+// the client whose Metadata.Name matches the given name. Returns an
+// error if no client with that name is found.
+func FindClientByName(
+	ctx context.Context,
+	logger *slog.Logger,
+	runPath string,
+	name string,
+) (*api.ClientDoc, error) {
+	clients, err := ScanClients(ctx, logger, runPath)
+	if err != nil {
+		return nil, err
+	}
+	return findMetadataBy(
+		clients,
+		func(s api.ClientDoc) bool { return clientName(s) == name },
+		fmt.Sprintf("client with name %q not found", name),
+	)
+}
+
+func clientID(s api.ClientDoc) string {
+	return string(s.Spec.ID)
+}
+
+func clientName(s api.ClientDoc) string {
+	return s.Metadata.Name
+}

--- a/pkg/discovery/clients_test.go
+++ b/pkg/discovery/clients_test.go
@@ -1,0 +1,157 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package discovery_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/pkg/api"
+	"github.com/eminwux/sbsh/pkg/discovery"
+)
+
+func writeClientDoc(t *testing.T, runPath, id, name string) {
+	t.Helper()
+	dir := filepath.Join(runPath, defaults.ClientsRunPath, id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	doc := api.ClientDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindClient,
+		Metadata:   api.ClientMetadata{Name: name},
+		Spec:       api.ClientSpec{ID: api.ID(id)},
+	}
+	b, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), b, 0o644); err != nil {
+		t.Fatalf("write metadata.json: %v", err)
+	}
+}
+
+func writeInvalidClientJSON(t *testing.T, runPath, id string) {
+	t.Helper()
+	dir := filepath.Join(runPath, defaults.ClientsRunPath, id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), []byte("{garbage"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestScanClients_EmptyRunPath(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	runPath := t.TempDir()
+
+	got, err := discovery.ScanClients(ctx, logger, runPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 clients, got %d", len(got))
+	}
+}
+
+func TestScanClients_MissingRunPath(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	runPath := filepath.Join(t.TempDir(), "nope")
+
+	got, err := discovery.ScanClients(ctx, logger, runPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 clients, got %d", len(got))
+	}
+}
+
+func TestScanClients_InvalidJSON(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	runPath := t.TempDir()
+	writeInvalidClientJSON(t, runPath, "bad")
+
+	_, err := discovery.ScanClients(ctx, logger, runPath)
+	if err == nil {
+		t.Fatal("expected decode error, got nil")
+	}
+}
+
+func TestScanClients_Sorted(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	runPath := t.TempDir()
+
+	writeClientDoc(t, runPath, "c-z", "zeta")
+	writeClientDoc(t, runPath, "c-a", "alpha")
+	writeClientDoc(t, runPath, "c-m", "mu")
+
+	got, err := discovery.ScanClients(ctx, logger, runPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantIDs := []string{"c-a", "c-m", "c-z"}
+	if len(got) != len(wantIDs) {
+		t.Fatalf("want %d clients, got %d", len(wantIDs), len(got))
+	}
+	for i, w := range wantIDs {
+		if string(got[i].Spec.ID) != w {
+			t.Fatalf("sort mismatch at %d: want %q, got %q", i, w, got[i].Spec.ID)
+		}
+	}
+}
+
+func TestFindClientByName(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	runPath := t.TempDir()
+	writeClientDoc(t, runPath, "c-1", "one")
+	writeClientDoc(t, runPath, "c-2", "two")
+
+	got, err := discovery.FindClientByName(ctx, logger, runPath, "two")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || got.Metadata.Name != "two" {
+		t.Fatalf("want name=two, got %+v", got)
+	}
+}
+
+func TestFindClientByName_NotFound(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	runPath := t.TempDir()
+	writeClientDoc(t, runPath, "c-1", "one")
+
+	_, err := discovery.FindClientByName(ctx, logger, runPath, "missing")
+	if err == nil {
+		t.Fatal("expected not-found error, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("expected error to mention %q, got: %v", "missing", err)
+	}
+}

--- a/pkg/discovery/profiles.go
+++ b/pkg/discovery/profiles.go
@@ -1,0 +1,112 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package discovery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+
+	"github.com/eminwux/sbsh/pkg/api"
+	"gopkg.in/yaml.v3"
+)
+
+// LoadProfilesFromPath reads a multi-document YAML file into []api.TerminalProfileDoc.
+// Documents missing APIVersion, Kind, or Metadata.Name are logged and skipped.
+func LoadProfilesFromPath(
+	ctx context.Context,
+	logger *slog.Logger,
+	profilesFile string,
+) ([]api.TerminalProfileDoc, error) {
+	logger.DebugContext(ctx, "LoadProfilesFromPath: opening file", "path", profilesFile)
+	f, err := os.Open(profilesFile)
+	if err != nil {
+		logger.ErrorContext(ctx, "LoadProfilesFromPath: failed to open file", "path", profilesFile, "error", err)
+		return nil, fmt.Errorf("open profiles file %q: %w", profilesFile, err)
+	}
+	defer f.Close()
+	logger.InfoContext(ctx, "LoadProfilesFromPath: file opened", "path", profilesFile)
+	return LoadProfilesFromReaderWithContext(ctx, logger, f)
+}
+
+// LoadProfilesFromReaderWithContext decodes one or more YAML documents from r
+// into []api.TerminalProfileDoc. Documents missing APIVersion, Kind, or
+// Metadata.Name are logged and skipped.
+func LoadProfilesFromReaderWithContext(
+	ctx context.Context,
+	logger *slog.Logger,
+	r io.Reader,
+) ([]api.TerminalProfileDoc, error) {
+	logger.DebugContext(ctx, "LoadProfilesFromReader: decoding YAML documents")
+	dec := yaml.NewDecoder(r)
+
+	var out []api.TerminalProfileDoc
+	docCount := 0
+	for {
+		var p api.TerminalProfileDoc
+		if err := dec.Decode(&p); err != nil {
+			if errors.Is(err, io.EOF) {
+				logger.InfoContext(ctx, "LoadProfilesFromReader: reached EOF", "count", docCount)
+				break
+			}
+			logger.ErrorContext(ctx, "LoadProfilesFromReader: decode error", "error", err)
+			return nil, fmt.Errorf("decode profile: %w", err)
+		}
+		docCount++
+
+		if p.Metadata.Name == "" || string(p.APIVersion) == "" || string(p.Kind) == "" {
+			logger.WarnContext(ctx,
+				"LoadProfilesFromReader: skipping empty/invalid profile document",
+				"doc",
+				docCount,
+				"name",
+				p.Metadata.Name,
+			)
+			continue
+		}
+		logger.DebugContext(ctx, "LoadProfilesFromReader: loaded profile", "name", p.Metadata.Name)
+		out = append(out, p)
+	}
+
+	logger.InfoContext(ctx, "LoadProfilesFromReader: finished loading profiles", "count", len(out))
+	return out, nil
+}
+
+// FindProfileByName scans the YAML file at path and returns the profile
+// whose Metadata.Name matches. The match is case-sensitive. Returns an
+// error if no profile with that name is found.
+func FindProfileByName(ctx context.Context, logger *slog.Logger, path, name string) (*api.TerminalProfileDoc, error) {
+	logger.DebugContext(ctx, "FindProfileByName: searching for profile", "name", name, "path", path)
+	profiles, err := LoadProfilesFromPath(ctx, logger, path)
+	if err != nil {
+		logger.ErrorContext(ctx, "FindProfileByName: failed to load profiles", "error", err)
+		return nil, err
+	}
+
+	for _, p := range profiles {
+		if p.Metadata.Name == name {
+			logger.InfoContext(ctx, "FindProfileByName: found profile", "name", name)
+			return &p, nil
+		}
+	}
+
+	logger.WarnContext(ctx, "FindProfileByName: profile not found", "name", name, "path", path)
+	return nil, fmt.Errorf("profile %q not found in %s", name, path)
+}

--- a/pkg/discovery/profiles_test.go
+++ b/pkg/discovery/profiles_test.go
@@ -1,0 +1,151 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package discovery_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/sbsh/pkg/discovery"
+)
+
+const multiDocProfiles = `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: alpha
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/bash
+---
+apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: beta
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/zsh
+`
+
+// A doc missing apiVersion/kind/name should be skipped (logged, not errored).
+const profilesWithEmptyDoc = `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: only
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/bash
+---
+metadata:
+  name: ""
+---
+apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: also
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/zsh
+`
+
+func writeProfileFile(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "profiles.yaml")
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write profiles: %v", err)
+	}
+	return p
+}
+
+func TestLoadProfilesFromPath_MultiDoc(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	path := writeProfileFile(t, multiDocProfiles)
+
+	got, err := discovery.LoadProfilesFromPath(ctx, logger, path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 profiles, got %d", len(got))
+	}
+	if got[0].Metadata.Name != "alpha" || got[1].Metadata.Name != "beta" {
+		t.Fatalf("unexpected names: %q, %q", got[0].Metadata.Name, got[1].Metadata.Name)
+	}
+}
+
+func TestLoadProfilesFromPath_SkipsEmptyDocs(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	path := writeProfileFile(t, profilesWithEmptyDoc)
+
+	got, err := discovery.LoadProfilesFromPath(ctx, logger, path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 profiles (empty doc skipped), got %d", len(got))
+	}
+	if got[0].Metadata.Name != "only" || got[1].Metadata.Name != "also" {
+		t.Fatalf("unexpected names: %q, %q", got[0].Metadata.Name, got[1].Metadata.Name)
+	}
+}
+
+func TestLoadProfilesFromPath_FileNotFound(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+
+	_, err := discovery.LoadProfilesFromPath(ctx, logger, filepath.Join(t.TempDir(), "missing.yaml"))
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+func TestFindProfileByName(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	path := writeProfileFile(t, multiDocProfiles)
+
+	got, err := discovery.FindProfileByName(ctx, logger, path, "beta")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || got.Metadata.Name != "beta" {
+		t.Fatalf("want name=beta, got %+v", got)
+	}
+}
+
+func TestFindProfileByName_NotFound(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	path := writeProfileFile(t, multiDocProfiles)
+
+	_, err := discovery.FindProfileByName(ctx, logger, path, "ghost")
+	if err == nil {
+		t.Fatal("expected not-found error, got nil")
+	}
+	if !strings.Contains(err.Error(), "ghost") {
+		t.Fatalf("expected error to mention %q, got: %v", "ghost", err)
+	}
+}

--- a/pkg/discovery/scan.go
+++ b/pkg/discovery/scan.go
@@ -93,6 +93,19 @@ func scanMetadataFiles[T any](
 	return out, nil
 }
 
+// cmpString returns -1 if a < b, 1 if a > b, 0 if equal. Used as a
+// comparator for slices.SortStableFunc.
+func cmpString(a, b string) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
 // findMetadataBy searches through a slice of metadata items and returns the first one that matches the predicate.
 // It returns a copy of the item to avoid referencing the loop variable.
 func findMetadataBy[T any](

--- a/pkg/discovery/scan.go
+++ b/pkg/discovery/scan.go
@@ -1,0 +1,112 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package discovery is the public surface for locating sbsh terminals,
+// clients and profiles persisted under a state root.
+//
+// External modules (e.g. kukeon) use this package to enumerate live
+// terminals/clients or to load profiles from disk without depending on
+// internal packages. All operations take an explicit runPath (or profile
+// file path) so callers can point the whole discovery surface at a
+// custom state root.
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+// scanMetadataFiles reads all metadata.json files matching the pattern and unmarshals them.
+// It returns a slice of unmarshaled metadata structs of type T.
+func scanMetadataFiles[T any](
+	ctx context.Context,
+	logger *slog.Logger,
+	runPath string,
+	subDir string,
+	logPrefix string,
+	idGetter func(T) string,
+	nameGetter func(T) string,
+) ([]T, error) {
+	pattern := filepath.Join(runPath, subDir, "*", "metadata.json")
+	logger.DebugContext(ctx, fmt.Sprintf("%s: globbing for metadata", logPrefix), "pattern", pattern)
+	paths, err := filepath.Glob(pattern)
+	if err != nil {
+		logger.ErrorContext(ctx, fmt.Sprintf("%s: glob failed", logPrefix), "error", err)
+		return nil, fmt.Errorf("glob %q: %w", pattern, err)
+	}
+
+	out := make([]T, 0, len(paths))
+	for _, p := range paths {
+		select {
+		case <-ctx.Done():
+			logger.WarnContext(ctx, fmt.Sprintf("%s: context done while reading", logPrefix))
+			return nil, ctx.Err()
+		default:
+		}
+		b, errRead := os.ReadFile(p)
+		if errRead != nil {
+			logger.ErrorContext(ctx, fmt.Sprintf("%s: failed to read file", logPrefix), "file", p, "error", errRead)
+			return nil, fmt.Errorf("read %s: %w", p, errRead)
+		}
+		var s T
+		if errUnmarshal := json.Unmarshal(b, &s); errUnmarshal != nil {
+			logger.ErrorContext(
+				ctx,
+				fmt.Sprintf("%s: failed to decode file", logPrefix),
+				"file",
+				p,
+				"error",
+				errUnmarshal,
+			)
+			return nil, fmt.Errorf("decode %s: %w", p, errUnmarshal)
+		}
+		logger.DebugContext(
+			ctx,
+			fmt.Sprintf("%s: loaded metadata", logPrefix),
+			"id",
+			idGetter(s),
+			"name",
+			nameGetter(s),
+		)
+		out = append(out, s)
+	}
+
+	logger.InfoContext(ctx, fmt.Sprintf("%s: finished scanning", logPrefix), "count", len(out))
+	return out, nil
+}
+
+// findMetadataBy searches through a slice of metadata items and returns the first one that matches the predicate.
+// It returns a copy of the item to avoid referencing the loop variable.
+func findMetadataBy[T any](
+	items []T,
+	predicate func(T) bool,
+	notFoundErrMsg string,
+) (*T, error) {
+	for _, item := range items {
+		if predicate(item) {
+			// return a copy to avoid referencing the loop variable
+			result := item
+			return &result, nil
+		}
+	}
+	//nolint:goerr113 // error message is constructed from parameter
+	return nil, errors.New(notFoundErrMsg)
+}

--- a/pkg/discovery/terminals.go
+++ b/pkg/discovery/terminals.go
@@ -1,0 +1,103 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+
+	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// ScanTerminals enumerates every terminal metadata.json under
+// runPath/terminals/*. Results are sorted by Spec.ID (then Spec.Name
+// for ties) so consecutive scans produce stable output.
+func ScanTerminals(ctx context.Context, logger *slog.Logger, runPath string) ([]api.TerminalDoc, error) {
+	out, err := scanMetadataFiles(
+		ctx,
+		logger,
+		runPath,
+		defaults.TerminalsRunPath,
+		"ScanTerminals",
+		terminalID,
+		terminalName,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		idi, idj := terminalID(out[i]), terminalID(out[j])
+		if idi != idj {
+			return idi < idj
+		}
+		return terminalName(out[i]) < terminalName(out[j])
+	})
+
+	return out, nil
+}
+
+// FindTerminalByID scans runPath/terminals/*/metadata.json and returns
+// the terminal whose Spec.ID matches the given id. Returns an error if
+// no terminal with that ID is found.
+func FindTerminalByID(
+	ctx context.Context,
+	logger *slog.Logger,
+	runPath string,
+	id string,
+) (*api.TerminalDoc, error) {
+	terminals, err := ScanTerminals(ctx, logger, runPath)
+	if err != nil {
+		return nil, err
+	}
+	return findMetadataBy(
+		terminals,
+		func(t api.TerminalDoc) bool { return string(t.Spec.ID) == id },
+		fmt.Sprintf("terminal %q not found", id),
+	)
+}
+
+// FindTerminalByName scans runPath/terminals/*/metadata.json and returns
+// the terminal whose Spec.Name matches the given name. Returns an error
+// if no terminal with that name is found.
+func FindTerminalByName(
+	ctx context.Context,
+	logger *slog.Logger,
+	runPath string,
+	name string,
+) (*api.TerminalDoc, error) {
+	terminals, err := ScanTerminals(ctx, logger, runPath)
+	if err != nil {
+		return nil, err
+	}
+	return findMetadataBy(
+		terminals,
+		func(t api.TerminalDoc) bool { return terminalName(t) == name },
+		fmt.Sprintf("terminal with name %q not found", name),
+	)
+}
+
+func terminalID(s api.TerminalDoc) string {
+	return string(s.Spec.ID)
+}
+
+func terminalName(s api.TerminalDoc) string {
+	return s.Spec.Name
+}

--- a/pkg/discovery/terminals.go
+++ b/pkg/discovery/terminals.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"sort"
+	"slices"
 
 	"github.com/eminwux/sbsh/internal/defaults"
 	"github.com/eminwux/sbsh/pkg/api"
@@ -36,19 +36,18 @@ func ScanTerminals(ctx context.Context, logger *slog.Logger, runPath string) ([]
 		runPath,
 		defaults.TerminalsRunPath,
 		"ScanTerminals",
-		terminalID,
-		terminalName,
+		TerminalID,
+		TerminalName,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	sort.Slice(out, func(i, j int) bool {
-		idi, idj := terminalID(out[i]), terminalID(out[j])
-		if idi != idj {
-			return idi < idj
+	slices.SortStableFunc(out, func(a, b api.TerminalDoc) int {
+		if c := cmpString(TerminalID(a), TerminalID(b)); c != 0 {
+			return c
 		}
-		return terminalName(out[i]) < terminalName(out[j])
+		return cmpString(TerminalName(a), TerminalName(b))
 	})
 
 	return out, nil
@@ -69,7 +68,7 @@ func FindTerminalByID(
 	}
 	return findMetadataBy(
 		terminals,
-		func(t api.TerminalDoc) bool { return string(t.Spec.ID) == id },
+		func(t api.TerminalDoc) bool { return TerminalID(t) == id },
 		fmt.Sprintf("terminal %q not found", id),
 	)
 }
@@ -89,15 +88,17 @@ func FindTerminalByName(
 	}
 	return findMetadataBy(
 		terminals,
-		func(t api.TerminalDoc) bool { return terminalName(t) == name },
+		func(t api.TerminalDoc) bool { return TerminalName(t) == name },
 		fmt.Sprintf("terminal with name %q not found", name),
 	)
 }
 
-func terminalID(s api.TerminalDoc) string {
+// TerminalID returns the canonical ID (Spec.ID) of a terminal document.
+func TerminalID(s api.TerminalDoc) string {
 	return string(s.Spec.ID)
 }
 
-func terminalName(s api.TerminalDoc) string {
+// TerminalName returns the canonical name (Spec.Name) of a terminal document.
+func TerminalName(s api.TerminalDoc) string {
 	return s.Spec.Name
 }

--- a/pkg/discovery/terminals_test.go
+++ b/pkg/discovery/terminals_test.go
@@ -1,0 +1,198 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package discovery_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/pkg/api"
+	"github.com/eminwux/sbsh/pkg/discovery"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func writeTerminalDoc(t *testing.T, runPath, id, name string) {
+	t.Helper()
+	dir := filepath.Join(runPath, defaults.TerminalsRunPath, id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	doc := api.TerminalDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindTerminal,
+		Metadata:   api.TerminalMetadata{Name: name},
+		Spec:       api.TerminalSpec{ID: api.ID(id), Name: name},
+	}
+	b, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), b, 0o644); err != nil {
+		t.Fatalf("write metadata.json: %v", err)
+	}
+}
+
+func writeInvalidTerminalJSON(t *testing.T, runPath, id string) {
+	t.Helper()
+	dir := filepath.Join(runPath, defaults.TerminalsRunPath, id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), []byte("{not valid json"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestScanTerminals_EmptyRunPath(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	runPath := t.TempDir()
+
+	got, err := discovery.ScanTerminals(ctx, logger, runPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 terminals, got %d", len(got))
+	}
+}
+
+func TestScanTerminals_MissingRunPath(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	runPath := filepath.Join(t.TempDir(), "does-not-exist")
+
+	got, err := discovery.ScanTerminals(ctx, logger, runPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 terminals, got %d", len(got))
+	}
+}
+
+func TestScanTerminals_InvalidJSON(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	runPath := t.TempDir()
+	writeInvalidTerminalJSON(t, runPath, "bad-id")
+
+	_, err := discovery.ScanTerminals(ctx, logger, runPath)
+	if err == nil {
+		t.Fatal("expected error on invalid JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "decode") {
+		t.Fatalf("expected decode error, got: %v", err)
+	}
+}
+
+func TestScanTerminals_SortedByIDThenName(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	runPath := t.TempDir()
+
+	// Deliberately insert out of order.
+	writeTerminalDoc(t, runPath, "id-b", "beta")
+	writeTerminalDoc(t, runPath, "id-a", "alpha")
+	writeTerminalDoc(t, runPath, "id-c", "charlie")
+
+	got, err := discovery.ScanTerminals(ctx, logger, runPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 terminals, got %d", len(got))
+	}
+	wantIDs := []string{"id-a", "id-b", "id-c"}
+	for i, w := range wantIDs {
+		if string(got[i].Spec.ID) != w {
+			t.Fatalf("sort mismatch at %d: want %q, got %q", i, w, got[i].Spec.ID)
+		}
+	}
+}
+
+func TestFindTerminalByID(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	runPath := t.TempDir()
+	writeTerminalDoc(t, runPath, "id-1", "one")
+	writeTerminalDoc(t, runPath, "id-2", "two")
+
+	got, err := discovery.FindTerminalByID(ctx, logger, runPath, "id-2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || string(got.Spec.ID) != "id-2" {
+		t.Fatalf("want id-2, got %+v", got)
+	}
+}
+
+func TestFindTerminalByID_NotFound(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	runPath := t.TempDir()
+	writeTerminalDoc(t, runPath, "id-1", "one")
+
+	_, err := discovery.FindTerminalByID(ctx, logger, runPath, "missing")
+	if err == nil {
+		t.Fatal("expected not-found error, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("expected error to mention %q, got: %v", "missing", err)
+	}
+}
+
+func TestFindTerminalByName(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	runPath := t.TempDir()
+	writeTerminalDoc(t, runPath, "id-1", "one")
+	writeTerminalDoc(t, runPath, "id-2", "two")
+
+	got, err := discovery.FindTerminalByName(ctx, logger, runPath, "two")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || got.Spec.Name != "two" {
+		t.Fatalf("want name=two, got %+v", got)
+	}
+}
+
+func TestFindTerminalByName_NotFound(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	runPath := t.TempDir()
+	writeTerminalDoc(t, runPath, "id-1", "one")
+
+	_, err := discovery.FindTerminalByName(ctx, logger, runPath, "ghost")
+	if err == nil {
+		t.Fatal("expected not-found error, got nil")
+	}
+	if !strings.Contains(err.Error(), "ghost") {
+		t.Fatalf("expected error to mention %q, got: %v", "ghost", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Promote `ScanTerminals`, `FindTerminalByID`, `FindTerminalByName`, `ScanClients`, `FindClientByName`, `LoadProfilesFromPath`, `LoadProfilesFromReaderWithContext`, and `FindProfileByName` into a new `pkg/discovery` package so external modules (e.g. `kukeon`) can enumerate terminals, clients, and profiles under a caller-supplied state root without importing `internal/`.
- Export canonical ID/Name accessors (`TerminalID`, `TerminalName`, `ClientID`, `ClientName`) from `pkg/discovery` and have `internal/discovery` call those instead of keeping duplicated helpers.
- Keep `internal/discovery` as a thin proxy for the scan/find/load names so in-tree callers (`cmd/sb/*`, `cmd/config/autocomplete.go`, `internal/client/controller.go`, `internal/profile/profile.go`, e2e tests) compile unchanged.
- Printer, prune, and reconcile helpers (`ScanAndPrintTerminals`, `ScanAndPruneClients`, `ReconcileTerminals`, `PrintHuman`, `NoTerminalsString`, etc.) stay internal — only the scan/find/load surface moves.
- Use `slices.SortStableFunc` (Go 1.21+) in `ScanTerminals`/`ScanClients` so the doc-comment guarantee of stable output holds when `(Spec.ID, Name)` tuples collide.
- Add unit tests in `pkg/discovery` covering empty/missing/invalid-JSON scans, `FindByID`/`ByName` found and not-found paths, sort order, and multi-doc/empty-doc/not-found behavior for profiles.

Refs #118 (PR-C). Does not close the umbrella — PR-G will.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test -count=1 ./pkg/... ./cmd/sb/... ./internal/discovery/...\`
- [x] \`go test -count=1 -tags=integration ./cmd/sb/get/...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)