### PR TITLE
feat: add pkg/builder helpers for TerminalSpec and ClientDoc

### DIFF
--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -115,6 +115,7 @@ type BuildTerminalSpecParams struct {
 	TerminalName     string
 	TerminalCmd      string
 	TerminalCmdArgs  []string
+	Cwd              string
 	CaptureFile      string
 	RunPath          string
 	ProfilesFile     string
@@ -250,6 +251,7 @@ func BuildTerminalSpec(
 
 // addInputValuesToTerminal mutates terminalSpec by overriding its fields with non-empty values from input.
 // It sets ID, Name, RunPath, CaptureFile, LogFile, LogLevel, SocketFile, and appends EnvVars, avoiding duplicates.
+// Cwd overrides the profile's Shell.Cwd only when non-empty so profile values stay sticky by default.
 func addInputValuesToTerminal(terminalSpec *api.TerminalSpec, input *BuildTerminalSpecParams) {
 	terminalSpec.ID = api.ID(input.TerminalID)
 	terminalSpec.Name = input.TerminalName
@@ -258,6 +260,9 @@ func addInputValuesToTerminal(terminalSpec *api.TerminalSpec, input *BuildTermin
 	terminalSpec.LogFile = input.LogFile
 	terminalSpec.LogLevel = input.LogLevel
 	terminalSpec.SocketFile = input.SocketFile
+	if input.Cwd != "" {
+		terminalSpec.Cwd = input.Cwd
+	}
 	terminalSpec.Env = append(terminalSpec.Env, input.EnvVars...)
 	// Inverted logic: when DisableSetPrompt is true, SetPrompt is false
 	terminalSpec.SetPrompt = !input.DisableSetPrompt

--- a/pkg/builder/client.go
+++ b/pkg/builder/client.go
@@ -1,0 +1,169 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package builder
+
+import (
+	"context"
+	"log/slog"
+	"path/filepath"
+
+	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/internal/naming"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// ClientOption mutates a clientConfig. Later options override
+// earlier ones so callers can compose defaults + overrides.
+type ClientOption func(*clientConfig)
+
+// clientConfig accumulates ClientOption values. Nil-able fields
+// distinguish "not set" from zero values (e.g. detachKeystroke).
+type clientConfig struct {
+	id              string
+	name            string
+	logFile         string
+	socketFile      string
+	mode            api.ClientMode
+	modeSet         bool
+	detachKeystroke *bool
+	terminalSpec    *api.TerminalSpec
+}
+
+// WithClientID sets the client ID. Empty means "generate a random
+// ID at build time".
+func WithClientID(id string) ClientOption {
+	return func(c *clientConfig) { c.id = id }
+}
+
+// WithClientName sets the human-readable client name. Empty means
+// "generate a random name at build time".
+func WithClientName(name string) ClientOption {
+	return func(c *clientConfig) { c.name = name }
+}
+
+// WithClientLogFile overrides the client's log file path. Empty
+// leaves the field unset (the client process picks its own
+// default).
+func WithClientLogFile(path string) ClientOption {
+	return func(c *clientConfig) { c.logFile = path }
+}
+
+// WithClientSocketFile overrides the client's control-socket path.
+// Empty means "derive from runPath + client ID".
+func WithClientSocketFile(path string) ClientOption {
+	return func(c *clientConfig) { c.socketFile = path }
+}
+
+// WithClientMode selects between RunNewTerminal (default) and
+// AttachToTerminal. Calling this explicitly is required for
+// attach-style clients.
+func WithClientMode(mode api.ClientMode) ClientOption {
+	return func(c *clientConfig) {
+		c.mode = mode
+		c.modeSet = true
+	}
+}
+
+// WithClientDetachKeystroke enables or disables the ^] ^] detach
+// keystroke. The default is enabled (true). Setting false matches
+// the CLI's --disable-detach behavior.
+func WithClientDetachKeystroke(enable bool) ClientOption {
+	return func(c *clientConfig) {
+		v := enable
+		c.detachKeystroke = &v
+	}
+}
+
+// WithClientTerminalSpec embeds a pre-built TerminalSpec into the
+// ClientDoc. For RunNewTerminal clients this is the spec that will
+// be spawned; for AttachToTerminal clients callers typically pass
+// a spec carrying only ID or Name (the controller resolves the
+// concrete terminal at run time). A nil spec is normalized to an
+// empty &api.TerminalSpec{} so downstream code never has to guard
+// against nil.
+func WithClientTerminalSpec(spec *api.TerminalSpec) ClientOption {
+	return func(c *clientConfig) { c.terminalSpec = spec }
+}
+
+// BuildClientDoc produces a ClientDoc from a runPath plus optional
+// inline overrides. Defaults mirror the CLI: random ID/Name when
+// unset, socket path under runPath/clients/<id>/socket, detach
+// keystroke enabled, RunNewTerminal mode.
+//
+// runPath is required; an empty runPath returns
+// errdefs.ErrRunPathRequired.
+func BuildClientDoc(
+	_ context.Context,
+	_ *slog.Logger,
+	runPath string,
+	opts ...ClientOption,
+) (*api.ClientDoc, error) {
+	if runPath == "" {
+		return nil, errdefs.ErrRunPathRequired
+	}
+
+	cfg := clientConfig{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+
+	if cfg.id == "" {
+		cfg.id = naming.RandomID()
+	}
+	if cfg.name == "" {
+		cfg.name = naming.RandomName()
+	}
+	if cfg.socketFile == "" {
+		cfg.socketFile = filepath.Join(runPath, defaults.ClientsRunPath, cfg.id, "socket")
+	}
+	if cfg.terminalSpec == nil {
+		cfg.terminalSpec = &api.TerminalSpec{}
+	}
+
+	detach := true
+	if cfg.detachKeystroke != nil {
+		detach = *cfg.detachKeystroke
+	}
+
+	mode := api.RunNewTerminal
+	if cfg.modeSet {
+		mode = cfg.mode
+	}
+
+	doc := &api.ClientDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindClient,
+		Metadata: api.ClientMetadata{
+			Name:        cfg.name,
+			Labels:      map[string]string{},
+			Annotations: map[string]string{},
+		},
+		Spec: api.ClientSpec{
+			ID:              api.ID(cfg.id),
+			RunPath:         runPath,
+			LogFile:         cfg.logFile,
+			SockerCtrl:      cfg.socketFile,
+			TerminalSpec:    cfg.terminalSpec,
+			DetachKeystroke: detach,
+			ClientMode:      mode,
+		},
+	}
+	return doc, nil
+}

--- a/pkg/builder/client.go
+++ b/pkg/builder/client.go
@@ -107,6 +107,10 @@ func WithClientTerminalSpec(spec *api.TerminalSpec) ClientOption {
 //
 // runPath is required; an empty runPath returns
 // errdefs.ErrRunPathRequired.
+//
+// ctx and logger are accepted but unused today; they are reserved
+// for future profile/discovery plumbing so the signature matches
+// BuildTerminalSpec and will not have to change when that lands.
 func BuildClientDoc(
 	_ context.Context,
 	_ *slog.Logger,

--- a/pkg/builder/client_test.go
+++ b/pkg/builder/client_test.go
@@ -1,0 +1,197 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package builder_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/pkg/api"
+	"github.com/eminwux/sbsh/pkg/builder"
+)
+
+func TestBuildClientDoc_EmptyRunPath(t *testing.T) {
+	_, err := builder.BuildClientDoc(context.Background(), testLogger(), "")
+	if !errors.Is(err, errdefs.ErrRunPathRequired) {
+		t.Fatalf("expected ErrRunPathRequired, got %v", err)
+	}
+}
+
+func TestBuildClientDoc_Defaults(t *testing.T) {
+	runPath := t.TempDir()
+	doc, err := builder.BuildClientDoc(context.Background(), testLogger(), runPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.APIVersion != api.APIVersionV1Beta1 {
+		t.Fatalf("apiVersion: want %q, got %q", api.APIVersionV1Beta1, doc.APIVersion)
+	}
+	if doc.Kind != api.KindClient {
+		t.Fatalf("kind: want %q, got %q", api.KindClient, doc.Kind)
+	}
+	if doc.Metadata.Name == "" {
+		t.Fatal("expected a default name, got empty")
+	}
+	if string(doc.Spec.ID) == "" {
+		t.Fatal("expected a default ID, got empty")
+	}
+	if doc.Spec.RunPath != runPath {
+		t.Fatalf("runPath: want %q, got %q", runPath, doc.Spec.RunPath)
+	}
+	wantSocket := filepath.Join(runPath, defaults.ClientsRunPath, string(doc.Spec.ID), "socket")
+	if doc.Spec.SockerCtrl != wantSocket {
+		t.Fatalf("socket: want %q, got %q", wantSocket, doc.Spec.SockerCtrl)
+	}
+	if !doc.Spec.DetachKeystroke {
+		t.Fatal("expected DetachKeystroke to default true")
+	}
+	if doc.Spec.ClientMode != api.RunNewTerminal {
+		t.Fatalf("mode: want RunNewTerminal, got %v", doc.Spec.ClientMode)
+	}
+	if doc.Spec.TerminalSpec == nil {
+		t.Fatal("expected non-nil TerminalSpec")
+	}
+}
+
+func TestBuildClientDoc_Overrides(t *testing.T) {
+	runPath := t.TempDir()
+	embed := &api.TerminalSpec{ID: "embedded"}
+	doc, err := builder.BuildClientDoc(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithClientID("client-id"),
+		builder.WithClientName("client-name"),
+		builder.WithClientSocketFile("/tmp/custom.sock"),
+		builder.WithClientLogFile("/tmp/custom.log"),
+		builder.WithClientMode(api.AttachToTerminal),
+		builder.WithClientDetachKeystroke(false),
+		builder.WithClientTerminalSpec(embed),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(doc.Spec.ID) != "client-id" {
+		t.Fatalf("id: want client-id, got %q", doc.Spec.ID)
+	}
+	if doc.Metadata.Name != "client-name" {
+		t.Fatalf("name: want client-name, got %q", doc.Metadata.Name)
+	}
+	if doc.Spec.SockerCtrl != "/tmp/custom.sock" {
+		t.Fatalf("socket: got %q", doc.Spec.SockerCtrl)
+	}
+	if doc.Spec.LogFile != "/tmp/custom.log" {
+		t.Fatalf("log: got %q", doc.Spec.LogFile)
+	}
+	if doc.Spec.ClientMode != api.AttachToTerminal {
+		t.Fatalf("mode: want AttachToTerminal, got %v", doc.Spec.ClientMode)
+	}
+	if doc.Spec.DetachKeystroke {
+		t.Fatal("expected DetachKeystroke=false after WithClientDetachKeystroke(false)")
+	}
+	if doc.Spec.TerminalSpec != embed {
+		t.Fatal("expected embedded TerminalSpec to be the same pointer")
+	}
+}
+
+func TestBuildClientDoc_OptionOverrideOrder(t *testing.T) {
+	runPath := t.TempDir()
+	doc, err := builder.BuildClientDoc(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithClientID("first"),
+		builder.WithClientID("second"),
+		builder.WithClientName("a"),
+		builder.WithClientName("b"),
+		builder.WithClientMode(api.AttachToTerminal),
+		builder.WithClientMode(api.RunNewTerminal),
+		builder.WithClientDetachKeystroke(false),
+		builder.WithClientDetachKeystroke(true),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(doc.Spec.ID) != "second" {
+		t.Fatalf("id: want second, got %q", doc.Spec.ID)
+	}
+	if doc.Metadata.Name != "b" {
+		t.Fatalf("name: want b, got %q", doc.Metadata.Name)
+	}
+	if doc.Spec.ClientMode != api.RunNewTerminal {
+		t.Fatalf("mode: want RunNewTerminal (last-wins), got %v", doc.Spec.ClientMode)
+	}
+	if !doc.Spec.DetachKeystroke {
+		t.Fatal("expected DetachKeystroke=true (last-wins)")
+	}
+}
+
+func TestBuildClientDoc_NilOptionSafe(t *testing.T) {
+	runPath := t.TempDir()
+	_, err := builder.BuildClientDoc(
+		context.Background(),
+		testLogger(),
+		runPath,
+		nil,
+		builder.WithClientID("x"),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Nil TerminalSpec passed explicitly still normalizes to an empty
+// non-nil spec so controller code never dereferences nil.
+func TestBuildClientDoc_NilTerminalSpec(t *testing.T) {
+	runPath := t.TempDir()
+	doc, err := builder.BuildClientDoc(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithClientTerminalSpec(nil),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.Spec.TerminalSpec == nil {
+		t.Fatal("expected non-nil TerminalSpec after WithClientTerminalSpec(nil)")
+	}
+}
+
+// Default socket path embeds the resolved (possibly random) ID so
+// that collisions across concurrent clients are avoided.
+func TestBuildClientDoc_SocketContainsResolvedID(t *testing.T) {
+	runPath := t.TempDir()
+	doc, err := builder.BuildClientDoc(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithClientID("explicit-id"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(doc.Spec.SockerCtrl, "explicit-id") {
+		t.Fatalf("expected socket path to contain ID, got %q", doc.Spec.SockerCtrl)
+	}
+}

--- a/pkg/builder/doc.go
+++ b/pkg/builder/doc.go
@@ -1,0 +1,27 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package builder exposes library-level helpers for constructing
+// TerminalSpec and ClientDoc values from a profile name or inline
+// fields, without importing internal/ packages or round-tripping
+// through YAML. It is the public counterpart of the CLI flag
+// plumbing today and the intended building block for spawn calls
+// (see pkg/spawn).
+//
+// Stability: pre-v1. Option names and defaults in this package may
+// change between minor releases until the umbrella issue (#118)
+// closes.
+package builder

--- a/pkg/builder/terminal.go
+++ b/pkg/builder/terminal.go
@@ -1,0 +1,192 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package builder
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+
+	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/internal/profile"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// TerminalOption mutates a terminalConfig. Later options override
+// earlier ones so callers can compose defaults + overrides.
+type TerminalOption func(*terminalConfig)
+
+// terminalConfig is the internal accumulator for TerminalOption
+// values. It mirrors the subset of profile.BuildTerminalSpecParams
+// that external callers are expected to control.
+type terminalConfig struct {
+	id               string
+	name             string
+	command          string
+	commandArgs      []string
+	envVars          []string
+	cwd              string
+	captureFile      string
+	logFile          string
+	logLevel         string
+	socketFile       string
+	profileName      string
+	profileFile      string
+	disableSetPrompt bool
+}
+
+// WithID sets the terminal ID. Empty means "generate a random ID".
+func WithID(id string) TerminalOption {
+	return func(c *terminalConfig) { c.id = id }
+}
+
+// WithName sets the human-readable terminal name. Empty means
+// "generate a random name".
+func WithName(name string) TerminalOption {
+	return func(c *terminalConfig) { c.name = name }
+}
+
+// WithProfile selects a profile by Metadata.Name from the profile
+// file resolved via WithProfileFile (or the default location if no
+// explicit path is set). Empty resolves to the hardcoded "default"
+// profile.
+func WithProfile(name string) TerminalOption {
+	return func(c *terminalConfig) { c.profileName = name }
+}
+
+// WithProfileFile points the builder at a specific multi-document
+// YAML file containing TerminalProfile documents. Empty means "use
+// the default profiles file under runPath".
+func WithProfileFile(path string) TerminalOption {
+	return func(c *terminalConfig) { c.profileFile = path }
+}
+
+// WithCommand sets the terminal's command and its argv. argv[0] is
+// the command binary; argv[1:] are its arguments. An empty or nil
+// argv leaves the value untouched (profile/default wins).
+func WithCommand(argv []string) TerminalOption {
+	return func(c *terminalConfig) {
+		if len(argv) == 0 || argv[0] == "" {
+			return
+		}
+		c.command = argv[0]
+		c.commandArgs = append([]string(nil), argv[1:]...)
+	}
+}
+
+// WithCwd sets the working directory for the spawned shell. Empty
+// means "inherit from the profile, or default to the parent's cwd".
+func WithCwd(path string) TerminalOption {
+	return func(c *terminalConfig) { c.cwd = path }
+}
+
+// WithEnv adds environment variables to the spawned shell. Keys
+// are applied in a stable (lexicographic) order so repeated calls
+// produce deterministic results. The resulting entries are
+// appended to whatever the profile defines — they do not replace
+// the profile's env map.
+func WithEnv(env map[string]string) TerminalOption {
+	return func(c *terminalConfig) {
+		if len(env) == 0 {
+			return
+		}
+		keys := make([]string, 0, len(env))
+		for k := range env {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			c.envVars = append(c.envVars, fmt.Sprintf("%s=%s", k, env[k]))
+		}
+	}
+}
+
+// WithCaptureFile overrides the on-disk capture file path. Empty
+// means "derive from runPath + terminal ID".
+func WithCaptureFile(path string) TerminalOption {
+	return func(c *terminalConfig) { c.captureFile = path }
+}
+
+// WithLogFile overrides the on-disk log file path. Empty means
+// "derive from runPath + terminal ID".
+func WithLogFile(path string) TerminalOption {
+	return func(c *terminalConfig) { c.logFile = path }
+}
+
+// WithLogLevel sets the terminal's log verbosity (e.g. "info",
+// "debug"). Empty means "use the default".
+func WithLogLevel(level string) TerminalOption {
+	return func(c *terminalConfig) { c.logLevel = level }
+}
+
+// WithSocketFile overrides the terminal's control-socket path.
+// Empty means "derive from runPath + terminal ID".
+func WithSocketFile(path string) TerminalOption {
+	return func(c *terminalConfig) { c.socketFile = path }
+}
+
+// WithDisableSetPrompt disables sbsh's automatic PS1 injection
+// when true. The default (false) preserves the shell-prompt
+// rewriting behavior.
+func WithDisableSetPrompt(disable bool) TerminalOption {
+	return func(c *terminalConfig) { c.disableSetPrompt = disable }
+}
+
+// BuildTerminalSpec produces a TerminalSpec from a runPath plus an
+// optional profile selection and inline overrides. It wraps
+// internal/profile.BuildTerminalSpec and keeps the same resolution
+// rules: inline option values override profile values, and a
+// missing profile falls back to the hardcoded "default" profile
+// only when the requested profile name is literally "default" (or
+// empty).
+//
+// runPath is required; an empty runPath returns
+// errdefs.ErrRunPathRequired.
+func BuildTerminalSpec(
+	ctx context.Context,
+	logger *slog.Logger,
+	runPath string,
+	opts ...TerminalOption,
+) (*api.TerminalSpec, error) {
+	if runPath == "" {
+		return nil, errdefs.ErrRunPathRequired
+	}
+
+	cfg := terminalConfig{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+
+	return profile.BuildTerminalSpec(ctx, logger, &profile.BuildTerminalSpecParams{
+		TerminalID:       cfg.id,
+		TerminalName:     cfg.name,
+		TerminalCmd:      cfg.command,
+		TerminalCmdArgs:  cfg.commandArgs,
+		CaptureFile:      cfg.captureFile,
+		RunPath:          runPath,
+		ProfilesFile:     cfg.profileFile,
+		ProfileName:      cfg.profileName,
+		LogFile:          cfg.logFile,
+		LogLevel:         cfg.logLevel,
+		SocketFile:       cfg.socketFile,
+		EnvVars:          cfg.envVars,
+		DisableSetPrompt: cfg.disableSetPrompt,
+	})
+}

--- a/pkg/builder/terminal.go
+++ b/pkg/builder/terminal.go
@@ -179,6 +179,7 @@ func BuildTerminalSpec(
 		TerminalName:     cfg.name,
 		TerminalCmd:      cfg.command,
 		TerminalCmdArgs:  cfg.commandArgs,
+		Cwd:              cfg.cwd,
 		CaptureFile:      cfg.captureFile,
 		RunPath:          runPath,
 		ProfilesFile:     cfg.profileFile,

--- a/pkg/builder/terminal_test.go
+++ b/pkg/builder/terminal_test.go
@@ -260,6 +260,72 @@ func TestBuildTerminalSpec_NilOptionSafe(t *testing.T) {
 	}
 }
 
+// WithCwd flows through to the resulting spec. With no profile cwd,
+// the inline value is what ends up on the spec.
+func TestBuildTerminalSpec_WithCwd(t *testing.T) {
+	runPath := t.TempDir()
+	spec, err := builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithCwd("/tmp/custom-cwd"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.Cwd != "/tmp/custom-cwd" {
+		t.Fatalf("cwd: want /tmp/custom-cwd, got %q", spec.Cwd)
+	}
+}
+
+// WithCwd overrides a profile-provided Shell.Cwd when non-empty, and
+// an empty WithCwd leaves the profile value intact.
+func TestBuildTerminalSpec_WithCwdOverridesProfile(t *testing.T) {
+	const profilesYAML = `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: cwd-profile
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/bash
+    cwd: /from/profile
+`
+	runPath := t.TempDir()
+	profiles := writeProfiles(t, profilesYAML)
+
+	// No WithCwd: profile value sticks.
+	spec, err := builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithProfileFile(profiles),
+		builder.WithProfile("cwd-profile"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.Cwd != "/from/profile" {
+		t.Fatalf("cwd (profile only): want /from/profile, got %q", spec.Cwd)
+	}
+
+	// With WithCwd: inline wins.
+	spec, err = builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithProfileFile(profiles),
+		builder.WithProfile("cwd-profile"),
+		builder.WithCwd("/from/option"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.Cwd != "/from/option" {
+		t.Fatalf("cwd (override): want /from/option, got %q", spec.Cwd)
+	}
+}
+
 // WithCommand with empty argv (or empty argv[0]) is a no-op.
 func TestBuildTerminalSpec_WithCommandEmpty(t *testing.T) {
 	runPath := t.TempDir()

--- a/pkg/builder/terminal_test.go
+++ b/pkg/builder/terminal_test.go
@@ -1,0 +1,283 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package builder_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/pkg/builder"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+const twoProfilesYAML = `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: alpha
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/bash
+    cmdArgs: ["-l"]
+    env:
+      FOO: bar
+---
+apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: beta
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/zsh
+`
+
+func writeProfiles(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "profiles.yaml")
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write profiles: %v", err)
+	}
+	return p
+}
+
+func TestBuildTerminalSpec_EmptyRunPath(t *testing.T) {
+	_, err := builder.BuildTerminalSpec(context.Background(), testLogger(), "")
+	if !errors.Is(err, errdefs.ErrRunPathRequired) {
+		t.Fatalf("expected ErrRunPathRequired, got %v", err)
+	}
+}
+
+// InlineOnly: no profile file, no profile name — falls back to the
+// hardcoded "default" profile with the inline command/env.
+func TestBuildTerminalSpec_InlineOnly(t *testing.T) {
+	runPath := t.TempDir()
+	spec, err := builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithCommand([]string{"/bin/sh", "-c", "exec bash"}),
+		builder.WithEnv(map[string]string{"A": "1", "B": "2"}),
+		builder.WithID("term-id"),
+		builder.WithName("term-name"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.Command != "/bin/sh" {
+		t.Fatalf("command: want /bin/sh, got %q", spec.Command)
+	}
+	if !reflect.DeepEqual(spec.CommandArgs, []string{"-c", "exec bash"}) {
+		t.Fatalf("args: got %v", spec.CommandArgs)
+	}
+	if string(spec.ID) != "term-id" {
+		t.Fatalf("id: want term-id, got %q", spec.ID)
+	}
+	if spec.Name != "term-name" {
+		t.Fatalf("name: want term-name, got %q", spec.Name)
+	}
+	if spec.RunPath != runPath {
+		t.Fatalf("runPath: want %q, got %q", runPath, spec.RunPath)
+	}
+	// WithEnv entries are appended after profile env (empty for the
+	// hardcoded default), in stable key order.
+	wantEnv := []string{"A=1", "B=2"}
+	if !reflect.DeepEqual(spec.Env, wantEnv) {
+		t.Fatalf("env: want %v, got %v", wantEnv, spec.Env)
+	}
+}
+
+// ProfileByName: when WithProfile + WithProfileFile resolve, the
+// profile's shell cmd/args flow into the spec.
+func TestBuildTerminalSpec_ProfileByName(t *testing.T) {
+	runPath := t.TempDir()
+	profiles := writeProfiles(t, twoProfilesYAML)
+
+	spec, err := builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithProfileFile(profiles),
+		builder.WithProfile("alpha"),
+		builder.WithID("id-a"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.Command != "/bin/bash" {
+		t.Fatalf("command: want /bin/bash, got %q", spec.Command)
+	}
+	if !reflect.DeepEqual(spec.CommandArgs, []string{"-l"}) {
+		t.Fatalf("args: got %v", spec.CommandArgs)
+	}
+	if spec.ProfileName != "alpha" {
+		t.Fatalf("profileName: want alpha, got %q", spec.ProfileName)
+	}
+	// Env comes from the profile's map (sorted) plus any WithEnv adds
+	// (none here).
+	wantEnv := []string{"FOO=bar"}
+	if !reflect.DeepEqual(spec.Env, wantEnv) {
+		t.Fatalf("env: want %v, got %v", wantEnv, spec.Env)
+	}
+}
+
+// UnknownProfile: a non-default profile name that is not present in
+// the profiles file must surface the underlying not-found error.
+func TestBuildTerminalSpec_UnknownProfile(t *testing.T) {
+	runPath := t.TempDir()
+	profiles := writeProfiles(t, twoProfilesYAML)
+
+	_, err := builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithProfileFile(profiles),
+		builder.WithProfile("ghost"),
+	)
+	if err == nil {
+		t.Fatal("expected error for unknown profile, got nil")
+	}
+	if !strings.Contains(err.Error(), "ghost") {
+		t.Fatalf("expected error to mention profile name, got: %v", err)
+	}
+}
+
+// Override order: later options win for scalar fields.
+func TestBuildTerminalSpec_OptionOverrideOrder(t *testing.T) {
+	runPath := t.TempDir()
+	spec, err := builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithID("first"),
+		builder.WithID("second"),
+		builder.WithName("a"),
+		builder.WithName("b"),
+		builder.WithCommand([]string{"/bin/echo", "one"}),
+		builder.WithCommand([]string{"/bin/sh", "-c", "exit 0"}),
+		builder.WithLogLevel("info"),
+		builder.WithLogLevel("debug"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(spec.ID) != "second" {
+		t.Fatalf("id: want second, got %q", spec.ID)
+	}
+	if spec.Name != "b" {
+		t.Fatalf("name: want b, got %q", spec.Name)
+	}
+	if spec.Command != "/bin/sh" {
+		t.Fatalf("command: want /bin/sh, got %q", spec.Command)
+	}
+	if !reflect.DeepEqual(spec.CommandArgs, []string{"-c", "exit 0"}) {
+		t.Fatalf("args: got %v", spec.CommandArgs)
+	}
+	if spec.LogLevel != "debug" {
+		t.Fatalf("logLevel: want debug, got %q", spec.LogLevel)
+	}
+}
+
+// WithEnv composes additively across calls; each call contributes
+// its entries in stable key order.
+func TestBuildTerminalSpec_WithEnvComposition(t *testing.T) {
+	runPath := t.TempDir()
+	spec, err := builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithEnv(map[string]string{"B": "2"}),
+		builder.WithEnv(map[string]string{"A": "1"}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Each WithEnv call sorts its own keys, so the net order is
+	// "B=2" (first call) then "A=1" (second call).
+	wantEnv := []string{"B=2", "A=1"}
+	if !reflect.DeepEqual(spec.Env, wantEnv) {
+		t.Fatalf("env: want %v, got %v", wantEnv, spec.Env)
+	}
+}
+
+// Missing profile file with a non-default profile name produces an
+// open/not-found error rather than silently falling back.
+func TestBuildTerminalSpec_MissingProfileFile(t *testing.T) {
+	runPath := t.TempDir()
+	missing := filepath.Join(runPath, "does-not-exist.yaml")
+
+	_, err := builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithProfileFile(missing),
+		builder.WithProfile("alpha"),
+	)
+	if err == nil {
+		t.Fatal("expected error for missing profile file, got nil")
+	}
+}
+
+// Nil options are tolerated.
+func TestBuildTerminalSpec_NilOptionSafe(t *testing.T) {
+	runPath := t.TempDir()
+	_, err := builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		nil,
+		builder.WithID("x"),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// WithCommand with empty argv (or empty argv[0]) is a no-op.
+func TestBuildTerminalSpec_WithCommandEmpty(t *testing.T) {
+	runPath := t.TempDir()
+	spec, err := builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithCommand(nil),
+		builder.WithCommand([]string{""}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// With no command set, the internal builder defaults to /bin/bash -i.
+	if spec.Command != "/bin/bash" {
+		t.Fatalf("command: want /bin/bash (default), got %q", spec.Command)
+	}
+	if !reflect.DeepEqual(spec.CommandArgs, []string{"-i"}) {
+		t.Fatalf("args: got %v", spec.CommandArgs)
+	}
+}


### PR DESCRIPTION
## Summary
- Introduces `pkg/builder` with `BuildTerminalSpec` and `BuildClientDoc` plus functional options (`WithProfile`, `WithProfileFile`, `WithCommand`, `WithEnv`, `WithID`, `WithName`, `WithCwd`, `WithCaptureFile`, `WithLogFile`, `WithLogLevel`, `WithSocketFile`, `WithDisableSetPrompt`, and the `WithClient*` counterparts). `BuildTerminalSpec` wraps `internal/profile.BuildTerminalSpec`; `BuildClientDoc` mirrors the CLI's inline `api.ClientDoc` construction with CLI-parity defaults.
- Lets external consumers (e.g. `kukeon`) build specs from a profile name or inline fields without importing `internal/` or round-tripping YAML, per sub-PR D in umbrella #118.
- Existing CLI callers (`cmd/sbsh/sbsh.go`, `cmd/sb/attach/attach.go`) are left on `profile.BuildTerminalSpec` directly — the new package is strictly additive, so there is no behavior change in `sbsh`/`sb`.
- Propagates `errdefs.ErrRunPathRequired` when the required `runPath` is empty, matching the PR-A state-root contract.

## Test plan
- [x] `make sbsh-sb` and `file ./sbsh` is `ELF 64-bit LSB executable`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/builder/...`
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')`
- [x] `go test -tags=integration ./cmd/sb/get/...`
- [x] `make test` (includes e2e)

Refs #118 (PR-D)

Closes #131