### PR TITLE
feat: introduce ConfigurationDoc for config.yaml

### DIFF
--- a/cmd/config/configuration.go
+++ b/cmd/config/configuration.go
@@ -26,6 +26,30 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// ApplyConfigurationDocEnv copies ConfigurationDoc.Spec values to the env vars
+// consumed by sb and sbsh subcommands, but only when the user hasn't already
+// set them. This preserves the precedence flag > env > doc > default.
+func ApplyConfigurationDocEnv(cfgDoc *api.ConfigurationDoc) {
+	if cfgDoc == nil {
+		return
+	}
+	setIfUnset := func(envVar, value string) {
+		if value == "" {
+			return
+		}
+		if _, present := os.LookupEnv(envVar); present {
+			return
+		}
+		_ = os.Setenv(envVar, value)
+	}
+	setIfUnset(SB_ROOT_RUN_PATH.EnvVar(), cfgDoc.Spec.RunPath)
+	setIfUnset(SBSH_ROOT_RUN_PATH.EnvVar(), cfgDoc.Spec.RunPath)
+	setIfUnset(SB_GET_PROFILES_FILE.EnvVar(), cfgDoc.Spec.ProfilesFile)
+	setIfUnset(SBSH_ROOT_PROFILES_FILE.EnvVar(), cfgDoc.Spec.ProfilesFile)
+	setIfUnset(SB_ROOT_LOG_LEVEL.EnvVar(), cfgDoc.Spec.LogLevel)
+	setIfUnset(SBSH_ROOT_LOG_LEVEL.EnvVar(), cfgDoc.Spec.LogLevel)
+}
+
 // LoadConfigurationDoc reads a YAML file and returns the first Configuration
 // document it contains. Returns (nil, nil) when the file does not exist or
 // when the file exists but contains no Configuration document, so callers can

--- a/cmd/config/configuration.go
+++ b/cmd/config/configuration.go
@@ -1,0 +1,71 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/eminwux/sbsh/pkg/api"
+	"gopkg.in/yaml.v3"
+)
+
+// LoadConfigurationDoc reads a YAML file and returns the first Configuration
+// document it contains. Returns (nil, nil) when the file does not exist or
+// when the file exists but contains no Configuration document, so callers can
+// fall back to built-in defaults. Returns a non-nil error only when the file
+// is present but malformed or uses an unsupported apiVersion/kind.
+func LoadConfigurationDoc(path string) (*api.ConfigurationDoc, error) {
+	if path == "" {
+		return nil, nil
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("open config file %q: %w", path, err)
+	}
+	defer f.Close()
+
+	dec := yaml.NewDecoder(f)
+	for {
+		var doc api.ConfigurationDoc
+		if err := dec.Decode(&doc); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("decode config file %q: %w", path, err)
+		}
+
+		if doc.APIVersion == "" && doc.Kind == "" {
+			continue
+		}
+
+		if doc.Kind != api.KindConfiguration {
+			return nil, fmt.Errorf(
+				"config file %q: unsupported kind %q (expected %q)",
+				path, doc.Kind, api.KindConfiguration,
+			)
+		}
+
+		return &doc, nil
+	}
+}

--- a/cmd/config/configuration.go
+++ b/cmd/config/configuration.go
@@ -83,6 +83,13 @@ func LoadConfigurationDoc(path string) (*api.ConfigurationDoc, error) {
 			continue
 		}
 
+		if doc.APIVersion != api.APIVersionV1Beta1 {
+			return nil, fmt.Errorf(
+				"config file %q: unsupported apiVersion %q (expected %q)",
+				path, doc.APIVersion, api.APIVersionV1Beta1,
+			)
+		}
+
 		if doc.Kind != api.KindConfiguration {
 			return nil, fmt.Errorf(
 				"config file %q: unsupported kind %q (expected %q)",

--- a/cmd/config/configuration_test.go
+++ b/cmd/config/configuration_test.go
@@ -1,0 +1,135 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+func Test_LoadConfigurationDoc_Missing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does-not-exist.yaml")
+	doc, err := LoadConfigurationDoc(path)
+	if err != nil {
+		t.Fatalf("expected no error for missing file, got %v", err)
+	}
+	if doc != nil {
+		t.Fatalf("expected nil doc for missing file, got %+v", doc)
+	}
+}
+
+func Test_LoadConfigurationDoc_EmptyPath(t *testing.T) {
+	doc, err := LoadConfigurationDoc("")
+	if err != nil {
+		t.Fatalf("expected no error for empty path, got %v", err)
+	}
+	if doc != nil {
+		t.Fatalf("expected nil doc for empty path, got %+v", doc)
+	}
+}
+
+func Test_LoadConfigurationDoc_HappyPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := `apiVersion: sbsh/v1beta1
+kind: Configuration
+metadata:
+  name: default
+spec:
+  runPath: /var/run/sbsh
+  profilesFile: /etc/sbsh/profiles.yaml
+  logLevel: debug
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	doc, err := LoadConfigurationDoc(path)
+	if err != nil {
+		t.Fatalf("LoadConfigurationDoc() error = %v", err)
+	}
+	if doc == nil {
+		t.Fatal("expected doc, got nil")
+	}
+
+	if got, want := doc.APIVersion, api.APIVersionV1Beta1; got != want {
+		t.Errorf("APIVersion = %q, want %q", got, want)
+	}
+	if got, want := doc.Kind, api.KindConfiguration; got != want {
+		t.Errorf("Kind = %q, want %q", got, want)
+	}
+	if got, want := doc.Spec.RunPath, "/var/run/sbsh"; got != want {
+		t.Errorf("Spec.RunPath = %q, want %q", got, want)
+	}
+	if got, want := doc.Spec.ProfilesFile, "/etc/sbsh/profiles.yaml"; got != want {
+		t.Errorf("Spec.ProfilesFile = %q, want %q", got, want)
+	}
+	if got, want := doc.Spec.LogLevel, "debug"; got != want {
+		t.Errorf("Spec.LogLevel = %q, want %q", got, want)
+	}
+}
+
+func Test_LoadConfigurationDoc_UnsupportedKind(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: default
+spec:
+  runTarget: local
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if _, err := LoadConfigurationDoc(path); err == nil {
+		t.Fatal("expected error for unsupported kind, got nil")
+	}
+}
+
+func Test_LoadConfigurationDoc_EmptyFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(""), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	doc, err := LoadConfigurationDoc(path)
+	if err != nil {
+		t.Fatalf("LoadConfigurationDoc() error = %v", err)
+	}
+	if doc != nil {
+		t.Fatalf("expected nil doc for empty file, got %+v", doc)
+	}
+}
+
+func Test_LoadConfigurationDoc_Malformed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := `apiVersion: sbsh/v1beta1
+kind: Configuration
+spec:
+  runPath: [not-a-string
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if _, err := LoadConfigurationDoc(path); err == nil {
+		t.Fatal("expected decode error, got nil")
+	}
+}

--- a/cmd/config/configuration_test.go
+++ b/cmd/config/configuration_test.go
@@ -85,6 +85,22 @@ spec:
 	}
 }
 
+func Test_LoadConfigurationDoc_UnsupportedAPIVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := `apiVersion: sbsh/v9999
+kind: Configuration
+spec:
+  runPath: /var/run/sbsh
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if _, err := LoadConfigurationDoc(path); err == nil {
+		t.Fatal("expected error for unsupported apiVersion, got nil")
+	}
+}
+
 func Test_LoadConfigurationDoc_UnsupportedKind(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	content := `apiVersion: sbsh/v1beta1

--- a/cmd/sb/sb.go
+++ b/cmd/sb/sb.go
@@ -38,7 +38,6 @@ import (
 	"github.com/eminwux/sbsh/cmd/types"
 	"github.com/eminwux/sbsh/internal/errdefs"
 	"github.com/eminwux/sbsh/internal/logging"
-	"github.com/eminwux/sbsh/pkg/api"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -173,7 +172,7 @@ func LoadConfig() error {
 	// Promote ConfigurationDoc values to env vars so subcommand helpers that
 	// read os.Getenv directly (e.g. GetRunPathFromEnvAndFlags) also see them.
 	// User-set env vars take precedence and are left untouched.
-	applyDocEnv(cfgDoc)
+	config.ApplyConfigurationDocEnv(cfgDoc)
 
 	_ = config.SB_ROOT_RUN_PATH.BindEnv()
 	runPath := config.DefaultRunPath()
@@ -197,28 +196,4 @@ func LoadConfig() error {
 	config.SBSH_ROOT_LOG_LEVEL.SetDefault(logLevel)
 
 	return nil
-}
-
-// applyDocEnv copies ConfigurationDoc.Spec values to the env vars consumed by
-// sb and sbsh subcommands, but only when the user hasn't already set them.
-// This preserves the precedence flag > env > doc > default.
-func applyDocEnv(cfgDoc *api.ConfigurationDoc) {
-	if cfgDoc == nil {
-		return
-	}
-	setIfUnset := func(envVar, value string) {
-		if value == "" {
-			return
-		}
-		if _, present := os.LookupEnv(envVar); present {
-			return
-		}
-		_ = os.Setenv(envVar, value)
-	}
-	setIfUnset(config.SB_ROOT_RUN_PATH.EnvVar(), cfgDoc.Spec.RunPath)
-	setIfUnset(config.SBSH_ROOT_RUN_PATH.EnvVar(), cfgDoc.Spec.RunPath)
-	setIfUnset(config.SB_GET_PROFILES_FILE.EnvVar(), cfgDoc.Spec.ProfilesFile)
-	setIfUnset(config.SBSH_ROOT_PROFILES_FILE.EnvVar(), cfgDoc.Spec.ProfilesFile)
-	setIfUnset(config.SB_ROOT_LOG_LEVEL.EnvVar(), cfgDoc.Spec.LogLevel)
-	setIfUnset(config.SBSH_ROOT_LOG_LEVEL.EnvVar(), cfgDoc.Spec.LogLevel)
 }

--- a/cmd/sb/sb.go
+++ b/cmd/sb/sb.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"path/filepath"
 
 	"github.com/eminwux/sbsh/cmd/config"
 	"github.com/eminwux/sbsh/cmd/sb/attach"
@@ -155,10 +154,6 @@ func LoadConfig() error {
 	configFile := viper.GetString(config.SBSH_ROOT_CONFIG_FILE.ViperKey)
 	if configFile == "" {
 		configFile = config.DefaultConfigFile()
-		viper.SetConfigName("config")
-		viper.SetConfigType("yaml")
-		// Add the directory containing the config file
-		viper.AddConfigPath(filepath.Dir(configFile))
 	}
 	_ = config.SBSH_ROOT_CONFIG_FILE.BindEnv()
 	if err := config.SBSH_ROOT_CONFIG_FILE.Set(configFile); err != nil {

--- a/cmd/sb/sb.go
+++ b/cmd/sb/sb.go
@@ -18,7 +18,6 @@ package sb
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -39,6 +38,7 @@ import (
 	"github.com/eminwux/sbsh/cmd/types"
 	"github.com/eminwux/sbsh/internal/errdefs"
 	"github.com/eminwux/sbsh/internal/logging"
+	"github.com/eminwux/sbsh/pkg/api"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -153,8 +153,8 @@ func setupRootCmd(rootCmd *cobra.Command) error {
 }
 
 func LoadConfig() error {
-	var configFile string
-	if viper.GetString(config.SBSH_ROOT_CONFIG_FILE.ViperKey) == "" {
+	configFile := viper.GetString(config.SBSH_ROOT_CONFIG_FILE.ViperKey)
+	if configFile == "" {
 		configFile = config.DefaultConfigFile()
 		viper.SetConfigName("config")
 		viper.SetConfigType("yaml")
@@ -166,30 +166,59 @@ func LoadConfig() error {
 		return fmt.Errorf("%w: failed to set config file: %w", errdefs.ErrConfig, err)
 	}
 
-	var runPath string
-	if viper.GetString(config.SB_ROOT_RUN_PATH.ViperKey) == "" {
-		runPath = config.DefaultRunPath()
+	cfgDoc, err := config.LoadConfigurationDoc(configFile)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errdefs.ErrConfig, err)
 	}
+	// Promote ConfigurationDoc values to env vars so subcommand helpers that
+	// read os.Getenv directly (e.g. GetRunPathFromEnvAndFlags) also see them.
+	// User-set env vars take precedence and are left untouched.
+	applyDocEnv(cfgDoc)
+
 	_ = config.SB_ROOT_RUN_PATH.BindEnv()
+	runPath := config.DefaultRunPath()
+	if cfgDoc != nil && cfgDoc.Spec.RunPath != "" {
+		runPath = cfgDoc.Spec.RunPath
+	}
 	config.SB_ROOT_RUN_PATH.SetDefault(runPath)
 
-	var profilesFile string
-	if viper.GetString(config.SB_GET_PROFILES_FILE.ViperKey) == "" {
-		profilesFile = config.DefaultProfilesFile()
-	}
 	_ = config.SB_GET_PROFILES_FILE.BindEnv()
+	profilesFile := config.DefaultProfilesFile()
+	if cfgDoc != nil && cfgDoc.Spec.ProfilesFile != "" {
+		profilesFile = cfgDoc.Spec.ProfilesFile
+	}
 	config.SB_GET_PROFILES_FILE.SetDefault(profilesFile)
 
 	_ = config.SBSH_ROOT_LOG_LEVEL.BindEnv()
-	config.SBSH_ROOT_LOG_LEVEL.SetDefault("info")
-
-	if err := viper.ReadInConfig(); err != nil {
-		// File not found is OK if ENV is set
-		var configFileNotFoundError viper.ConfigFileNotFoundError
-		if !errors.As(err, &configFileNotFoundError) {
-			return fmt.Errorf("%w: %w", errdefs.ErrConfig, err)
-		}
+	logLevel := "info"
+	if cfgDoc != nil && cfgDoc.Spec.LogLevel != "" {
+		logLevel = cfgDoc.Spec.LogLevel
 	}
+	config.SBSH_ROOT_LOG_LEVEL.SetDefault(logLevel)
 
 	return nil
+}
+
+// applyDocEnv copies ConfigurationDoc.Spec values to the env vars consumed by
+// sb and sbsh subcommands, but only when the user hasn't already set them.
+// This preserves the precedence flag > env > doc > default.
+func applyDocEnv(cfgDoc *api.ConfigurationDoc) {
+	if cfgDoc == nil {
+		return
+	}
+	setIfUnset := func(envVar, value string) {
+		if value == "" {
+			return
+		}
+		if _, present := os.LookupEnv(envVar); present {
+			return
+		}
+		_ = os.Setenv(envVar, value)
+	}
+	setIfUnset(config.SB_ROOT_RUN_PATH.EnvVar(), cfgDoc.Spec.RunPath)
+	setIfUnset(config.SBSH_ROOT_RUN_PATH.EnvVar(), cfgDoc.Spec.RunPath)
+	setIfUnset(config.SB_GET_PROFILES_FILE.EnvVar(), cfgDoc.Spec.ProfilesFile)
+	setIfUnset(config.SBSH_ROOT_PROFILES_FILE.EnvVar(), cfgDoc.Spec.ProfilesFile)
+	setIfUnset(config.SB_ROOT_LOG_LEVEL.EnvVar(), cfgDoc.Spec.LogLevel)
+	setIfUnset(config.SBSH_ROOT_LOG_LEVEL.EnvVar(), cfgDoc.Spec.LogLevel)
 }

--- a/cmd/sb/sb_test.go
+++ b/cmd/sb/sb_test.go
@@ -17,6 +17,8 @@
 package sb
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/eminwux/sbsh/cmd/config"
@@ -91,7 +93,11 @@ func Test_LoadConfig_HappyPath(t *testing.T) {
 		viper.Reset()
 	})
 
-	t.Setenv(config.SBSH_ROOT_CONFIG_FILE.EnvVar(), "")
+	// Point at a tmp dir without a config.yaml so the loader reaches the
+	// built-in defaults regardless of what's at $HOME/.sbsh/config.yaml.
+	missingCfg := filepath.Join(t.TempDir(), "config.yaml")
+	t.Setenv(config.SBSH_ROOT_CONFIG_FILE.EnvVar(), missingCfg)
+	_ = config.SBSH_ROOT_CONFIG_FILE.BindEnv()
 	t.Setenv(config.SB_ROOT_RUN_PATH.EnvVar(), "")
 	t.Setenv(config.SB_GET_PROFILES_FILE.EnvVar(), "")
 	t.Setenv(config.SBSH_ROOT_LOG_LEVEL.EnvVar(), "")
@@ -110,5 +116,48 @@ func Test_LoadConfig_HappyPath(t *testing.T) {
 
 	if got := viper.GetString(config.SBSH_ROOT_LOG_LEVEL.ViperKey); got != "info" {
 		t.Fatalf("expected log level info, got %s", got)
+	}
+}
+
+func Test_LoadConfig_ConfigurationDoc(t *testing.T) {
+	t.Cleanup(func() {
+		viper.Reset()
+	})
+	viper.Reset()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	content := `apiVersion: sbsh/v1beta1
+kind: Configuration
+metadata:
+  name: default
+spec:
+  runPath: /tmp/sbsh-test-run
+  profilesFile: /tmp/sbsh-test-profiles.yaml
+  logLevel: debug
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	t.Setenv(config.SBSH_ROOT_CONFIG_FILE.EnvVar(), cfgPath)
+	t.Setenv(config.SB_ROOT_RUN_PATH.EnvVar(), "")
+	t.Setenv(config.SB_GET_PROFILES_FILE.EnvVar(), "")
+	t.Setenv(config.SBSH_ROOT_LOG_LEVEL.EnvVar(), "")
+
+	_ = config.SBSH_ROOT_CONFIG_FILE.BindEnv()
+
+	if err := LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+
+	if got, want := viper.GetString(config.SB_ROOT_RUN_PATH.ViperKey), "/tmp/sbsh-test-run"; got != want {
+		t.Errorf("run path = %q, want %q", got, want)
+	}
+	if got, want := viper.GetString(config.SB_GET_PROFILES_FILE.ViperKey), "/tmp/sbsh-test-profiles.yaml"; got != want {
+		t.Errorf("profiles file = %q, want %q", got, want)
+	}
+	if got, want := viper.GetString(config.SBSH_ROOT_LOG_LEVEL.ViperKey), "debug"; got != want {
+		t.Errorf("log level = %q, want %q", got, want)
 	}
 }

--- a/cmd/sbsh/sbsh.go
+++ b/cmd/sbsh/sbsh.go
@@ -434,8 +434,8 @@ func runClient(
 
 // LoadConfig loads config.yaml from the given path or HOME/.sbsh.
 func LoadConfig() error {
-	var configFile string
-	if viper.GetString(config.SBSH_ROOT_CONFIG_FILE.ViperKey) == "" {
+	configFile := viper.GetString(config.SBSH_ROOT_CONFIG_FILE.ViperKey)
+	if configFile == "" {
 		configFile = config.DefaultConfigFile()
 		viper.SetConfigName("config")
 		viper.SetConfigType("yaml")
@@ -445,32 +445,60 @@ func LoadConfig() error {
 	_ = config.SBSH_ROOT_CONFIG_FILE.BindEnv()
 	_ = config.SBSH_ROOT_CONFIG_FILE.Set(configFile)
 
-	var runPath string
-	if viper.GetString(config.SBSH_ROOT_RUN_PATH.ViperKey) == "" {
-		runPath = config.DefaultRunPath()
+	cfgDoc, err := config.LoadConfigurationDoc(configFile)
+	if err != nil {
+		return err
 	}
+	// Promote ConfigurationDoc values to env vars so subcommand helpers that
+	// read os.Getenv directly also see them. User-set env vars are untouched.
+	applyDocEnv(cfgDoc)
+
 	_ = config.SBSH_ROOT_RUN_PATH.BindEnv()
+	runPath := config.DefaultRunPath()
+	if cfgDoc != nil && cfgDoc.Spec.RunPath != "" {
+		runPath = cfgDoc.Spec.RunPath
+	}
 	config.SBSH_ROOT_RUN_PATH.SetDefault(runPath)
 
-	var profilesFile string
-	if viper.GetString(config.SBSH_ROOT_PROFILES_FILE.ViperKey) == "" {
-		profilesFile = config.DefaultProfilesFile()
-	}
 	_ = config.SBSH_ROOT_PROFILES_FILE.BindEnv()
+	profilesFile := config.DefaultProfilesFile()
+	if cfgDoc != nil && cfgDoc.Spec.ProfilesFile != "" {
+		profilesFile = cfgDoc.Spec.ProfilesFile
+	}
 	config.SBSH_ROOT_PROFILES_FILE.SetDefault(profilesFile)
 
 	_ = config.SBSH_ROOT_LOG_LEVEL.BindEnv()
-	config.SBSH_ROOT_LOG_LEVEL.SetDefault("info")
-
-	if err := viper.ReadInConfig(); err != nil {
-		// File not found is OK if ENV is set
-		var configFileNotFoundError viper.ConfigFileNotFoundError
-		if !errors.As(err, &configFileNotFoundError) {
-			return err // Config file was found but another error was produced
-		}
+	logLevel := "info"
+	if cfgDoc != nil && cfgDoc.Spec.LogLevel != "" {
+		logLevel = cfgDoc.Spec.LogLevel
 	}
+	config.SBSH_ROOT_LOG_LEVEL.SetDefault(logLevel)
 
 	return nil
+}
+
+// applyDocEnv copies ConfigurationDoc.Spec values to the env vars consumed by
+// sb and sbsh subcommands, but only when the user hasn't already set them.
+// This preserves the precedence flag > env > doc > default.
+func applyDocEnv(cfgDoc *api.ConfigurationDoc) {
+	if cfgDoc == nil {
+		return
+	}
+	setIfUnset := func(envVar, value string) {
+		if value == "" {
+			return
+		}
+		if _, present := os.LookupEnv(envVar); present {
+			return
+		}
+		_ = os.Setenv(envVar, value)
+	}
+	setIfUnset(config.SBSH_ROOT_RUN_PATH.EnvVar(), cfgDoc.Spec.RunPath)
+	setIfUnset(config.SB_ROOT_RUN_PATH.EnvVar(), cfgDoc.Spec.RunPath)
+	setIfUnset(config.SBSH_ROOT_PROFILES_FILE.EnvVar(), cfgDoc.Spec.ProfilesFile)
+	setIfUnset(config.SB_GET_PROFILES_FILE.EnvVar(), cfgDoc.Spec.ProfilesFile)
+	setIfUnset(config.SBSH_ROOT_LOG_LEVEL.EnvVar(), cfgDoc.Spec.LogLevel)
+	setIfUnset(config.SB_ROOT_LOG_LEVEL.EnvVar(), cfgDoc.Spec.LogLevel)
 }
 
 func detachSelf() {

--- a/cmd/sbsh/sbsh.go
+++ b/cmd/sbsh/sbsh.go
@@ -437,10 +437,6 @@ func LoadConfig() error {
 	configFile := viper.GetString(config.SBSH_ROOT_CONFIG_FILE.ViperKey)
 	if configFile == "" {
 		configFile = config.DefaultConfigFile()
-		viper.SetConfigName("config")
-		viper.SetConfigType("yaml")
-		// Add the directory containing the config file
-		viper.AddConfigPath(filepath.Dir(configFile))
 	}
 	_ = config.SBSH_ROOT_CONFIG_FILE.BindEnv()
 	_ = config.SBSH_ROOT_CONFIG_FILE.Set(configFile)

--- a/cmd/sbsh/sbsh.go
+++ b/cmd/sbsh/sbsh.go
@@ -451,7 +451,7 @@ func LoadConfig() error {
 	}
 	// Promote ConfigurationDoc values to env vars so subcommand helpers that
 	// read os.Getenv directly also see them. User-set env vars are untouched.
-	applyDocEnv(cfgDoc)
+	config.ApplyConfigurationDocEnv(cfgDoc)
 
 	_ = config.SBSH_ROOT_RUN_PATH.BindEnv()
 	runPath := config.DefaultRunPath()
@@ -475,30 +475,6 @@ func LoadConfig() error {
 	config.SBSH_ROOT_LOG_LEVEL.SetDefault(logLevel)
 
 	return nil
-}
-
-// applyDocEnv copies ConfigurationDoc.Spec values to the env vars consumed by
-// sb and sbsh subcommands, but only when the user hasn't already set them.
-// This preserves the precedence flag > env > doc > default.
-func applyDocEnv(cfgDoc *api.ConfigurationDoc) {
-	if cfgDoc == nil {
-		return
-	}
-	setIfUnset := func(envVar, value string) {
-		if value == "" {
-			return
-		}
-		if _, present := os.LookupEnv(envVar); present {
-			return
-		}
-		_ = os.Setenv(envVar, value)
-	}
-	setIfUnset(config.SBSH_ROOT_RUN_PATH.EnvVar(), cfgDoc.Spec.RunPath)
-	setIfUnset(config.SB_ROOT_RUN_PATH.EnvVar(), cfgDoc.Spec.RunPath)
-	setIfUnset(config.SBSH_ROOT_PROFILES_FILE.EnvVar(), cfgDoc.Spec.ProfilesFile)
-	setIfUnset(config.SB_GET_PROFILES_FILE.EnvVar(), cfgDoc.Spec.ProfilesFile)
-	setIfUnset(config.SBSH_ROOT_LOG_LEVEL.EnvVar(), cfgDoc.Spec.LogLevel)
-	setIfUnset(config.SB_ROOT_LOG_LEVEL.EnvVar(), cfgDoc.Spec.LogLevel)
 }
 
 func detachSelf() {

--- a/docs/site/cli/sb.md
+++ b/docs/site/cli/sb.md
@@ -96,7 +96,7 @@ sb autocomplete zsh
 
 These flags apply to all `sb` commands:
 
-- `--config <file>`: Config file (default: `$HOME/.sbsh/config.yaml`)
+- `--config <file>`: Config file (default: `$HOME/.sbsh/config.yaml`). See the [Configuration guide](../guides/configuration.md) for the `Configuration` document schema.
 - `-v, --verbose`: Enable verbose logging
 - `--log-level <level>`: Log level (debug, info, warn, error)
 - `--run-path <path>`: Run path directory

--- a/docs/site/cli/sbsh.md
+++ b/docs/site/cli/sbsh.md
@@ -49,7 +49,7 @@ sbsh terminal --name my-terminal -p profile-name
 These flags apply to all `sbsh` commands:
 
 - `--run-path <path>`: Optional run path for the client
-- `--config <file>`: Config file (default: `$HOME/.sbsh/config.yaml`)
+- `--config <file>`: Config file (default: `$HOME/.sbsh/config.yaml`). See the [Configuration guide](../guides/configuration.md) for the `Configuration` document schema.
 - `--profiles <file>`: Profiles manifests file (default: `$HOME/.sbsh/profiles.yaml`)
 
 ### Client Flags

--- a/docs/site/guides/configuration.md
+++ b/docs/site/guides/configuration.md
@@ -1,0 +1,65 @@
+# Configuration
+
+sbsh reads user-level defaults from a single YAML file shaped as a `Configuration` document. The file sets defaults for the run path, profiles file, and log level; any CLI flag or environment variable still overrides what the document declares.
+
+## File location
+
+By default, both `sbsh` and `sb` look for the config file at:
+
+```
+$HOME/.sbsh/config.yaml
+```
+
+Override the location with the `--config` flag or the `SBSH_CONFIG_FILE` environment variable.
+
+The file is optional. If it is absent, sbsh falls back to built-in defaults.
+
+## Schema
+
+```yaml
+apiVersion: sbsh/v1beta1
+kind: Configuration
+metadata:
+  name: default
+spec:
+  runPath: /path/to/state-root         # optional, default $HOME/.sbsh/run
+  profilesFile: /path/to/profiles.yaml # optional, default $HOME/.sbsh/profiles.yaml
+  logLevel: info                       # optional, default info (debug|info|warn|error)
+```
+
+All fields under `spec` are optional. An empty or missing field keeps the built-in default.
+
+### Fields
+
+| Field               | Description                                                                 |
+| ------------------- | --------------------------------------------------------------------------- |
+| `apiVersion`        | Must be `sbsh/v1beta1`.                                                     |
+| `kind`              | Must be `Configuration`. Any other kind is rejected.                        |
+| `metadata.name`     | Free-form label for the document. Optional.                                 |
+| `spec.runPath`      | Root directory where sbsh writes per-terminal and per-client state.         |
+| `spec.profilesFile` | Path to the YAML file containing `TerminalProfile` documents.               |
+| `spec.logLevel`     | Default log level when `--log-level` and `SBSH_LOG_LEVEL` are not provided. |
+
+## Precedence
+
+For each setting, the first source that provides a non-empty value wins:
+
+1. CLI flag (e.g. `--run-path`, `--profiles`, `--log-level`)
+2. Environment variable (e.g. `SBSH_RUN_PATH`, `SBSH_PROFILES_FILE`, `SBSH_LOG_LEVEL`)
+3. `spec` value from `config.yaml`
+4. Built-in default
+
+## Example
+
+```yaml
+apiVersion: sbsh/v1beta1
+kind: Configuration
+metadata:
+  name: default
+spec:
+  runPath: /var/lib/sbsh
+  profilesFile: /etc/sbsh/profiles.yaml
+  logLevel: debug
+```
+
+With this file in place, running `sbsh` without any flags uses `/var/lib/sbsh` as the run path, loads profiles from `/etc/sbsh/profiles.yaml`, and logs at `debug` level.

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -81,7 +81,7 @@ sbsh applies the same principles of Infrastructure-as-Code to interactive enviro
 
 - **[Getting Started](getting-started.md)** - Install and configure sbsh
 - **[Concepts](concepts/terminals.md)** - Understand terminals, profiles, and clients
-- **[Guides](guides/profiles.md)** - Comprehensive guides for profiles, CI/CD, and containers
+- **[Guides](guides/profiles.md)** - Comprehensive guides for profiles, configuration, CI/CD, and containers
 - **[CLI Reference](cli/commands.md)** - Complete command documentation
 - **[Tutorials](tutorials/create-your-first-profile.md)** - Step-by-step tutorials
 

--- a/pkg/api/configuration.go
+++ b/pkg/api/configuration.go
@@ -1,0 +1,46 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+// apiVersion: sbsh/v1beta1
+// kind: Configuration
+
+const KindConfiguration Kind = "Configuration"
+
+// ConfigurationDoc models one YAML document containing user-level defaults
+// for sbsh. It is the declarative equivalent of the --run-path, --profiles,
+// and --log-level flags and their corresponding environment variables.
+type ConfigurationDoc struct {
+	APIVersion Version               `json:"apiVersion" yaml:"apiVersion"`
+	Kind       Kind                  `json:"kind"       yaml:"kind"`
+	Metadata   ConfigurationMetadata `json:"metadata"   yaml:"metadata"`
+	Spec       ConfigurationSpec     `json:"spec"       yaml:"spec"`
+}
+
+type ConfigurationMetadata struct {
+	Name        string            `json:"name,omitempty"        yaml:"name,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"      yaml:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+}
+
+// ConfigurationSpec holds the user-level defaults loaded from config.yaml.
+// Fields are optional; empty values fall back to built-in defaults.
+type ConfigurationSpec struct {
+	RunPath      string `json:"runPath,omitempty"      yaml:"runPath,omitempty"`
+	ProfilesFile string `json:"profilesFile,omitempty" yaml:"profilesFile,omitempty"`
+	LogLevel     string `json:"logLevel,omitempty"     yaml:"logLevel,omitempty"`
+}


### PR DESCRIPTION
## Summary
- Adds the declarative `Configuration` document type so user-level defaults (`runPath`, `profilesFile`, `logLevel`) can be expressed as a Doc-shaped YAML, mirroring the existing `TerminalProfile` shape.
- Wires `LoadConfigurationDoc` into both `sb` and `sbsh` config loaders so `Spec` values become viper defaults and are also propagated to env vars (preserving precedence: flag > env > doc > default).
- Documents the schema, file location, and precedence rules in `docs/site/guides/configuration.md` and links to it from the CLI references.

## Test plan
- [ ] `make sbsh-sb` (canonical build, hardlinks `sb`)
- [ ] `file ./sbsh` confirms ELF executable
- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `go test ./pkg/api/... ./cmd/config/... ./cmd/sb/... ./cmd/sbsh/...`

Closes #30