### PR TITLE
fix: surface terminal exit errors in client

### DIFF
--- a/cmd/sbsh/sbsh.go
+++ b/cmd/sbsh/sbsh.go
@@ -422,11 +422,7 @@ func runClient(
 				err = fmt.Errorf("%w: %w: %w", err, errdefs.ErrWaitOnClose, errC)
 			}
 			logger.ErrorContext(ctx, "client controller exited with error", "error", err)
-			logger.DebugContext(ctx, "controller exited after error")
-
-			// return err
-			// return nothing to avoid polluting the terminal with errors
-			return nil
+			return err
 		}
 	}
 	return nil

--- a/cmd/sbsh/sbsh_test.go
+++ b/cmd/sbsh/sbsh_test.go
@@ -292,10 +292,14 @@ func TestRunTerminal_ErrChildExit(t *testing.T) {
 	// Wait for Run() to complete and error to be handled
 	select {
 	case err := <-done:
-		// runClient returns nil when errCh receives error (line 412)
-		// The error is logged but not returned to avoid polluting terminal
-		if err != nil {
-			t.Fatalf("expected nil (error logged but not returned); got: '%v'", err)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !errors.Is(err, errdefs.ErrChildExit) {
+			t.Fatalf("expected '%v'; got: '%v'", errdefs.ErrChildExit, err)
+		}
+		if !errors.Is(err, runErr) {
+			t.Fatalf("expected wrapped error '%v'; got: '%v'", runErr, err)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for runClient to return")
@@ -356,10 +360,20 @@ func TestRunTerminal_ErrChildExitWithWaitCloseError(t *testing.T) {
 	// Wait for Run() to complete and error to be handled
 	select {
 	case err := <-done:
-		// runClient returns nil when errCh receives error (line 412)
-		// The error is logged but not returned to avoid polluting terminal
-		if err != nil {
-			t.Fatalf("expected nil (error logged but not returned); got: '%v'", err)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !errors.Is(err, errdefs.ErrChildExit) {
+			t.Fatalf("expected '%v'; got: '%v'", errdefs.ErrChildExit, err)
+		}
+		if !errors.Is(err, runErr) {
+			t.Fatalf("expected wrapped error '%v'; got: '%v'", runErr, err)
+		}
+		if !errors.Is(err, errdefs.ErrWaitOnClose) {
+			t.Fatalf("expected wrapped '%v'; got: '%v'", errdefs.ErrWaitOnClose, err)
+		}
+		if !errors.Is(err, waitCloseErr) {
+			t.Fatalf("expected wrapped error '%v'; got: '%v'", waitCloseErr, err)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for runClient to return")

--- a/internal/client/clientrunner/lifecycle.go
+++ b/internal/client/clientrunner/lifecycle.go
@@ -102,6 +102,7 @@ func (sr *Exec) StartTerminalCmd(terminal *api.AttachedTerminal) error {
 	// IMPORTANT: reap it in the background so it never zombifies
 	go func() {
 		errWait := cmd.Wait()
+		var eventErr error
 		if errWait != nil {
 			sr.logger.Warn(
 				"StartTerminalCmd: process exited with error",
@@ -110,10 +111,10 @@ func (sr *Exec) StartTerminalCmd(terminal *api.AttachedTerminal) error {
 				"error",
 				errWait,
 			)
+			eventErr = fmt.Errorf("terminal %s process exited: %w", terminal.Spec.ID, errWait)
 		} else {
 			sr.logger.Info("StartTerminalCmd: process exited", "terminal_id", terminal.Spec.ID)
 		}
-		eventErr := fmt.Errorf("terminal %s process has exited", terminal.Spec.ID)
 		trySendEvent(
 			sr.logger,
 			sr.events,

--- a/internal/client/controller.go
+++ b/internal/client/controller.go
@@ -263,6 +263,9 @@ func (s *Controller) Run(doc *api.ClientDoc) error {
 
 		case errClose := <-s.closeReqCh:
 			s.logger.Warn("close request received", "error", errClose)
+			if errClose == nil {
+				return nil
+			}
 			return fmt.Errorf("%w: %w", errdefs.ErrCloseReq, errClose)
 		}
 	}


### PR DESCRIPTION
## Summary
- Client previously swallowed errors when the `sbsh terminal` subprocess failed to start or exited abnormally — user saw nothing and exit code was 0.
- Controller now distinguishes a clean subprocess exit (exit status 0) from a failure, so normal shell exits stay silent while real failures propagate.
- `runClient` returns the wrapped error instead of `nil`, letting cobra print it to stderr and set a non-zero exit code.

## Test plan
- [ ] `make test` (includes e2e)
- [ ] `./sbsh --terminal-command /bin/nonexistent-xyz` prints error and exits 1
- [ ] Normal interactive session (exit 0 from shell) stays silent and exits 0

Closes #43