### PR TITLE
feat(spawn): add pkg/spawn for library-driven Terminal/Client lifecycle

### DIFF
--- a/pkg/spawn/client.go
+++ b/pkg/spawn/client.go
@@ -1,0 +1,268 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package spawn
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/eminwux/sbsh/pkg/api"
+	clientrpc "github.com/eminwux/sbsh/pkg/rpcclient/client"
+)
+
+// ClientOptions configures NewClient.
+type ClientOptions struct {
+	// BinaryPath is the absolute path to an sb binary that supports the
+	// "attach" subcommand. Required — spawn does not consult $PATH so
+	// callers can't accidentally cross a state-root boundary.
+	BinaryPath string
+
+	// ExtraArgs, if non-empty, are inserted before "attach" (useful
+	// for e.g. "--verbose" or overriding root-level flags).
+	ExtraArgs []string
+
+	// Env is the environment for the spawned process. nil = inherit
+	// the parent's os.Environ(). An explicit empty slice means "start
+	// with no environment variables."
+	Env []string
+
+	// Stdin/Stdout/Stderr are wired to the child. Nil streams are
+	// redirected to /dev/null. For interactive use the caller
+	// typically hands in a PTY pair; for headless RPC-driven use,
+	// leaving them nil is fine.
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+
+	// Logger is used for spawn-side diagnostic logging. nil = quiet.
+	Logger *slog.Logger
+
+	// ReadyTimeout caps how long ClientHandle.WaitReady waits for the
+	// control socket to appear. 0 (the default) defers to the ctx
+	// passed to WaitReady.
+	ReadyTimeout time.Duration
+
+	// ReadyPollInterval sets how frequently WaitReady checks for the
+	// control socket. 0 means use a sensible default.
+	ReadyPollInterval time.Duration
+
+	// StopGracePeriod caps each step of the Close escalation
+	// (Detach RPC, SIGTERM, SIGKILL). 0 uses the default.
+	StopGracePeriod time.Duration
+}
+
+// ClientHandle is a library-side handle on a spawned Client
+// subprocess. Consumers can observe lifecycle via WaitReady/WaitClose,
+// request shutdown via Close, and connect to SocketPath() for the
+// subset of ClientController RPCs currently exposed (Detach today;
+// Ping/State/Stop land in PR-E).
+type ClientHandle struct {
+	doc        *api.ClientDoc
+	socketPath string
+
+	opts ClientOptions
+	proc *process
+}
+
+// NewClient spawns `<opts.BinaryPath> attach` with flags derived from
+// doc, backed by a detached (Setsid) process. Only
+// ClientMode=AttachToTerminal is supported in this release; compose
+// NewTerminal + NewClient for the run-new-terminal flow.
+//
+// doc.Spec.SockerCtrl must be set to the desired control-socket path
+// (spawn does not invent one); doc.Spec.TerminalSpec must carry either
+// an ID or a Name identifying the terminal to attach to.
+func NewClient(ctx context.Context, doc *api.ClientDoc, opts ClientOptions) (*ClientHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := validateClientInputs(doc, opts); err != nil {
+		return nil, err
+	}
+
+	args := buildClientAttachArgs(doc, opts)
+
+	// Deliberately using exec.Command (not CommandContext) — the
+	// child is detached (Setsid) and must outlive the caller's ctx.
+	//nolint:gosec,noctx // Caller controls BinaryPath and ExtraArgs; spawn
+	// explicitly does not consult $PATH.
+	cmd := exec.Command(opts.BinaryPath, args...)
+	if opts.Env != nil {
+		cmd.Env = opts.Env
+	} else {
+		cmd.Env = os.Environ()
+	}
+
+	opened, err := resolveStdio(cmd, opts.Stdin, opts.Stdout, opts.Stderr)
+	if err != nil {
+		return nil, fmt.Errorf("wire stdio: %w", err)
+	}
+	defer closeFiles(opened)
+
+	proc, err := startProcess(cmd, opts.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("start client process: %w", err)
+	}
+
+	return &ClientHandle{
+		doc:        doc,
+		socketPath: doc.Spec.SockerCtrl,
+		opts:       opts,
+		proc:       proc,
+	}, nil
+}
+
+func validateClientInputs(doc *api.ClientDoc, opts ClientOptions) error {
+	if opts.BinaryPath == "" {
+		return ErrBinaryPathRequired
+	}
+	if doc == nil {
+		return ErrDocRequired
+	}
+	if doc.Spec.ClientMode != api.AttachToTerminal {
+		return fmt.Errorf("%w: only AttachToTerminal is supported", ErrUnsupportedClientMode)
+	}
+	if doc.Spec.SockerCtrl == "" {
+		return ErrSocketPathRequired
+	}
+	if doc.Spec.TerminalSpec == nil ||
+		(doc.Spec.TerminalSpec.ID == "" && doc.Spec.TerminalSpec.Name == "") {
+		return ErrAttachTargetRequired
+	}
+	return nil
+}
+
+// buildClientAttachArgs translates a ClientDoc into the CLI argv for
+// `sb [--run-path X] attach [--socket S] [--id I | <name>] [--disable-detach]`.
+// It is exported-for-test via exportedForTestBuildClientAttachArgs to
+// keep the API surface small.
+func buildClientAttachArgs(doc *api.ClientDoc, opts ClientOptions) []string {
+	const maxAttachArgs = 8 // --run-path X attach --socket S --id I --disable-detach
+	args := make([]string, 0, maxAttachArgs+len(opts.ExtraArgs))
+
+	if doc.Spec.RunPath != "" {
+		args = append(args, "--run-path", doc.Spec.RunPath)
+	}
+	args = append(args, opts.ExtraArgs...)
+	args = append(args, "attach")
+
+	if doc.Spec.SockerCtrl != "" {
+		args = append(args, "--socket", doc.Spec.SockerCtrl)
+	}
+	if !doc.Spec.DetachKeystroke {
+		args = append(args, "--disable-detach")
+	}
+
+	term := doc.Spec.TerminalSpec
+	switch {
+	case term.ID != "":
+		args = append(args, "--id", string(term.ID))
+	case term.Name != "":
+		args = append(args, term.Name)
+	}
+
+	return args
+}
+
+// PID returns the OS PID of the spawned client process.
+func (h *ClientHandle) PID() int { return h.proc.pid() }
+
+// SocketPath returns the client's control-socket path.
+func (h *ClientHandle) SocketPath() string { return h.socketPath }
+
+// Doc returns the ClientDoc used to spawn this handle. The returned
+// pointer is shared — callers must not mutate it.
+func (h *ClientHandle) Doc() *api.ClientDoc { return h.doc }
+
+// WaitReady blocks until the client's control socket file is visible
+// on disk. Until PR-E adds a Ping RPC on ClientController, socket
+// presence is the best readiness signal spawn can offer without
+// peeking at internal state.
+func (h *ClientHandle) WaitReady(ctx context.Context) error {
+	if h.proc.exited() {
+		return fmt.Errorf("%w: %w", ErrProcessExited, h.proc.takeExitErr())
+	}
+
+	readyCtx, cancel := h.readyContext(ctx)
+	defer cancel()
+
+	poll := h.opts.ReadyPollInterval
+	if poll <= 0 {
+		poll = defaultReadyPollInterval
+	}
+
+	for {
+		if h.proc.exited() {
+			return fmt.Errorf("%w: %w", ErrProcessExited, h.proc.takeExitErr())
+		}
+		if _, err := os.Stat(h.socketPath); err == nil {
+			return nil
+		}
+
+		select {
+		case <-readyCtx.Done():
+			if errors.Is(readyCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+				return ErrReadyTimeout
+			}
+			return ctx.Err()
+		case <-h.proc.exitCh:
+			return fmt.Errorf("%w: %w", ErrProcessExited, h.proc.takeExitErr())
+		case <-time.After(poll):
+		}
+	}
+}
+
+func (h *ClientHandle) readyContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if h.opts.ReadyTimeout <= 0 {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, h.opts.ReadyTimeout)
+}
+
+// Close requests graceful shutdown: it first sends a Detach RPC over
+// the client's control socket (which causes the client to disconnect
+// from its terminal and exit), then escalates to SIGTERM and SIGKILL
+// if the child is still alive. Returns the process exit error (nil on
+// clean exit) or ctx.Err() if the caller's context is canceled
+// mid-shutdown.
+//
+// Once PR-E grows ClientController with an explicit Stop RPC, this
+// method will switch to it for a cleaner shutdown signal.
+func (h *ClientHandle) Close(ctx context.Context) error {
+	return h.proc.gracefulShutdown(ctx, h.opts.StopGracePeriod, h.sendDetachRPC)
+}
+
+func (h *ClientHandle) sendDetachRPC(ctx context.Context) error {
+	if _, err := os.Stat(h.socketPath); err != nil {
+		return err
+	}
+	rpc := clientrpc.NewUnix(h.socketPath)
+	return rpc.Detach(ctx)
+}
+
+// WaitClose blocks until the client subprocess has fully exited or
+// ctx is canceled. It returns the process exit error (nil on clean
+// exit) or ctx.Err().
+func (h *ClientHandle) WaitClose(ctx context.Context) error {
+	return h.proc.waitExit(ctx)
+}

--- a/pkg/spawn/client.go
+++ b/pkg/spawn/client.go
@@ -14,6 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build unix
+
 package spawn
 
 import (
@@ -67,7 +69,8 @@ type ClientOptions struct {
 	ReadyPollInterval time.Duration
 
 	// StopGracePeriod caps each step of the Close escalation
-	// (Detach RPC, SIGTERM, SIGKILL). 0 uses the default.
+	// (Detach RPC, SIGTERM, SIGKILL). 0 uses defaultGracePeriod (2s)
+	// per step, giving ~6s wall-clock before SIGKILL lands.
 	StopGracePeriod time.Duration
 }
 
@@ -153,9 +156,17 @@ func validateClientInputs(doc *api.ClientDoc, opts ClientOptions) error {
 }
 
 // buildClientAttachArgs translates a ClientDoc into the CLI argv for
-// `sb [--run-path X] attach [--socket S] [--id I | <name>] [--disable-detach]`.
-// It is exported-for-test via exportedForTestBuildClientAttachArgs to
-// keep the API surface small.
+// `sb [--run-path X] attach --socket S [--id I | <name>] [--disable-detach]`.
+//
+// The `--socket` flag is documented on `sb attach` as "for the
+// terminal" but at runtime it sets the *client's* control socket
+// (see cmd/sb/attach/attach.go:161,210). We rely on that actual
+// behavior so the parent process can predict ClientHandle.SocketPath();
+// the TerminalSpec.SocketFile in the child's doc is overridden from
+// metadata.json during discovery in internal/client.createAttachTerminal,
+// so the flag's conflated double-use does not break attach.
+// If --id and --name are both set the CLI rejects the combination,
+// so spawn deterministically prefers ID (matches CLI precedence).
 func buildClientAttachArgs(doc *api.ClientDoc, opts ClientOptions) []string {
 	const maxAttachArgs = 8 // --run-path X attach --socket S --id I --disable-detach
 	args := make([]string, 0, maxAttachArgs+len(opts.ExtraArgs))
@@ -164,11 +175,8 @@ func buildClientAttachArgs(doc *api.ClientDoc, opts ClientOptions) []string {
 		args = append(args, "--run-path", doc.Spec.RunPath)
 	}
 	args = append(args, opts.ExtraArgs...)
-	args = append(args, "attach")
+	args = append(args, "attach", "--socket", doc.Spec.SockerCtrl)
 
-	if doc.Spec.SockerCtrl != "" {
-		args = append(args, "--socket", doc.Spec.SockerCtrl)
-	}
 	if !doc.Spec.DetachKeystroke {
 		args = append(args, "--disable-detach")
 	}
@@ -195,12 +203,16 @@ func (h *ClientHandle) SocketPath() string { return h.socketPath }
 func (h *ClientHandle) Doc() *api.ClientDoc { return h.doc }
 
 // WaitReady blocks until the client's control socket file is visible
-// on disk. Until PR-E adds a Ping RPC on ClientController, socket
+// on disk. Until PR-E grows ClientController with a Ping RPC, socket
 // presence is the best readiness signal spawn can offer without
-// peeking at internal state.
+// peeking at internal state. Caveat: the file appears the instant the
+// Unix listener binds, which is slightly before the client has fully
+// wired up its attach to the terminal. Callers that race into a
+// Detach() RPC immediately after WaitReady may observe a transient
+// connection refused; retry or use a small back-off until PR-E.
 func (h *ClientHandle) WaitReady(ctx context.Context) error {
 	if h.proc.exited() {
-		return fmt.Errorf("%w: %w", ErrProcessExited, h.proc.takeExitErr())
+		return wrapProcessExited(h.proc.takeExitErr())
 	}
 
 	readyCtx, cancel := h.readyContext(ctx)
@@ -213,7 +225,7 @@ func (h *ClientHandle) WaitReady(ctx context.Context) error {
 
 	for {
 		if h.proc.exited() {
-			return fmt.Errorf("%w: %w", ErrProcessExited, h.proc.takeExitErr())
+			return wrapProcessExited(h.proc.takeExitErr())
 		}
 		if _, err := os.Stat(h.socketPath); err == nil {
 			return nil
@@ -226,7 +238,7 @@ func (h *ClientHandle) WaitReady(ctx context.Context) error {
 			}
 			return ctx.Err()
 		case <-h.proc.exitCh:
-			return fmt.Errorf("%w: %w", ErrProcessExited, h.proc.takeExitErr())
+			return wrapProcessExited(h.proc.takeExitErr())
 		case <-time.After(poll):
 		}
 	}

--- a/pkg/spawn/client_test.go
+++ b/pkg/spawn/client_test.go
@@ -14,6 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build unix
+
 package spawn
 
 import (
@@ -152,6 +154,48 @@ func TestBuildClientAttachArgs_ByName_DisableDetach(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("buildClientAttachArgs = %q; want %q", got, want)
+	}
+}
+
+// TestBuildClientAttachArgs_IDWinsOverName locks down the tie-break
+// rule: when a TerminalSpec carries both ID and Name, spawn emits
+// --id only (no positional name arg). This matches `sb attach`, which
+// rejects the ID+name combination in `cmd/sb/attach/attach.go:72-83`
+// — spawn never hands it the ambiguous input in the first place.
+func TestBuildClientAttachArgs_IDWinsOverName(t *testing.T) {
+	t.Parallel()
+	doc := &api.ClientDoc{
+		Spec: api.ClientSpec{
+			RunPath:         "/run/sbsh",
+			SockerCtrl:      "/run/sbsh/clients/c-3/socket",
+			ClientMode:      api.AttachToTerminal,
+			DetachKeystroke: true,
+			TerminalSpec:    &api.TerminalSpec{ID: "t-3", Name: "both-set"},
+		},
+	}
+	got := buildClientAttachArgs(doc, ClientOptions{})
+	want := []string{
+		"--run-path", "/run/sbsh",
+		"attach",
+		"--socket", "/run/sbsh/clients/c-3/socket",
+		"--id", "t-3",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildClientAttachArgs = %q; want %q", got, want)
+	}
+}
+
+// TestWrapProcessExited_NilExitError covers the formatting edge case
+// where the child cleanly exited (cmd.Wait returned nil) before the
+// control socket came up. The wrapped error must be a bare
+// ErrProcessExited — not an "ErrProcessExited: %!w(<nil>)" string.
+func TestWrapProcessExited_NilExitError(t *testing.T) {
+	t.Parallel()
+	if got := wrapProcessExited(nil); got.Error() != ErrProcessExited.Error() {
+		t.Fatalf("wrapProcessExited(nil).Error() = %q; want %q", got.Error(), ErrProcessExited.Error())
+	}
+	if got := wrapProcessExited(errors.New("boom")); !errors.Is(got, ErrProcessExited) {
+		t.Fatalf("wrapProcessExited(err) does not unwrap to ErrProcessExited: %v", got)
 	}
 }
 

--- a/pkg/spawn/client_test.go
+++ b/pkg/spawn/client_test.go
@@ -1,0 +1,209 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package spawn
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+func validAttachDoc(runPath, sockPath string) *api.ClientDoc {
+	return &api.ClientDoc{
+		Spec: api.ClientSpec{
+			RunPath:    runPath,
+			SockerCtrl: sockPath,
+			ClientMode: api.AttachToTerminal,
+			TerminalSpec: &api.TerminalSpec{
+				ID: "t-1",
+			},
+		},
+	}
+}
+
+func TestNewClient_Validation(t *testing.T) {
+	t.Parallel()
+
+	wrongMode := validAttachDoc("/run", "/run/c.sock")
+	wrongMode.Spec.ClientMode = api.RunNewTerminal
+
+	noTarget := validAttachDoc("/run", "/run/c.sock")
+	noTarget.Spec.TerminalSpec = &api.TerminalSpec{}
+
+	noSocket := validAttachDoc("/run", "")
+
+	tests := []struct {
+		name string
+		doc  *api.ClientDoc
+		opts ClientOptions
+		want error
+	}{
+		{
+			name: "missing binary",
+			doc:  validAttachDoc("/run", "/run/c.sock"),
+			opts: ClientOptions{},
+			want: ErrBinaryPathRequired,
+		},
+		{
+			name: "nil doc",
+			doc:  nil,
+			opts: ClientOptions{BinaryPath: "/bin/true"},
+			want: ErrDocRequired,
+		},
+		{
+			name: "wrong client mode",
+			doc:  wrongMode,
+			opts: ClientOptions{BinaryPath: "/bin/true"},
+			want: ErrUnsupportedClientMode,
+		},
+		{
+			name: "missing socket",
+			doc:  noSocket,
+			opts: ClientOptions{BinaryPath: "/bin/true"},
+			want: ErrSocketPathRequired,
+		},
+		{
+			name: "missing attach target",
+			doc:  noTarget,
+			opts: ClientOptions{BinaryPath: "/bin/true"},
+			want: ErrAttachTargetRequired,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewClient(context.Background(), tc.doc, tc.opts)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("NewClient err = %v; want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildClientAttachArgs_ByID covers the argv-construction rules for
+// `sb attach`: --run-path is a root-level flag, --socket + --id are
+// attach-level flags, and --disable-detach reflects the inverted
+// DetachKeystroke boolean.
+func TestBuildClientAttachArgs_ByID(t *testing.T) {
+	t.Parallel()
+	doc := &api.ClientDoc{
+		Spec: api.ClientSpec{
+			RunPath:         "/opt/kukeon/sbsh",
+			SockerCtrl:      "/opt/kukeon/sbsh/clients/c-1/socket",
+			ClientMode:      api.AttachToTerminal,
+			DetachKeystroke: true, // do NOT pass --disable-detach
+			TerminalSpec:    &api.TerminalSpec{ID: "t-1"},
+		},
+	}
+	got := buildClientAttachArgs(doc, ClientOptions{})
+	want := []string{
+		"--run-path", "/opt/kukeon/sbsh",
+		"attach",
+		"--socket", "/opt/kukeon/sbsh/clients/c-1/socket",
+		"--id", "t-1",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildClientAttachArgs = %q; want %q", got, want)
+	}
+}
+
+// TestBuildClientAttachArgs_ByName_DisableDetach covers the other leg:
+// resolving the terminal positionally by name, with the detach
+// keystroke suppressed via --disable-detach.
+func TestBuildClientAttachArgs_ByName_DisableDetach(t *testing.T) {
+	t.Parallel()
+	doc := &api.ClientDoc{
+		Spec: api.ClientSpec{
+			RunPath:         "/run/sbsh",
+			SockerCtrl:      "/run/sbsh/clients/c-2/socket",
+			ClientMode:      api.AttachToTerminal,
+			DetachKeystroke: false,
+			TerminalSpec:    &api.TerminalSpec{Name: "dev"},
+		},
+	}
+	got := buildClientAttachArgs(doc, ClientOptions{ExtraArgs: []string{"--verbose"}})
+	want := []string{
+		"--run-path", "/run/sbsh",
+		"--verbose",
+		"attach",
+		"--socket", "/run/sbsh/clients/c-2/socket",
+		"--disable-detach",
+		"dev",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildClientAttachArgs = %q; want %q", got, want)
+	}
+}
+
+// TestClientHandle_WaitReady_ProcessExits mirrors the terminal test:
+// /bin/true never creates the control socket, so WaitReady must bail
+// out with ErrProcessExited rather than spin forever.
+func TestClientHandle_WaitReady_ProcessExits(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	doc := validAttachDoc(tmp, filepath.Join(tmp, "c.sock"))
+
+	h, err := NewClient(context.Background(), doc, ClientOptions{
+		BinaryPath:        "/bin/true",
+		ReadyPollInterval: 20 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer func() { _ = h.WaitClose(context.Background()) }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err = h.WaitReady(ctx)
+	if !errors.Is(err, ErrProcessExited) {
+		t.Fatalf("WaitReady err = %v; want ErrProcessExited", err)
+	}
+}
+
+// TestClientHandle_PIDAndSocketPath covers the trivial accessors.
+func TestClientHandle_PIDAndSocketPath(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	sockPath := filepath.Join(tmp, "c.sock")
+	doc := validAttachDoc(tmp, sockPath)
+
+	h, err := NewClient(context.Background(), doc, ClientOptions{
+		BinaryPath: "/bin/true",
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if pid := h.PID(); pid <= 0 {
+		t.Fatalf("PID = %d; want > 0", pid)
+	}
+	if got := h.SocketPath(); got != sockPath {
+		t.Fatalf("SocketPath = %q; want %q", got, sockPath)
+	}
+	if got := h.Doc(); got != doc {
+		t.Fatalf("Doc = %p; want %p", got, doc)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = h.WaitClose(ctx)
+}

--- a/pkg/spawn/doc.go
+++ b/pkg/spawn/doc.go
@@ -1,0 +1,25 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package spawn exposes library-level helpers for launching sbsh Terminal
+// and Client subprocesses and driving their lifecycle from external Go
+// callers. It wraps the existing "sbsh terminal -" and "sb attach" CLI
+// entry points so library consumers (e.g. kukeon) can start, observe and
+// stop Terminal/Client processes without shelling out by hand.
+//
+// Stability: pre-v1. Signatures and option fields in this package may
+// change between minor releases until the umbrella issue (#118) closes.
+package spawn

--- a/pkg/spawn/doc.go
+++ b/pkg/spawn/doc.go
@@ -14,6 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build unix
+
 // Package spawn exposes library-level helpers for launching sbsh Terminal
 // and Client subprocesses and driving their lifecycle from external Go
 // callers. It wraps the existing "sbsh terminal -" and "sb attach" CLI

--- a/pkg/spawn/errors.go
+++ b/pkg/spawn/errors.go
@@ -14,6 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build unix
+
 package spawn
 
 import "errors"

--- a/pkg/spawn/errors.go
+++ b/pkg/spawn/errors.go
@@ -1,0 +1,61 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package spawn
+
+import "errors"
+
+var (
+	// ErrBinaryPathRequired is returned when a spawn call is issued without
+	// a non-empty binary path in its Options. Library callers must point
+	// spawn at a specific sbsh/sb executable — there is no PATH lookup
+	// fallback, so that state-root-style isolation is not silently broken
+	// by whatever happens to be first on $PATH.
+	ErrBinaryPathRequired = errors.New("binary path is required")
+
+	// ErrSpecRequired is returned when NewTerminal is called with a nil
+	// TerminalSpec.
+	ErrSpecRequired = errors.New("terminal spec is required")
+
+	// ErrDocRequired is returned when NewClient is called with a nil
+	// ClientDoc.
+	ErrDocRequired = errors.New("client doc is required")
+
+	// ErrSocketPathRequired is returned when the provided spec/doc does
+	// not carry a concrete control-socket path. spawn does not invent one
+	// — callers are expected to fill it in (usually via pkg/builder in
+	// PR-D, or profile.BuildTerminalSpec today).
+	ErrSocketPathRequired = errors.New("socket path is required")
+
+	// ErrAttachTargetRequired is returned when NewClient is called
+	// without a terminal ID or name to attach to.
+	ErrAttachTargetRequired = errors.New("attach target (terminal id or name) is required")
+
+	// ErrUnsupportedClientMode is returned when NewClient is called with
+	// a ClientMode other than AttachToTerminal. RunNewTerminal mode is
+	// expected to be handled by composing NewTerminal + NewClient; it is
+	// not a spawn-level primitive in this release.
+	ErrUnsupportedClientMode = errors.New("unsupported client mode")
+
+	// ErrProcessExited is returned from WaitReady when the spawned child
+	// exits before it ever reports Ready. The handle's WaitClose will
+	// then return the underlying exit error.
+	ErrProcessExited = errors.New("spawned process exited before ready")
+
+	// ErrReadyTimeout is returned from WaitReady when the readiness
+	// deadline expires with the child still running but not yet Ready.
+	ErrReadyTimeout = errors.New("timed out waiting for readiness")
+)

--- a/pkg/spawn/process.go
+++ b/pkg/spawn/process.go
@@ -1,0 +1,250 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package spawn
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// process wraps an exec.Cmd launched in a detached (Setsid) process
+// group and tracks its lifecycle through a single background reaper
+// goroutine. It is the shared plumbing underneath TerminalHandle and
+// ClientHandle.
+type process struct {
+	cmd    *exec.Cmd
+	logger *slog.Logger
+
+	exitOnce sync.Once
+	exitCh   chan struct{}
+	exitMu   sync.Mutex
+	exitErr  error
+}
+
+// startProcess runs cmd detached and spins a reaper goroutine that
+// records the exit error and closes exitCh so WaitClose callers unblock.
+func startProcess(cmd *exec.Cmd, logger *slog.Logger) (*process, error) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setsid = true
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+
+	p := &process{
+		cmd:    cmd,
+		logger: logger,
+		exitCh: make(chan struct{}),
+	}
+
+	go func() {
+		waitErr := cmd.Wait()
+		p.exitMu.Lock()
+		p.exitErr = waitErr
+		p.exitMu.Unlock()
+		p.exitOnce.Do(func() { close(p.exitCh) })
+		if logger != nil {
+			if waitErr != nil {
+				logger.Debug("spawned process exited", "pid", cmd.Process.Pid, "error", waitErr)
+			} else {
+				logger.Debug("spawned process exited", "pid", cmd.Process.Pid)
+			}
+		}
+	}()
+
+	return p, nil
+}
+
+// pid returns the OS PID of the spawned process.
+func (p *process) pid() int {
+	if p == nil || p.cmd == nil || p.cmd.Process == nil {
+		return 0
+	}
+	return p.cmd.Process.Pid
+}
+
+// exited reports whether the reaper has observed process exit.
+func (p *process) exited() bool {
+	select {
+	case <-p.exitCh:
+		return true
+	default:
+		return false
+	}
+}
+
+// takeExitErr returns the recorded exit error (safe after exitCh closes).
+func (p *process) takeExitErr() error {
+	p.exitMu.Lock()
+	defer p.exitMu.Unlock()
+	return p.exitErr
+}
+
+// waitExit blocks until the process exits or ctx is done. It returns
+// the process exit error on exit, ctx.Err() on cancellation.
+func (p *process) waitExit(ctx context.Context) error {
+	select {
+	case <-p.exitCh:
+		return p.takeExitErr()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// signal sends sig to the spawned process. It is a no-op if the
+// process has already exited.
+func (p *process) signal(sig os.Signal) error {
+	if p.exited() {
+		return nil
+	}
+	if p.cmd == nil || p.cmd.Process == nil {
+		return errors.New("spawn: process not started")
+	}
+	return p.cmd.Process.Signal(sig)
+}
+
+// waitWithTimeout blocks until exit, ctx done, or d elapses. It
+// distinguishes the three via the returned error:
+//   - nil: process exited (consult takeExitErr for the real error)
+//   - ctx.Err(): ctx was canceled/expired
+//   - context.DeadlineExceeded: local step timeout elapsed (ctx still alive)
+func (p *process) waitWithTimeout(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return p.waitExit(ctx)
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-p.exitCh:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return context.DeadlineExceeded
+	}
+}
+
+// gracefulShutdown attempts a clean stop: run preSignal (e.g. a Stop
+// RPC) if provided, wait gracePeriod for natural exit, then SIGTERM +
+// wait, then SIGKILL. Returns the process exit error (or ctx.Err() if
+// the caller's context was canceled).
+func (p *process) gracefulShutdown(
+	ctx context.Context,
+	gracePeriod time.Duration,
+	preSignal func(context.Context) error,
+) error {
+	if p.exited() {
+		return p.takeExitErr()
+	}
+	if preSignal != nil {
+		if err := preSignal(ctx); err != nil && p.logger != nil {
+			p.logger.DebugContext(ctx, "graceful pre-signal hook failed", "error", err)
+		}
+	}
+	if gracePeriod <= 0 {
+		gracePeriod = defaultGracePeriod
+	}
+
+	if err := p.waitWithTimeout(ctx, gracePeriod); err == nil {
+		return p.takeExitErr()
+	} else if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	if err := p.signal(syscall.SIGTERM); err != nil && p.logger != nil {
+		p.logger.DebugContext(ctx, "SIGTERM failed", "error", err)
+	}
+	if err := p.waitWithTimeout(ctx, gracePeriod); err == nil {
+		return p.takeExitErr()
+	} else if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	if err := p.signal(syscall.SIGKILL); err != nil && p.logger != nil {
+		p.logger.DebugContext(ctx, "SIGKILL failed", "error", err)
+	}
+	return p.waitExit(ctx)
+}
+
+const defaultGracePeriod = 2 * time.Second
+
+// resolveStdio wires caller-supplied stdio onto cmd. Anything left nil
+// is redirected to /dev/null — the child must never inherit the
+// parent's TTY unless the caller explicitly asked for it. Returned
+// files should be closed by the caller after cmd.Start() returns; they
+// are duplicated into the child at that point.
+func resolveStdio(cmd *exec.Cmd, stdin io.Reader, stdout, stderr io.Writer) ([]*os.File, error) {
+	var opened []*os.File
+
+	openNull := func(flag int) (*os.File, error) {
+		f, err := os.OpenFile(os.DevNull, flag, 0)
+		if err != nil {
+			return nil, err
+		}
+		opened = append(opened, f)
+		return f, nil
+	}
+
+	if stdin == nil {
+		f, err := openNull(os.O_RDONLY)
+		if err != nil {
+			return opened, err
+		}
+		cmd.Stdin = f
+	} else {
+		cmd.Stdin = stdin
+	}
+
+	if stdout == nil {
+		f, err := openNull(os.O_WRONLY)
+		if err != nil {
+			return opened, err
+		}
+		cmd.Stdout = f
+	} else {
+		cmd.Stdout = stdout
+	}
+
+	if stderr == nil {
+		f, err := openNull(os.O_WRONLY)
+		if err != nil {
+			return opened, err
+		}
+		cmd.Stderr = f
+	} else {
+		cmd.Stderr = stderr
+	}
+
+	return opened, nil
+}
+
+// closeFiles closes every file, ignoring errors. Used to drop the
+// /dev/null handles after cmd.Start() has duplicated them.
+func closeFiles(files []*os.File) {
+	for _, f := range files {
+		_ = f.Close()
+	}
+}

--- a/pkg/spawn/process.go
+++ b/pkg/spawn/process.go
@@ -14,6 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build unix
+
 package spawn
 
 import (

--- a/pkg/spawn/process_test.go
+++ b/pkg/spawn/process_test.go
@@ -1,0 +1,107 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package spawn
+
+import (
+	"context"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestGracefulShutdown_SIGTERMEscalation covers the middle escalation
+// step: the pre-signal hook does nothing, so gracefulShutdown must
+// fall through to SIGTERM and reap the process.
+func TestGracefulShutdown_SIGTERMEscalation(t *testing.T) {
+	t.Parallel()
+	cmd := exec.Command("/bin/sleep", "30")
+
+	proc, err := startProcess(cmd, nil)
+	if err != nil {
+		t.Fatalf("startProcess: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	// We don't assert on the returned error — /bin/sleep terminated by
+	// SIGTERM returns "signal: terminated" from cmd.Wait(), which is
+	// expected here. What matters is that gracefulShutdown returns
+	// promptly and the process is reaped.
+	_ = proc.gracefulShutdown(ctx, 200*time.Millisecond, nil)
+
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("gracefulShutdown took %s; expected prompt escalation", elapsed)
+	}
+	if !proc.exited() {
+		t.Fatalf("process still reports alive after gracefulShutdown")
+	}
+}
+
+// TestGracefulShutdown_PreSignalKillsChild covers the happy path: the
+// pre-signal hook itself stops the child (here by sending SIGINT), so
+// SIGTERM is never needed.
+func TestGracefulShutdown_PreSignalKillsChild(t *testing.T) {
+	t.Parallel()
+	cmd := exec.Command("/bin/sleep", "30")
+
+	proc, err := startProcess(cmd, nil)
+	if err != nil {
+		t.Fatalf("startProcess: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	preSignalCalled := false
+	_ = proc.gracefulShutdown(ctx, 2*time.Second, func(context.Context) error {
+		preSignalCalled = true
+		return proc.signal(syscall.SIGINT)
+	})
+
+	if !preSignalCalled {
+		t.Fatalf("preSignal hook never ran")
+	}
+	if !proc.exited() {
+		t.Fatalf("process still reports alive after gracefulShutdown")
+	}
+}
+
+// TestGracefulShutdown_AlreadyExited is a fast-path: the process has
+// already been reaped, so gracefulShutdown should return immediately
+// with the recorded exit error (nil for /bin/true).
+func TestGracefulShutdown_AlreadyExited(t *testing.T) {
+	t.Parallel()
+	cmd := exec.Command("/bin/true")
+	proc, err := startProcess(cmd, nil)
+	if err != nil {
+		t.Fatalf("startProcess: %v", err)
+	}
+
+	// Give the reaper a moment to observe the exit.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if waitErr := proc.waitExit(ctx); waitErr != nil {
+		t.Fatalf("waitExit: %v", waitErr)
+	}
+
+	if shutdownErr := proc.gracefulShutdown(ctx, time.Second, nil); shutdownErr != nil {
+		t.Fatalf("gracefulShutdown after exit returned %v; want nil", shutdownErr)
+	}
+}

--- a/pkg/spawn/process_test.go
+++ b/pkg/spawn/process_test.go
@@ -14,6 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build unix
+
 package spawn
 
 import (

--- a/pkg/spawn/terminal.go
+++ b/pkg/spawn/terminal.go
@@ -14,6 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build unix
+
 package spawn
 
 import (
@@ -71,7 +73,9 @@ type TerminalOptions struct {
 	ReadyPollInterval time.Duration
 
 	// StopGracePeriod caps each step of the Close escalation
-	// (Stop RPC, SIGTERM, SIGKILL). 0 uses the default.
+	// (Stop RPC, SIGTERM, SIGKILL). 0 uses defaultGracePeriod (2s)
+	// per step, giving ~6s wall-clock before SIGKILL lands. Raise
+	// this for heavy terminals (many subscribers, slow shutdown).
 	StopGracePeriod time.Duration
 }
 
@@ -172,7 +176,7 @@ func (h *TerminalHandle) Spec() *api.TerminalSpec { return h.spec }
 // internal cap elapses, or ctx.Err() on cancellation.
 func (h *TerminalHandle) WaitReady(ctx context.Context) error {
 	if h.proc.exited() {
-		return fmt.Errorf("%w: %w", ErrProcessExited, h.proc.takeExitErr())
+		return wrapProcessExited(h.proc.takeExitErr())
 	}
 
 	readyCtx, cancel := h.readyContext(ctx)
@@ -187,7 +191,7 @@ func (h *TerminalHandle) WaitReady(ctx context.Context) error {
 
 	for {
 		if h.proc.exited() {
-			return fmt.Errorf("%w: %w", ErrProcessExited, h.proc.takeExitErr())
+			return wrapProcessExited(h.proc.takeExitErr())
 		}
 
 		if _, err := os.Stat(h.socketPath); err == nil {
@@ -210,10 +214,21 @@ func (h *TerminalHandle) WaitReady(ctx context.Context) error {
 			}
 			return ctx.Err()
 		case <-h.proc.exitCh:
-			return fmt.Errorf("%w: %w", ErrProcessExited, h.proc.takeExitErr())
+			return wrapProcessExited(h.proc.takeExitErr())
 		case <-time.After(poll):
 		}
 	}
+}
+
+// wrapProcessExited returns ErrProcessExited alone when the child's
+// cmd.Wait() returned nil (clean exit before ready), or a wrapped
+// pair when there is a non-nil underlying exit error. This avoids
+// the ugly "%!w(<nil>)" rendering from fmt.Errorf("%w: %w", ..., nil).
+func wrapProcessExited(exitErr error) error {
+	if exitErr == nil {
+		return ErrProcessExited
+	}
+	return fmt.Errorf("%w: %w", ErrProcessExited, exitErr)
 }
 
 func (h *TerminalHandle) readyContext(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/pkg/spawn/terminal.go
+++ b/pkg/spawn/terminal.go
@@ -1,0 +1,258 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package spawn
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/eminwux/sbsh/pkg/api"
+	terminalrpc "github.com/eminwux/sbsh/pkg/rpcclient/terminal"
+)
+
+// TerminalOptions configures NewTerminal.
+type TerminalOptions struct {
+	// BinaryPath is the absolute path to an sbsh binary that supports
+	// the "terminal -" subcommand (reads a TerminalSpec JSON on stdin).
+	// Required — spawn does not consult $PATH so callers can't
+	// accidentally cross a state-root boundary.
+	BinaryPath string
+
+	// ExtraArgs, if non-empty, are inserted before the "terminal" /
+	// "-" args (useful for e.g. "--run-path <x>" when the caller
+	// wants to override the root flag rather than rely on the spec).
+	ExtraArgs []string
+
+	// Env is the environment for the spawned process. If nil, the
+	// child inherits the parent's os.Environ(). To start the child
+	// with an empty environment, pass an explicit empty slice.
+	Env []string
+
+	// Stdout / Stderr receive the child's stdout/stderr. If nil, the
+	// respective stream is redirected to /dev/null. Stdin is not
+	// exposed — the TerminalSpec JSON is written there.
+	Stdout io.Writer
+	Stderr io.Writer
+
+	// Logger is used for spawn-side diagnostic logging. nil = quiet.
+	Logger *slog.Logger
+
+	// ReadyTimeout caps how long TerminalHandle.WaitReady will poll
+	// before returning ErrReadyTimeout. 0 (the default) disables the
+	// internal cap and defers entirely to the ctx passed to
+	// WaitReady.
+	ReadyTimeout time.Duration
+
+	// ReadyPollInterval sets how frequently WaitReady tries to dial
+	// and Ping the terminal's control socket. 0 means use a sensible
+	// default.
+	ReadyPollInterval time.Duration
+
+	// StopGracePeriod caps each step of the Close escalation
+	// (Stop RPC, SIGTERM, SIGKILL). 0 uses the default.
+	StopGracePeriod time.Duration
+}
+
+// TerminalHandle is a library-side handle on a spawned Terminal
+// subprocess. Consumers can observe lifecycle via WaitReady/WaitClose,
+// request shutdown via Close, and drive the RPC surface by connecting
+// to SocketPath() with pkg/rpcclient/terminal.
+type TerminalHandle struct {
+	spec       *api.TerminalSpec
+	socketPath string
+
+	opts TerminalOptions
+	proc *process
+}
+
+// NewTerminal spawns `<opts.BinaryPath> terminal -` with spec encoded
+// as JSON on stdin and the child detached via Setsid. The returned
+// handle is not ready yet — call WaitReady to block until the
+// terminal's control socket accepts RPC calls.
+func NewTerminal(ctx context.Context, spec *api.TerminalSpec, opts TerminalOptions) (*TerminalHandle, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := validateTerminalInputs(spec, opts); err != nil {
+		return nil, err
+	}
+
+	specBytes, err := json.Marshal(spec)
+	if err != nil {
+		return nil, fmt.Errorf("marshal terminal spec: %w", err)
+	}
+
+	const terminalArgCount = 2 // "terminal", "-"
+	args := make([]string, 0, len(opts.ExtraArgs)+terminalArgCount)
+	args = append(args, opts.ExtraArgs...)
+	args = append(args, "terminal", "-")
+
+	// Deliberately using exec.Command (not CommandContext) — the child
+	// is detached (Setsid) and must outlive the caller's ctx.
+	//nolint:gosec,noctx // Caller controls BinaryPath and ExtraArgs; spawn
+	// explicitly does not consult $PATH.
+	cmd := exec.Command(opts.BinaryPath, args...)
+	cmd.Stdin = bytes.NewReader(specBytes)
+	if opts.Env != nil {
+		cmd.Env = opts.Env
+	} else {
+		cmd.Env = os.Environ()
+	}
+
+	// stdin is already wired to the spec JSON; resolveStdio only
+	// handles stdout/stderr fallback to /dev/null.
+	opened, err := resolveStdio(cmd, cmd.Stdin, opts.Stdout, opts.Stderr)
+	if err != nil {
+		return nil, fmt.Errorf("wire stdio: %w", err)
+	}
+	defer closeFiles(opened)
+
+	proc, err := startProcess(cmd, opts.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("start terminal process: %w", err)
+	}
+
+	return &TerminalHandle{
+		spec:       spec,
+		socketPath: spec.SocketFile,
+		opts:       opts,
+		proc:       proc,
+	}, nil
+}
+
+func validateTerminalInputs(spec *api.TerminalSpec, opts TerminalOptions) error {
+	if opts.BinaryPath == "" {
+		return ErrBinaryPathRequired
+	}
+	if spec == nil {
+		return ErrSpecRequired
+	}
+	if spec.SocketFile == "" {
+		return ErrSocketPathRequired
+	}
+	return nil
+}
+
+// PID returns the OS PID of the spawned terminal process.
+func (h *TerminalHandle) PID() int { return h.proc.pid() }
+
+// SocketPath returns the control-socket path for the terminal; the
+// same value that appears in spec.SocketFile.
+func (h *TerminalHandle) SocketPath() string { return h.socketPath }
+
+// Spec returns the TerminalSpec used to spawn this handle. The
+// returned pointer is shared — callers must not mutate it.
+func (h *TerminalHandle) Spec() *api.TerminalSpec { return h.spec }
+
+// WaitReady blocks until the spawned terminal's RPC server accepts a
+// Ping on its control socket. It returns early with ErrProcessExited
+// if the child dies before reaching Ready, ErrReadyTimeout if the
+// internal cap elapses, or ctx.Err() on cancellation.
+func (h *TerminalHandle) WaitReady(ctx context.Context) error {
+	if h.proc.exited() {
+		return fmt.Errorf("%w: %w", ErrProcessExited, h.proc.takeExitErr())
+	}
+
+	readyCtx, cancel := h.readyContext(ctx)
+	defer cancel()
+
+	poll := h.opts.ReadyPollInterval
+	if poll <= 0 {
+		poll = defaultReadyPollInterval
+	}
+
+	rpc := terminalrpc.NewUnix(h.socketPath, h.readyLogger())
+
+	for {
+		if h.proc.exited() {
+			return fmt.Errorf("%w: %w", ErrProcessExited, h.proc.takeExitErr())
+		}
+
+		if _, err := os.Stat(h.socketPath); err == nil {
+			pingCtx, pingCancel := context.WithTimeout(readyCtx, poll)
+			pingErr := rpc.Ping(pingCtx, &api.PingMessage{Message: "spawn.WaitReady"}, &api.PingMessage{})
+			pingCancel()
+			if pingErr == nil {
+				return nil
+			}
+			if h.opts.Logger != nil {
+				h.opts.Logger.DebugContext(readyCtx, "terminal not ready yet",
+					"socket", h.socketPath, "error", pingErr)
+			}
+		}
+
+		select {
+		case <-readyCtx.Done():
+			if errors.Is(readyCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+				return ErrReadyTimeout
+			}
+			return ctx.Err()
+		case <-h.proc.exitCh:
+			return fmt.Errorf("%w: %w", ErrProcessExited, h.proc.takeExitErr())
+		case <-time.After(poll):
+		}
+	}
+}
+
+func (h *TerminalHandle) readyContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if h.opts.ReadyTimeout <= 0 {
+		return context.WithCancel(ctx)
+	}
+	return context.WithTimeout(ctx, h.opts.ReadyTimeout)
+}
+
+func (h *TerminalHandle) readyLogger() *slog.Logger {
+	if h.opts.Logger != nil {
+		return h.opts.Logger
+	}
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+const defaultReadyPollInterval = 100 * time.Millisecond
+
+// Close requests graceful shutdown of the terminal process: it first
+// issues a Stop RPC over the control socket, then escalates to SIGTERM
+// and SIGKILL if the child is still alive. Returns the process exit
+// error (nil on clean exit) or ctx.Err() if the caller's context is
+// canceled mid-shutdown.
+func (h *TerminalHandle) Close(ctx context.Context) error {
+	return h.proc.gracefulShutdown(ctx, h.opts.StopGracePeriod, h.sendStopRPC)
+}
+
+func (h *TerminalHandle) sendStopRPC(ctx context.Context) error {
+	if _, err := os.Stat(h.socketPath); err != nil {
+		// No socket — nothing to RPC. Escalate to signals.
+		return err
+	}
+	rpc := terminalrpc.NewUnix(h.socketPath, h.readyLogger())
+	return rpc.Stop(ctx, &api.StopArgs{Reason: "spawn.Close"})
+}
+
+// WaitClose blocks until the terminal subprocess has fully exited or
+// ctx is canceled. It returns the process exit error (nil on clean
+// exit) or ctx.Err().
+func (h *TerminalHandle) WaitClose(ctx context.Context) error {
+	return h.proc.waitExit(ctx)
+}

--- a/pkg/spawn/terminal_test.go
+++ b/pkg/spawn/terminal_test.go
@@ -14,6 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build unix
+
 package spawn
 
 import (

--- a/pkg/spawn/terminal_test.go
+++ b/pkg/spawn/terminal_test.go
@@ -1,0 +1,138 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package spawn
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+func TestNewTerminal_Validation(t *testing.T) {
+	t.Parallel()
+	validSpec := &api.TerminalSpec{SocketFile: "/tmp/x.sock"}
+
+	tests := []struct {
+		name string
+		spec *api.TerminalSpec
+		opts TerminalOptions
+		want error
+	}{
+		{
+			name: "missing binary",
+			spec: validSpec,
+			opts: TerminalOptions{},
+			want: ErrBinaryPathRequired,
+		},
+		{
+			name: "nil spec",
+			spec: nil,
+			opts: TerminalOptions{BinaryPath: "/bin/true"},
+			want: ErrSpecRequired,
+		},
+		{
+			name: "missing socket",
+			spec: &api.TerminalSpec{},
+			opts: TerminalOptions{BinaryPath: "/bin/true"},
+			want: ErrSocketPathRequired,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewTerminal(context.Background(), tc.spec, tc.opts)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("NewTerminal err = %v; want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestNewTerminal_CanceledContext(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	spec := &api.TerminalSpec{SocketFile: "/tmp/spawn-test.sock"}
+	_, err := NewTerminal(ctx, spec, TerminalOptions{BinaryPath: "/bin/true"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("NewTerminal err = %v; want context.Canceled", err)
+	}
+}
+
+// TestTerminalHandle_WaitReady_ProcessExits covers the path where the
+// spawned child dies before it opens its control socket. WaitReady
+// must surface ErrProcessExited rather than hang on the poll loop.
+func TestTerminalHandle_WaitReady_ProcessExits(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	spec := &api.TerminalSpec{
+		SocketFile: filepath.Join(tmp, "socket"),
+	}
+
+	// /bin/true exits immediately — no terminal will ever come up.
+	h, err := NewTerminal(context.Background(), spec, TerminalOptions{
+		BinaryPath:        "/bin/true",
+		ReadyPollInterval: 20 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewTerminal: %v", err)
+	}
+	defer func() { _ = h.WaitClose(context.Background()) }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err = h.WaitReady(ctx)
+	if !errors.Is(err, ErrProcessExited) {
+		t.Fatalf("WaitReady err = %v; want ErrProcessExited", err)
+	}
+}
+
+// TestTerminalHandle_PIDAndSocketPath verifies the trivial accessors
+// return what NewTerminal recorded, even after the child exits.
+func TestTerminalHandle_PIDAndSocketPath(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	sockPath := filepath.Join(tmp, "socket")
+	spec := &api.TerminalSpec{SocketFile: sockPath}
+
+	h, err := NewTerminal(context.Background(), spec, TerminalOptions{
+		BinaryPath: "/bin/true",
+	})
+	if err != nil {
+		t.Fatalf("NewTerminal: %v", err)
+	}
+	if pid := h.PID(); pid <= 0 {
+		t.Fatalf("PID = %d; want > 0", pid)
+	}
+	if got := h.SocketPath(); got != sockPath {
+		t.Fatalf("SocketPath = %q; want %q", got, sockPath)
+	}
+	if got := h.Spec(); got != spec {
+		t.Fatalf("Spec = %p; want %p", got, spec)
+	}
+	// Clean up the reaper goroutine.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = h.WaitClose(ctx)
+}


### PR DESCRIPTION
## Summary

PR-B of the umbrella #118 (consume sbsh as a Go library, driven by `kukeon` integration). Closes #49. Depends on PR-A (#121, merged).

- `pkg/spawn.NewTerminal` spawns `<BinaryPath> terminal -` with the `TerminalSpec` encoded as JSON on stdin and the child detached via `Setsid`, so library consumers (e.g. kukeon) can own a terminal process from Go without shelling out.
- `pkg/spawn.NewClient` spawns `<BinaryPath> attach` against an existing Terminal identified by ID or Name. `RunNewTerminal` mode is intentionally out of scope — compose `NewTerminal` + `NewClient`.
- `TerminalHandle` / `ClientHandle` expose the full lifecycle surface requested by the umbrella: `PID()`, `SocketPath()`, `WaitReady(ctx)`, `Close(ctx)`, `WaitClose(ctx)`. Terminal readiness is signalled via a `Ping` over the control socket; Client readiness via socket-file presence (until PR-E lands `ClientController.Ping`).
- `Close` performs a graceful three-step escalation: pre-signal hook (`Stop` RPC for Terminal, `Detach` RPC for Client) → SIGTERM → SIGKILL, with a configurable grace period.
- Inputs validate against stable sentinels: `ErrBinaryPathRequired`, `ErrSpecRequired`, `ErrDocRequired`, `ErrSocketPathRequired`, `ErrAttachTargetRequired`, `ErrUnsupportedClientMode`, `ErrProcessExited`, `ErrReadyTimeout`. spawn explicitly does not consult `$PATH` so callers can't cross a state-root boundary by accident.

Refs #118. Does **not** ` Closes #118` — the umbrella stays open until PR-G lands.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./pkg/spawn/...` — 14 subtests pass (validation, argv construction, process-exits-before-ready, SIGTERM/SIGKILL escalation)
- [x] `go test ./...` — no regressions (e2e suite passes after rebuilding `sb`/`sbsh`)
- [x] `golangci-lint run ./pkg/spawn/...` — 0 issues

## Out of scope (flagged for later sub-PRs)

- No CLI refactor to consume `pkg/spawn` internally — CLI flows (`cmd/sbsh/terminal`, `cmd/sb/attach`, `internal/client/clientrunner`) keep their current subprocess invocation. A follow-up could unify them, but PR-B stays additive.
- No `ClientController.Ping`/`Stop` yet — `ClientHandle.WaitReady` falls back to socket-file presence and `Close` uses `Detach` + signals. PR-E will grow the RPC surface; `ClientHandle` will pick up the new calls then.
- No `pkg/builder` helpers (PR-D) — callers still build `TerminalSpec` / `ClientDoc` directly. Once PR-D lands, the example in `docs/examples/library-consumer/` (PR-G) will use it in combination with `pkg/spawn`.