### PR TITLE
fix: expand env vars in terminal cwd

### DIFF
--- a/internal/terminal/terminalrunner/terminal.go
+++ b/internal/terminal/terminalrunner/terminal.go
@@ -104,9 +104,12 @@ func (sr *Exec) prepareTerminalCommand() error {
 	return nil
 }
 
-// expandCwd resolves a leading "~" or "~/" against the user's home directory.
-// Other shell expansions (env vars, globs) are not performed.
+// expandCwd resolves environment variables (e.g. "$HOME", "${HOME}") and a
+// leading "~" or "~/" against the user's home directory. Glob patterns are
+// not expanded. Env var lookup uses the parent process environment, so vars
+// defined only in the profile's shell.env are not visible here.
 func expandCwd(p string) (string, error) {
+	p = os.ExpandEnv(p)
 	if p == "~" || strings.HasPrefix(p, "~/") {
 		home, err := os.UserHomeDir()
 		if err != nil {

--- a/internal/terminal/terminalrunner/terminal_test.go
+++ b/internal/terminal/terminalrunner/terminal_test.go
@@ -1,0 +1,60 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrunner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExpandCwd(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir: %v", err)
+	}
+
+	t.Setenv("SBSH_TEST_DIR", "/var/tmp/sbsh-test")
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"absolute", "/tmp/foo", "/tmp/foo"},
+		{"relative", "foo/bar", "foo/bar"},
+		{"tilde", "~", home},
+		{"tilde-slash", "~/projects", filepath.Join(home, "projects")},
+		{"env-bare", "$HOME/projects", filepath.Join(home, "projects")},
+		{"env-braced", "${HOME}/projects", filepath.Join(home, "projects")},
+		{"env-custom", "$SBSH_TEST_DIR/sub", "/var/tmp/sbsh-test/sub"},
+		{"env-unset", "$UNSET_VAR_XYZ_12345/sub", "/sub"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := expandCwd(tc.in)
+			if err != nil {
+				t.Fatalf("expandCwd(%q) returned error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("expandCwd(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `TerminalSpec.Cwd` (from `shell.cwd` in a profile) previously only expanded a leading `~`/`~/`, so a path like `$HOME/projects` was passed verbatim to `exec.Cmd.Dir`, the directory lookup failed, and the terminal never started in the configured working directory.
- Apply `os.ExpandEnv` before the tilde check so common forms (`$HOME/foo`, `${HOME}/foo`, custom inherited env vars) resolve against the parent process environment.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/terminal/terminalrunner/...`
- [x] `go test ./...`
- [x] `make sbsh-sb` and `file ./sbsh` is ELF executable
- [x] Manual repro: profile with `cwd: "$HOME/cwd-target-dir"` now starts the shell in the expanded directory

Closes #81