### PR TITLE
feat: add sb validate profiles command

### DIFF
--- a/cmd/sb/sb.go
+++ b/cmd/sb/sb.go
@@ -33,6 +33,7 @@ import (
 	"github.com/eminwux/sbsh/cmd/sb/prune"
 	"github.com/eminwux/sbsh/cmd/sb/read"
 	"github.com/eminwux/sbsh/cmd/sb/stop"
+	"github.com/eminwux/sbsh/cmd/sb/validate"
 	"github.com/eminwux/sbsh/cmd/sb/version"
 	"github.com/eminwux/sbsh/cmd/sb/write"
 	"github.com/eminwux/sbsh/cmd/types"
@@ -121,6 +122,7 @@ func setupRootCmd(rootCmd *cobra.Command) error {
 	rootCmd.AddCommand(autocomplete.NewAutoCompleteCmd(rootCmd))
 	rootCmd.AddCommand(prune.NewPruneCmd())
 	rootCmd.AddCommand(stop.NewStopCmd())
+	rootCmd.AddCommand(validate.NewValidateCmd())
 	rootCmd.AddCommand(detach.NewDetachCmd())
 	rootCmd.AddCommand(attach.NewAttachCmd())
 	rootCmd.AddCommand(get.NewGetCmd())

--- a/cmd/sb/validate/profiles.go
+++ b/cmd/sb/validate/profiles.go
@@ -17,7 +17,6 @@
 package validate
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -68,7 +67,7 @@ func runValidateProfiles(cmd *cobra.Command, args []string, stdout, stderr io.Wr
 		return err
 	}
 
-	return reportResults(cmd.Context(), stdout, stderr, path, results, err)
+	return reportResults(stdout, stderr, path, results, err)
 }
 
 func resolveProfilesPath(args []string) string {
@@ -79,7 +78,6 @@ func resolveProfilesPath(args []string) string {
 }
 
 func reportResults(
-	_ context.Context,
 	stdout, stderr io.Writer,
 	path string,
 	results []profile.ProfileValidationResult,

--- a/cmd/sb/validate/profiles.go
+++ b/cmd/sb/validate/profiles.go
@@ -1,0 +1,123 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+
+	"github.com/eminwux/sbsh/cmd/config"
+	"github.com/eminwux/sbsh/cmd/types"
+	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/internal/profile"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func NewValidateProfilesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "profiles [path]",
+		Aliases: []string{"profile", "prof", "pro", "p"},
+		Short:   "Validate profile YAML",
+		Long: `Validate one or more TerminalProfile YAML documents.
+
+Each document is strictly decoded (unknown fields are rejected), required
+fields are checked, runTarget and restartPolicy are validated against the
+accepted enum values, and shell.cmd is checked against $PATH when
+runTarget is "local".
+
+The path argument is optional; when omitted, the profiles file from
+configuration (SB_PROFILES_FILE or --config) is validated.`,
+		Args:         cobra.MaximumNArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runValidateProfiles(cmd, args, os.Stdout, os.Stderr)
+		},
+	}
+	return cmd
+}
+
+func runValidateProfiles(cmd *cobra.Command, args []string, stdout, stderr io.Writer) error {
+	logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)
+	if !ok || logger == nil {
+		return errdefs.ErrLoggerNotFound
+	}
+
+	path := resolveProfilesPath(args)
+	logger.Debug("validate profiles invoked", "path", path)
+
+	results, err := profile.ValidateProfilesFromPath(cmd.Context(), logger, path)
+	if err != nil && len(results) == 0 {
+		return err
+	}
+
+	return reportResults(cmd.Context(), stdout, stderr, path, results, err)
+}
+
+func resolveProfilesPath(args []string) string {
+	if len(args) == 1 && args[0] != "" {
+		return args[0]
+	}
+	return viper.GetString(config.SB_GET_PROFILES_FILE.ViperKey)
+}
+
+func reportResults(
+	_ context.Context,
+	stdout, stderr io.Writer,
+	path string,
+	results []profile.ProfileValidationResult,
+	decodeErr error,
+) error {
+	fmt.Fprintf(stdout, "Validating %s\n", path)
+
+	invalid := 0
+	for _, r := range results {
+		label := formatLabel(r)
+		if r.OK() {
+			fmt.Fprintf(stdout, "  [OK]     %s\n", label)
+			continue
+		}
+		invalid++
+		fmt.Fprintf(stdout, "  [INVALID] %s\n", label)
+		for _, e := range r.Errors {
+			fmt.Fprintf(stdout, "    - %s\n", e)
+		}
+	}
+
+	total := len(results)
+	valid := total - invalid
+	fmt.Fprintf(stdout, "%d profile(s): %d valid, %d invalid\n", total, valid, invalid)
+
+	if decodeErr != nil {
+		fmt.Fprintf(stderr, "warning: stopped at unrecoverable parse error: %v\n", decodeErr)
+	}
+
+	if invalid > 0 || decodeErr != nil {
+		return errdefs.ErrInvalidProfiles
+	}
+	return nil
+}
+
+func formatLabel(r profile.ProfileValidationResult) string {
+	if r.ProfileName == "" {
+		return fmt.Sprintf("document %d", r.DocIndex)
+	}
+	return fmt.Sprintf("document %d (%s)", r.DocIndex, r.ProfileName)
+}

--- a/cmd/sb/validate/profiles_test.go
+++ b/cmd/sb/validate/profiles_test.go
@@ -1,0 +1,109 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/sbsh/cmd/types"
+	"github.com/eminwux/sbsh/internal/errdefs"
+)
+
+func writeTempProfile(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profiles.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write temp profile: %v", err)
+	}
+	return path
+}
+
+func runCmd(t *testing.T, args []string) (string, string, error) {
+	t.Helper()
+	cmd := NewValidateProfilesCmd()
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	cmd.SetContext(ctx)
+
+	var stdout, stderr bytes.Buffer
+	err := runValidateProfiles(cmd, args, &stdout, &stderr)
+	return stdout.String(), stderr.String(), err
+}
+
+func TestValidateProfilesCmd_NoLogger(t *testing.T) {
+	cmd := NewValidateProfilesCmd()
+	cmd.SetContext(context.Background())
+	err := runValidateProfiles(cmd, nil, io.Discard, io.Discard)
+	if !errors.Is(err, errdefs.ErrLoggerNotFound) {
+		t.Fatalf("expected ErrLoggerNotFound, got %v", err)
+	}
+}
+
+func TestValidateProfilesCmd_ValidFile(t *testing.T) {
+	path := writeTempProfile(t, `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: bash
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/sh
+`)
+	stdout, _, err := runCmd(t, []string{path})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout, "1 profile(s): 1 valid, 0 invalid") {
+		t.Fatalf("unexpected summary: %s", stdout)
+	}
+}
+
+func TestValidateProfilesCmd_InvalidReturnsError(t *testing.T) {
+	path := writeTempProfile(t, `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: bad
+spec:
+  runTarget: kubernetes
+  shell:
+    cmd: /bin/sh
+`)
+	stdout, _, err := runCmd(t, []string{path})
+	if !errors.Is(err, errdefs.ErrInvalidProfiles) {
+		t.Fatalf("expected ErrInvalidProfiles, got %v", err)
+	}
+	if !strings.Contains(stdout, "[INVALID]") {
+		t.Fatalf("stdout should show INVALID tag: %s", stdout)
+	}
+}
+
+func TestValidateProfilesCmd_MissingFile(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "nope.yaml")
+	_, _, err := runCmd(t, []string{missing})
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}

--- a/cmd/sb/validate/validate.go
+++ b/cmd/sb/validate/validate.go
@@ -1,0 +1,40 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import "github.com/spf13/cobra"
+
+func NewValidateCmd() *cobra.Command {
+	validateCmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Validate sbsh configuration",
+		Long: `Validate sbsh configuration.
+
+Run strict pre-flight checks on on-disk documents (profiles today) so that
+authoring mistakes surface here instead of at terminal launch.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+
+	setupValidateCmd(validateCmd)
+	return validateCmd
+}
+
+func setupValidateCmd(validateCmd *cobra.Command) {
+	validateCmd.AddCommand(NewValidateProfilesCmd())
+}

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -83,4 +83,5 @@ var (
 	ErrSignalProcess          = errors.New("failed to signal terminal process")
 	ErrTerminalStdinClosed    = errors.New("terminal stdin is closed")
 	ErrSubscriberLagged       = errors.New("subscriber fell behind and was disconnected")
+	ErrInvalidProfiles        = errors.New("one or more profiles failed validation")
 )

--- a/internal/profile/validate.go
+++ b/internal/profile/validate.go
@@ -100,6 +100,11 @@ func ValidateProfilesFromReader(
 // validateOneDocument runs the strict-decode pass (to surface unknown fields)
 // alongside a tolerant decode (to exercise enum + PATH checks even when strict
 // decoding fails). Both error sets are aggregated on the returned result.
+//
+// When the tolerant decode itself fails (e.g. a type mismatch), the strict
+// pass and field-level checks are skipped: the strict pass would just
+// re-report the same structural error, and field checks on a zero-valued
+// struct produce cascading "required" noise for one underlying issue.
 func validateOneDocument(ctx context.Context, logger *slog.Logger, docIndex int, node *yaml.Node) ProfileValidationResult {
 	res := ProfileValidationResult{DocIndex: docIndex}
 
@@ -107,6 +112,7 @@ func validateOneDocument(ctx context.Context, logger *slog.Logger, docIndex int,
 	if err := node.Decode(&tolerant); err != nil {
 		logger.DebugContext(ctx, "ValidateProfilesFromReader: tolerant decode failed", "doc", docIndex, "error", err)
 		res.Errors = append(res.Errors, err)
+		return res
 	}
 	res.ProfileName = tolerant.Metadata.Name
 

--- a/internal/profile/validate.go
+++ b/internal/profile/validate.go
@@ -1,0 +1,201 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package profile
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+
+	"github.com/eminwux/sbsh/pkg/api"
+	"gopkg.in/yaml.v3"
+)
+
+// ProfileValidationResult holds the outcome of validating a single YAML document.
+type ProfileValidationResult struct {
+	DocIndex    int     // 1-based index of the document within the file
+	ProfileName string  // metadata.name, empty if decoding failed
+	Errors      []error // all issues found for this document; nil when valid
+}
+
+// OK reports whether the profile document passed all checks.
+func (r ProfileValidationResult) OK() bool { return len(r.Errors) == 0 }
+
+// ValidateProfilesFromPath validates every profile document in the YAML file at
+// profilesFile. See ValidateProfilesFromReader for the semantics.
+func ValidateProfilesFromPath(
+	ctx context.Context,
+	logger *slog.Logger,
+	profilesFile string,
+) ([]ProfileValidationResult, error) {
+	logger.DebugContext(ctx, "ValidateProfilesFromPath: opening file", "path", profilesFile)
+	f, err := os.Open(profilesFile)
+	if err != nil {
+		return nil, fmt.Errorf("open profiles file %q: %w", profilesFile, err)
+	}
+	defer f.Close()
+	return ValidateProfilesFromReader(ctx, logger, f)
+}
+
+// ValidateProfilesFromReader decodes each YAML document in r strictly (unknown
+// fields are rejected) and runs per-document validation: required apiVersion /
+// kind / metadata.name / shell.cmd, enum checks on runTarget and restartPolicy,
+// and a PATH-resolution check on shell.cmd when runTarget is "local" (or unset).
+//
+// It returns one ProfileValidationResult per document. Decode errors on a doc
+// produce a result with empty ProfileName and the decode error attached; when
+// the underlying YAML stream becomes unparsable the function stops and returns
+// the partial results together with a non-nil error.
+func ValidateProfilesFromReader(
+	ctx context.Context,
+	logger *slog.Logger,
+	r io.Reader,
+) ([]ProfileValidationResult, error) {
+	dec := yaml.NewDecoder(r)
+
+	var results []ProfileValidationResult
+	docIndex := 0
+	for {
+		var node yaml.Node
+		if err := dec.Decode(&node); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			docIndex++
+			logger.ErrorContext(ctx, "ValidateProfilesFromReader: unrecoverable parse error", "doc", docIndex, "error", err)
+			results = append(results, ProfileValidationResult{
+				DocIndex: docIndex,
+				Errors:   []error{err},
+			})
+			return results, fmt.Errorf("parse profile document %d: %w", docIndex, err)
+		}
+		docIndex++
+
+		results = append(results, validateOneDocument(ctx, logger, docIndex, &node))
+	}
+
+	logger.InfoContext(ctx, "ValidateProfilesFromReader: finished", "count", len(results))
+	return results, nil
+}
+
+// validateOneDocument runs the strict-decode pass (to surface unknown fields)
+// alongside a tolerant decode (to exercise enum + PATH checks even when strict
+// decoding fails). Both error sets are aggregated on the returned result.
+func validateOneDocument(ctx context.Context, logger *slog.Logger, docIndex int, node *yaml.Node) ProfileValidationResult {
+	res := ProfileValidationResult{DocIndex: docIndex}
+
+	var tolerant api.TerminalProfileDoc
+	if err := node.Decode(&tolerant); err != nil {
+		logger.DebugContext(ctx, "ValidateProfilesFromReader: tolerant decode failed", "doc", docIndex, "error", err)
+		res.Errors = append(res.Errors, err)
+	}
+	res.ProfileName = tolerant.Metadata.Name
+
+	if strictErr := decodeStrict(node); strictErr != nil {
+		res.Errors = append(res.Errors, strictErr)
+	}
+
+	res.Errors = append(res.Errors, validateProfileDoc(&tolerant)...)
+	return res
+}
+
+func decodeStrict(node *yaml.Node) error {
+	buf, err := yaml.Marshal(node)
+	if err != nil {
+		return fmt.Errorf("re-marshal for strict decode: %w", err)
+	}
+	dec := yaml.NewDecoder(bytes.NewReader(buf))
+	dec.KnownFields(true)
+	var strict api.TerminalProfileDoc
+	if err := dec.Decode(&strict); err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	return nil
+}
+
+func validateProfileDoc(p *api.TerminalProfileDoc) []error {
+	var errs []error
+
+	if p.APIVersion == "" {
+		errs = append(errs, errors.New("apiVersion is required"))
+	} else if p.APIVersion != api.APIVersionV1Beta1 {
+		errs = append(errs, fmt.Errorf("apiVersion %q not supported (expected %q)", p.APIVersion, api.APIVersionV1Beta1))
+	}
+
+	if p.Kind == "" {
+		errs = append(errs, errors.New("kind is required"))
+	} else if p.Kind != api.KindTerminalProfile {
+		errs = append(errs, fmt.Errorf("kind %q not supported (expected %q)", p.Kind, api.KindTerminalProfile))
+	}
+
+	if p.Metadata.Name == "" {
+		errs = append(errs, errors.New("metadata.name is required"))
+	}
+
+	if p.Spec.Shell.Cmd == "" {
+		errs = append(errs, errors.New("spec.shell.cmd is required"))
+	}
+
+	if err := validateRunTarget(p.Spec.RunTarget); err != nil {
+		errs = append(errs, err)
+	}
+	if err := validateRestartPolicy(p.Spec.RestartPolicy); err != nil {
+		errs = append(errs, err)
+	}
+
+	// Only exercise the PATH check when runTarget targets the local host.
+	if p.Spec.Shell.Cmd != "" && isLocalRunTarget(p.Spec.RunTarget) {
+		if err := validateCmdInPath(p.Spec.Shell.Cmd); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errs
+}
+
+func isLocalRunTarget(rt api.RunTarget) bool {
+	return rt == api.RunTargetLocal || rt == ""
+}
+
+func validateRunTarget(rt api.RunTarget) error {
+	switch rt {
+	case api.RunTargetLocal, "":
+		return nil
+	}
+	return fmt.Errorf("spec.runTarget %q not one of [%q]", rt, api.RunTargetLocal)
+}
+
+func validateRestartPolicy(rp api.RestartPolicy) error {
+	switch rp {
+	case api.RestartExit, api.RestartUnlimited, api.RestartOnError, "":
+		return nil
+	}
+	return fmt.Errorf("spec.restartPolicy %q not one of [%q, %q, %q]",
+		rp, api.RestartExit, api.RestartUnlimited, api.RestartOnError)
+}
+
+func validateCmdInPath(cmd string) error {
+	if _, err := exec.LookPath(cmd); err != nil {
+		return fmt.Errorf("spec.shell.cmd %q: %w", cmd, err)
+	}
+	return nil
+}

--- a/internal/profile/validate_test.go
+++ b/internal/profile/validate_test.go
@@ -1,0 +1,209 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package profile
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func TestValidateProfilesFromReader_Valid(t *testing.T) {
+	const doc = `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: bash
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/sh
+`
+	results, err := ValidateProfilesFromReader(context.Background(), discardLogger(), strings.NewReader(doc))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(results))
+	}
+	if !results[0].OK() {
+		t.Fatalf("expected OK result, got errors: %v", results[0].Errors)
+	}
+	if results[0].ProfileName != "bash" {
+		t.Fatalf("want profile name 'bash', got %q", results[0].ProfileName)
+	}
+}
+
+func TestValidateProfilesFromReader_UnknownFieldRejected(t *testing.T) {
+	const doc = `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: bash
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/sh
+    unknownField: oops
+`
+	results, err := ValidateProfilesFromReader(context.Background(), discardLogger(), strings.NewReader(doc))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(results))
+	}
+	if results[0].OK() {
+		t.Fatalf("expected failure for unknown field, got OK")
+	}
+	joined := joinErrors(results[0].Errors)
+	if !strings.Contains(joined, "unknownField") {
+		t.Fatalf("expected error to mention unknownField, got: %s", joined)
+	}
+}
+
+func TestValidateProfilesFromReader_BadEnums(t *testing.T) {
+	const doc = `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: bogus-enums
+spec:
+  runTarget: kubernetes
+  restartPolicy: restart-sometimes
+  shell:
+    cmd: /bin/sh
+`
+	results, err := ValidateProfilesFromReader(context.Background(), discardLogger(), strings.NewReader(doc))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(results))
+	}
+	if results[0].OK() {
+		t.Fatalf("expected enum validation failure")
+	}
+	joined := joinErrors(results[0].Errors)
+	if !strings.Contains(joined, "runTarget") {
+		t.Fatalf("expected runTarget error, got: %s", joined)
+	}
+	if !strings.Contains(joined, "restartPolicy") {
+		t.Fatalf("expected restartPolicy error, got: %s", joined)
+	}
+}
+
+func TestValidateProfilesFromReader_CmdNotInPath(t *testing.T) {
+	const doc = `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: bad-cmd
+spec:
+  runTarget: local
+  shell:
+    cmd: definitely-not-a-real-binary-sbsh
+`
+	results, err := ValidateProfilesFromReader(context.Background(), discardLogger(), strings.NewReader(doc))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if results[0].OK() {
+		t.Fatalf("expected PATH lookup to fail")
+	}
+	joined := joinErrors(results[0].Errors)
+	if !strings.Contains(joined, "shell.cmd") {
+		t.Fatalf("expected shell.cmd error, got: %s", joined)
+	}
+}
+
+func TestValidateProfilesFromReader_MissingRequired(t *testing.T) {
+	const doc = `apiVersion: ""
+kind: ""
+metadata:
+  name: ""
+spec:
+  shell:
+    cmd: ""
+`
+	results, err := ValidateProfilesFromReader(context.Background(), discardLogger(), strings.NewReader(doc))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(results))
+	}
+	joined := joinErrors(results[0].Errors)
+	for _, want := range []string{"apiVersion", "kind", "metadata.name", "spec.shell.cmd"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("expected error mentioning %q, got: %s", want, joined)
+		}
+	}
+}
+
+func TestValidateProfilesFromReader_MultiDocMixed(t *testing.T) {
+	const doc = `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: good
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/sh
+---
+apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: bad
+spec:
+  runTarget: kubernetes
+  shell:
+    cmd: /bin/sh
+`
+	results, err := ValidateProfilesFromReader(context.Background(), discardLogger(), strings.NewReader(doc))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("want 2 results, got %d", len(results))
+	}
+	if !results[0].OK() {
+		t.Fatalf("first doc expected OK, got: %v", results[0].Errors)
+	}
+	if results[1].OK() {
+		t.Fatalf("second doc expected invalid")
+	}
+}
+
+func TestValidateProfilesFromPath_FileNotFound(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
+	_, err := ValidateProfilesFromPath(context.Background(), discardLogger(), missing)
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func joinErrors(errs []error) string {
+	parts := make([]string, 0, len(errs))
+	for _, e := range errs {
+		parts = append(parts, e.Error())
+	}
+	return strings.Join(parts, " | ")
+}

--- a/internal/profile/validate_test.go
+++ b/internal/profile/validate_test.go
@@ -192,6 +192,34 @@ spec:
 	}
 }
 
+func TestValidateProfilesFromReader_TypeMismatchNoCascade(t *testing.T) {
+	const doc = `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: typeoops
+spec:
+  runTarget: local
+  shell:
+    cmd: [not, a, string]
+`
+	results, err := ValidateProfilesFromReader(context.Background(), discardLogger(), strings.NewReader(doc))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("want 1 result, got %d", len(results))
+	}
+	if results[0].OK() {
+		t.Fatalf("expected failure for type mismatch")
+	}
+	if got := len(results[0].Errors); got != 1 {
+		t.Fatalf("want single error for type mismatch, got %d: %v", got, results[0].Errors)
+	}
+	if joined := joinErrors(results[0].Errors); !strings.Contains(joined, "cannot unmarshal") {
+		t.Fatalf("expected unmarshal error, got: %s", joined)
+	}
+}
+
 func TestValidateProfilesFromPath_FileNotFound(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "does-not-exist.yaml")
 	_, err := ValidateProfilesFromPath(context.Background(), discardLogger(), missing)


### PR DESCRIPTION
## Summary
- Adds `sb validate profiles [path]` so authoring mistakes surface pre-flight instead of inside the PTY at launch — prerequisite for agents managing profiles programmatically.
- Strict YAML decode rejects unknown fields; enum checks on `runTarget` / `restartPolicy`; `shell.cmd` is resolved against `$PATH` when `runTarget: local`.
- Each document is reported independently (OK / INVALID + per-error lines) with a summary and non-zero exit on any failure (`errdefs.ErrInvalidProfiles`).

## Test plan
- [ ] `make sbsh-sb`
- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `go test ./internal/profile/... ./cmd/sb/validate/...`
- [ ] `./sb validate profiles <mixed.yaml>` — exits 1, reports per-doc OK/INVALID with enum + unknown-field + PATH errors.

Closes #110