### PR TITLE
ci: add test workflow with build and test coverage

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,45 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Build & Test
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build binary
+        run: make sbsh-sb
+
+      - name: Verify binary
+        run: file ./sbsh | grep -q 'ELF 64-bit LSB executable'
+
+      - name: Compile all packages
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Unit tests
+        run: go test $(go list ./... | grep -v '/e2e$')
+
+      - name: Integration tests
+        run: go test -tags=integration ./cmd/sb/get/...

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,7 @@ jobs:
         run: go vet ./...
 
       - name: Unit tests
-        run: go test $(go list ./... | grep -v '/e2e$')
+        run: go test -timeout=5m $(go list ./... | grep -v '/e2e$')
 
       - name: Integration tests
         run: go test -tags=integration ./cmd/sb/get/...

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![status: active](https://img.shields.io/badge/status-active-blue)
 ![state: beta](https://img.shields.io/badge/state-beta-orange)
 ![license: apache2](https://img.shields.io/badge/license-Apache%202.0-green)
+[![Test](https://github.com/eminwux/sbsh/actions/workflows/test.yaml/badge.svg?branch=main)](https://github.com/eminwux/sbsh/actions/workflows/test.yaml)
 
 sbsh brings _Terminal-as-Code_ to your workflow: define terminal environments declaratively with YAML manifests that can be version-controlled, shared, and reused across your team. Each profile specifies environment variables, lifecycle hooks, startup commands, and visual prompts, ensuring consistent setups across local machines, jump hosts, and CI/CD pipelines. Terminals survive network drops, client restarts, and accidental disconnects, remaining discoverable and shareable for collaboration.
 


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that builds the canonical `sbsh`+`sb` binary, verifies it's a real ELF executable, and runs `go vet`, `go build ./...`, all unit tests (excluding `./e2e` which needs a real TTY), and the tagged integration tests under `./cmd/sb/get/...`. This gives PRs and `main` pushes a visible build-health signal.
- Add a **Test** badge to `README.md` linked to the new workflow so repo visitors can see build status at a glance.

## Test plan
- [ ] `make sbsh-sb` locally and confirm `file ./sbsh` reports `ELF 64-bit LSB executable`
- [ ] `go vet ./...` clean
- [ ] `go build ./...` clean
- [ ] `go test \$(go list ./... | grep -v '/e2e\$')` green
- [ ] `go test -tags=integration ./cmd/sb/get/...` green
- [ ] First CI run on the PR completes green and the README badge renders

Closes #54