### PR TITLE
feat: grow ClientController with Ping/Metadata/State/Stop RPCs

### DIFF
--- a/internal/client/clientrpc/rpc_server.go
+++ b/internal/client/clientrpc/rpc_server.go
@@ -30,3 +30,34 @@ func (s *ClientControllerRPC) WaitReady(_ *api.Empty, _ *api.Empty) error {
 func (s *ClientControllerRPC) Detach(_ *api.Empty, _ *api.Empty) error {
 	return s.Core.Detach()
 }
+
+func (s *ClientControllerRPC) Ping(in *api.PingMessage, out *api.PingMessage) error {
+	pong, err := s.Core.Ping(in)
+	if err != nil {
+		return err
+	}
+	*out = *pong
+	return nil
+}
+
+func (s *ClientControllerRPC) Metadata(_ api.Empty, doc *api.ClientDoc) error {
+	md, err := s.Core.Metadata()
+	if err != nil {
+		return err
+	}
+	*doc = *md
+	return nil
+}
+
+func (s *ClientControllerRPC) State(_ api.Empty, state *api.ClientStatusMode) error {
+	st, err := s.Core.State()
+	if err != nil {
+		return err
+	}
+	*state = *st
+	return nil
+}
+
+func (s *ClientControllerRPC) Stop(args *api.StopArgs, _ *api.Empty) error {
+	return s.Core.Stop(args)
+}

--- a/internal/client/clientrpc/rpc_server_test.go
+++ b/internal/client/clientrpc/rpc_server_test.go
@@ -1,0 +1,121 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clientrpc_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/eminwux/sbsh/internal/client"
+	"github.com/eminwux/sbsh/internal/client/clientrpc"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+func TestClientControllerRPC_Ping_Roundtrip(t *testing.T) {
+	t.Parallel()
+	core := &client.ControllerTest{
+		PingFunc: func(in *api.PingMessage) (*api.PingMessage, error) {
+			if in == nil || in.Message != "PING" {
+				return nil, errors.New("unexpected ping message")
+			}
+			return &api.PingMessage{Message: "PONG"}, nil
+		},
+	}
+	rpc := &clientrpc.ClientControllerRPC{Core: core}
+
+	out := &api.PingMessage{}
+	if err := rpc.Ping(&api.PingMessage{Message: "PING"}, out); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	if out.Message != "PONG" {
+		t.Fatalf("Ping reply = %q; want %q", out.Message, "PONG")
+	}
+}
+
+func TestClientControllerRPC_Ping_PropagatesError(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("boom")
+	core := &client.ControllerTest{
+		PingFunc: func(_ *api.PingMessage) (*api.PingMessage, error) { return nil, wantErr },
+	}
+	rpc := &clientrpc.ClientControllerRPC{Core: core}
+
+	out := &api.PingMessage{}
+	if err := rpc.Ping(&api.PingMessage{Message: "PING"}, out); !errors.Is(err, wantErr) {
+		t.Fatalf("Ping err = %v; want %v", err, wantErr)
+	}
+}
+
+func TestClientControllerRPC_Metadata_Roundtrip(t *testing.T) {
+	t.Parallel()
+	want := &api.ClientDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindClient,
+		Metadata:   api.ClientMetadata{Name: "alpha"},
+		Spec:       api.ClientSpec{ID: "c-1"},
+		Status:     api.ClientStatus{Pid: 4242, State: api.ClientReady},
+	}
+	core := &client.ControllerTest{
+		MetadataFunc: func() (*api.ClientDoc, error) { return want, nil },
+	}
+	rpc := &clientrpc.ClientControllerRPC{Core: core}
+
+	out := &api.ClientDoc{}
+	if err := rpc.Metadata(api.Empty{}, out); err != nil {
+		t.Fatalf("Metadata: %v", err)
+	}
+	if out.Metadata.Name != "alpha" || out.Spec.ID != "c-1" || out.Status.Pid != 4242 ||
+		out.Status.State != api.ClientReady {
+		t.Fatalf("Metadata reply = %+v; want %+v", out, want)
+	}
+}
+
+func TestClientControllerRPC_State_Roundtrip(t *testing.T) {
+	t.Parallel()
+	state := api.ClientAttached
+	core := &client.ControllerTest{
+		StateFunc: func() (*api.ClientStatusMode, error) { return &state, nil },
+	}
+	rpc := &clientrpc.ClientControllerRPC{Core: core}
+
+	out := api.ClientInitializing
+	if err := rpc.State(api.Empty{}, &out); err != nil {
+		t.Fatalf("State: %v", err)
+	}
+	if out != api.ClientAttached {
+		t.Fatalf("State reply = %v; want %v", out, api.ClientAttached)
+	}
+}
+
+func TestClientControllerRPC_Stop_PassesArgs(t *testing.T) {
+	t.Parallel()
+	var got *api.StopArgs
+	core := &client.ControllerTest{
+		StopFunc: func(args *api.StopArgs) error {
+			got = args
+			return nil
+		},
+	}
+	rpc := &clientrpc.ClientControllerRPC{Core: core}
+
+	if err := rpc.Stop(&api.StopArgs{Reason: "bye"}, &api.Empty{}); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if got == nil || got.Reason != "bye" {
+		t.Fatalf("Stop got = %+v; want Reason=%q", got, "bye")
+	}
+}

--- a/internal/client/clientrunner/client_runner.go
+++ b/internal/client/clientrunner/client_runner.go
@@ -33,6 +33,8 @@ type ClientRunner interface {
 	CreateMetadata() error
 	Detach() error
 	StartTerminalCmd(terminal *api.AttachedTerminal) error
+	Metadata() (*api.ClientDoc, error)
+	State() (*api.ClientStatusMode, error)
 }
 
 func (sr *Exec) ID() api.ID {

--- a/internal/client/clientrunner/client_runner_fake.go
+++ b/internal/client/clientrunner/client_runner_fake.go
@@ -54,6 +54,8 @@ type Test struct {
 	CreateMetadataFunc   func() error
 	DetachFunc           func() error
 	StartTerminalCmdFunc func(terminal *api.AttachedTerminal) error
+	MetadataFunc         func() (*api.ClientDoc, error)
+	StateFunc            func() (*api.ClientStatusMode, error)
 }
 
 // NewClientRunnerTest returns a new ClientRunnerTest instance.
@@ -131,4 +133,18 @@ func (t *Test) StartTerminalCmd(terminal *api.AttachedTerminal) error {
 		return t.StartTerminalCmdFunc(terminal)
 	}
 	return errdefs.ErrFuncNotSet
+}
+
+func (t *Test) Metadata() (*api.ClientDoc, error) {
+	if t.MetadataFunc != nil {
+		return t.MetadataFunc()
+	}
+	return nil, errdefs.ErrFuncNotSet
+}
+
+func (t *Test) State() (*api.ClientStatusMode, error) {
+	if t.StateFunc != nil {
+		return t.StateFunc()
+	}
+	return nil, errdefs.ErrFuncNotSet
 }

--- a/internal/client/clientrunner/metadata.go
+++ b/internal/client/clientrunner/metadata.go
@@ -68,6 +68,24 @@ func (sr *Exec) CreateMetadata() error {
 	return nil
 }
 
+// Metadata returns a snapshot of the runner's ClientDoc. The returned
+// pointer is a deep copy — callers may freely mutate it without
+// racing the runner's own metadata writes.
+func (sr *Exec) Metadata() (*api.ClientDoc, error) {
+	sr.metadataMu.RLock()
+	defer sr.metadataMu.RUnlock()
+	doc := sr.metadata
+	return &doc, nil
+}
+
+// State returns the current lifecycle state of the client.
+func (sr *Exec) State() (*api.ClientStatusMode, error) {
+	sr.metadataMu.RLock()
+	defer sr.metadataMu.RUnlock()
+	state := sr.metadata.Status.State
+	return &state, nil
+}
+
 func (sr *Exec) updateMetadata() error {
 	sr.metadataMu.RLock()
 	metadataCopy := sr.metadata

--- a/internal/client/controller.go
+++ b/internal/client/controller.go
@@ -393,3 +393,42 @@ func (s *Controller) Detach() error {
 	}
 	return nil
 }
+
+func (s *Controller) Ping(in *api.PingMessage) (*api.PingMessage, error) {
+	if in != nil && in.Message == "PING" {
+		return &api.PingMessage{Message: "PONG"}, nil
+	}
+	msg := ""
+	if in != nil {
+		msg = in.Message
+	}
+	return &api.PingMessage{}, fmt.Errorf("unexpected ping message: %s", msg)
+}
+
+func (s *Controller) Metadata() (*api.ClientDoc, error) {
+	if s.sr == nil {
+		return nil, errors.New("client runner not initialized")
+	}
+	return s.sr.Metadata()
+}
+
+func (s *Controller) State() (*api.ClientStatusMode, error) {
+	if s.sr == nil {
+		return nil, errors.New("client runner not initialized")
+	}
+	return s.sr.State()
+}
+
+func (s *Controller) Stop(args *api.StopArgs) error {
+	reason := "stop requested"
+	if args != nil && args.Reason != "" {
+		reason = args.Reason
+	}
+	s.logger.InfoContext(s.ctx, "Stop RPC invoked", "reason", reason)
+	// Close asynchronously so the RPC reply can be written before the
+	// server socket is torn down.
+	go func() {
+		_ = s.Close(fmt.Errorf("stop: %s", reason))
+	}()
+	return nil
+}

--- a/internal/client/controller_fake.go
+++ b/internal/client/controller_fake.go
@@ -37,6 +37,10 @@ type ControllerTest struct {
 	CloseFunc     func(reason error) error
 	WaitCloseFunc func() error
 	DetachFunc    func() error
+	PingFunc      func(in *api.PingMessage) (*api.PingMessage, error)
+	MetadataFunc  func() (*api.ClientDoc, error)
+	StateFunc     func() (*api.ClientStatusMode, error)
+	StopFunc      func(args *api.StopArgs) error
 }
 
 func NewClientControllerTest() *ControllerTest {
@@ -94,6 +98,34 @@ func (t *ControllerTest) WaitClose() error {
 func (t *ControllerTest) Detach() error {
 	if t.DetachFunc != nil {
 		return t.DetachFunc()
+	}
+	return errdefs.ErrFuncNotSet
+}
+
+func (t *ControllerTest) Ping(in *api.PingMessage) (*api.PingMessage, error) {
+	if t.PingFunc != nil {
+		return t.PingFunc(in)
+	}
+	return nil, errdefs.ErrFuncNotSet
+}
+
+func (t *ControllerTest) Metadata() (*api.ClientDoc, error) {
+	if t.MetadataFunc != nil {
+		return t.MetadataFunc()
+	}
+	return nil, errdefs.ErrFuncNotSet
+}
+
+func (t *ControllerTest) State() (*api.ClientStatusMode, error) {
+	if t.StateFunc != nil {
+		return t.StateFunc()
+	}
+	return nil, errdefs.ErrFuncNotSet
+}
+
+func (t *ControllerTest) Stop(args *api.StopArgs) error {
+	if t.StopFunc != nil {
+		return t.StopFunc(args)
 	}
 	return errdefs.ErrFuncNotSet
 }

--- a/internal/client/controller_rpcs_test.go
+++ b/internal/client/controller_rpcs_test.go
@@ -1,0 +1,167 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/internal/client/clientrunner"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+func newControllerForRPCTest(t *testing.T, runner *clientrunner.Test) *Controller {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	c := NewClientController(context.Background(), logger).(*Controller)
+	if runner != nil {
+		c.sr = runner
+	}
+	return c
+}
+
+func TestController_Ping_Pong(t *testing.T) {
+	t.Parallel()
+	c := newControllerForRPCTest(t, nil)
+	out, err := c.Ping(&api.PingMessage{Message: "PING"})
+	if err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	if out.Message != "PONG" {
+		t.Fatalf("Ping reply = %q; want PONG", out.Message)
+	}
+}
+
+func TestController_Ping_RejectsUnknownMessage(t *testing.T) {
+	t.Parallel()
+	c := newControllerForRPCTest(t, nil)
+	if _, err := c.Ping(&api.PingMessage{Message: "huh"}); err == nil {
+		t.Fatalf("Ping err = nil; want non-nil for unknown message")
+	}
+}
+
+func TestController_Metadata_DelegatesToRunner(t *testing.T) {
+	t.Parallel()
+	want := &api.ClientDoc{
+		Metadata: api.ClientMetadata{Name: "delegate"},
+		Spec:     api.ClientSpec{ID: "c-9"},
+		Status:   api.ClientStatus{State: api.ClientReady, Pid: 7},
+	}
+	runner := &clientrunner.Test{
+		MetadataFunc: func() (*api.ClientDoc, error) { return want, nil },
+	}
+	c := newControllerForRPCTest(t, runner)
+	got, err := c.Metadata()
+	if err != nil {
+		t.Fatalf("Metadata: %v", err)
+	}
+	if got != want {
+		t.Fatalf("Metadata = %p; want %p", got, want)
+	}
+}
+
+func TestController_Metadata_NoRunner(t *testing.T) {
+	t.Parallel()
+	c := newControllerForRPCTest(t, nil)
+	if _, err := c.Metadata(); err == nil {
+		t.Fatalf("Metadata err = nil; want runner-not-init error")
+	}
+}
+
+func TestController_State_DelegatesToRunner(t *testing.T) {
+	t.Parallel()
+	state := api.ClientAttached
+	runner := &clientrunner.Test{
+		StateFunc: func() (*api.ClientStatusMode, error) { return &state, nil },
+	}
+	c := newControllerForRPCTest(t, runner)
+	got, err := c.State()
+	if err != nil {
+		t.Fatalf("State: %v", err)
+	}
+	if *got != api.ClientAttached {
+		t.Fatalf("State = %v; want %v", *got, api.ClientAttached)
+	}
+}
+
+func TestController_State_NoRunner(t *testing.T) {
+	t.Parallel()
+	c := newControllerForRPCTest(t, nil)
+	if _, err := c.State(); err == nil {
+		t.Fatalf("State err = nil; want runner-not-init error")
+	}
+}
+
+func TestController_Stop_TriggersAsyncClose(t *testing.T) {
+	t.Parallel()
+	closed := make(chan error, 1)
+	runner := &clientrunner.Test{
+		CloseFunc: func(reason error) error {
+			select {
+			case closed <- reason:
+			default:
+			}
+			return nil
+		},
+	}
+	c := newControllerForRPCTest(t, runner)
+
+	if err := c.Stop(&api.StopArgs{Reason: "stop-reason"}); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	select {
+	case reason := <-closed:
+		if reason == nil || !strings.Contains(reason.Error(), "stop-reason") {
+			t.Fatalf("Close reason = %v; want to contain %q", reason, "stop-reason")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Close was not triggered by Stop")
+	}
+}
+
+func TestController_Stop_NilArgsUsesDefaultReason(t *testing.T) {
+	t.Parallel()
+	closed := make(chan error, 1)
+	runner := &clientrunner.Test{
+		CloseFunc: func(reason error) error {
+			select {
+			case closed <- reason:
+			default:
+			}
+			return nil
+		},
+	}
+	c := newControllerForRPCTest(t, runner)
+
+	if err := c.Stop(nil); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	select {
+	case reason := <-closed:
+		if reason == nil {
+			t.Fatalf("expected non-nil close reason on Stop(nil)")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Close was not triggered by Stop(nil)")
+	}
+}
+

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -22,6 +22,10 @@ type ClientController interface {
 	Close(reason error) error
 	WaitClose() error
 	Detach() error
+	Ping(ping *PingMessage) (*PingMessage, error)
+	Metadata() (*ClientDoc, error)
+	State() (*ClientStatusMode, error)
+	Stop(args *StopArgs) error
 }
 
 type ClientSpec struct {
@@ -108,5 +112,9 @@ type AttachedTerminal struct {
 const ClientService = "ClientController"
 
 const (
-	ClientMethodDetach = ClientService + ".Detach"
+	ClientMethodDetach   = ClientService + ".Detach"
+	ClientMethodPing     = ClientService + ".Ping"
+	ClientMethodMetadata = ClientService + ".Metadata"
+	ClientMethodState    = ClientService + ".State"
+	ClientMethodStop     = ClientService + ".Stop"
 )

--- a/pkg/rpcclient/client/iface.go
+++ b/pkg/rpcclient/client/iface.go
@@ -18,9 +18,15 @@ package client
 
 import (
 	"context"
+
+	"github.com/eminwux/sbsh/pkg/api"
 )
 
 type Client interface {
 	Detach(ctx context.Context) error
+	Ping(ctx context.Context, ping *api.PingMessage, pong *api.PingMessage) error
+	Metadata(ctx context.Context, doc *api.ClientDoc) error
+	State(ctx context.Context, state *api.ClientStatusMode) error
+	Stop(ctx context.Context, args *api.StopArgs) error
 	Close() error
 }

--- a/pkg/rpcclient/client/rpc_client.go
+++ b/pkg/rpcclient/client/rpc_client.go
@@ -64,3 +64,35 @@ func (c *client) call(ctx context.Context, method string, in, out any) error {
 func (c *client) Detach(ctx context.Context) error {
 	return c.call(ctx, api.ClientMethodDetach, &api.Empty{}, &api.Empty{})
 }
+
+func (c *client) Ping(ctx context.Context, ping *api.PingMessage, pong *api.PingMessage) error {
+	if ping == nil {
+		ping = &api.PingMessage{}
+	}
+	if pong == nil {
+		return c.call(ctx, api.ClientMethodPing, ping, &api.PingMessage{})
+	}
+	return c.call(ctx, api.ClientMethodPing, ping, pong)
+}
+
+func (c *client) Metadata(ctx context.Context, doc *api.ClientDoc) error {
+	if doc == nil {
+		return c.call(ctx, api.ClientMethodMetadata, &api.Empty{}, &api.ClientDoc{})
+	}
+	return c.call(ctx, api.ClientMethodMetadata, &api.Empty{}, doc)
+}
+
+func (c *client) State(ctx context.Context, state *api.ClientStatusMode) error {
+	if state == nil {
+		var dummy api.ClientStatusMode
+		return c.call(ctx, api.ClientMethodState, &api.Empty{}, &dummy)
+	}
+	return c.call(ctx, api.ClientMethodState, &api.Empty{}, state)
+}
+
+func (c *client) Stop(ctx context.Context, args *api.StopArgs) error {
+	if args == nil {
+		args = &api.StopArgs{}
+	}
+	return c.call(ctx, api.ClientMethodStop, args, &api.Empty{})
+}

--- a/pkg/rpcclient/client/rpc_client_test.go
+++ b/pkg/rpcclient/client/rpc_client_test.go
@@ -1,0 +1,240 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unix
+
+package client_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	internalclient "github.com/eminwux/sbsh/internal/client"
+	"github.com/eminwux/sbsh/internal/client/clientrpc"
+	"github.com/eminwux/sbsh/pkg/api"
+	rpcclient "github.com/eminwux/sbsh/pkg/rpcclient/client"
+)
+
+// startTestServer wires a real net/rpc JSON server backed by the given
+// fake controller, listening on a tempdir Unix socket. The server runs
+// until the test ends. Returns the socket path so callers can dial it
+// with rpcclient.NewUnix.
+func startTestServer(t *testing.T, core *internalclient.ControllerTest) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "client.sock")
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	srv := rpc.NewServer()
+	if err := srv.RegisterName(api.ClientService, &clientrpc.ClientControllerRPC{Core: core}); err != nil {
+		_ = ln.Close()
+		t.Fatalf("RegisterName: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			conn, errAccept := ln.Accept()
+			if errAccept != nil {
+				return
+			}
+			go srv.ServeCodec(jsonrpc.NewServerCodec(conn))
+		}
+	}()
+
+	t.Cleanup(func() {
+		_ = ln.Close()
+		wg.Wait()
+	})
+
+	return sockPath
+}
+
+func TestClient_Ping_Roundtrip(t *testing.T) {
+	t.Parallel()
+	var gotIn *api.PingMessage
+	core := &internalclient.ControllerTest{
+		PingFunc: func(in *api.PingMessage) (*api.PingMessage, error) {
+			gotIn = in
+			return &api.PingMessage{Message: "PONG"}, nil
+		},
+	}
+
+	sock := startTestServer(t, core)
+	c := rpcclient.NewUnix(sock)
+	t.Cleanup(func() { _ = c.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	out := &api.PingMessage{}
+	if err := c.Ping(ctx, &api.PingMessage{Message: "PING"}, out); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	if out.Message != "PONG" {
+		t.Fatalf("Ping reply = %q; want PONG", out.Message)
+	}
+	if gotIn == nil || gotIn.Message != "PING" {
+		t.Fatalf("server saw %+v; want PING", gotIn)
+	}
+}
+
+func TestClient_Ping_PropagatesError(t *testing.T) {
+	t.Parallel()
+	core := &internalclient.ControllerTest{
+		PingFunc: func(_ *api.PingMessage) (*api.PingMessage, error) {
+			return nil, errors.New("nope")
+		},
+	}
+	sock := startTestServer(t, core)
+	c := rpcclient.NewUnix(sock)
+	t.Cleanup(func() { _ = c.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := c.Ping(ctx, &api.PingMessage{Message: "PING"}, &api.PingMessage{}); err == nil {
+		t.Fatalf("Ping err = nil; want non-nil")
+	}
+}
+
+func TestClient_Metadata_Roundtrip(t *testing.T) {
+	t.Parallel()
+	want := &api.ClientDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindClient,
+		Metadata: api.ClientMetadata{
+			Name:   "rpc-test",
+			Labels: map[string]string{"k": "v"},
+		},
+		Spec:   api.ClientSpec{ID: "c-rpc", LogFile: "/tmp/log"},
+		Status: api.ClientStatus{Pid: 999, State: api.ClientReady},
+	}
+	core := &internalclient.ControllerTest{
+		MetadataFunc: func() (*api.ClientDoc, error) { return want, nil },
+	}
+	sock := startTestServer(t, core)
+	c := rpcclient.NewUnix(sock)
+	t.Cleanup(func() { _ = c.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	got := &api.ClientDoc{}
+	if err := c.Metadata(ctx, got); err != nil {
+		t.Fatalf("Metadata: %v", err)
+	}
+	if got.Metadata.Name != "rpc-test" || got.Spec.ID != "c-rpc" ||
+		got.Status.Pid != 999 || got.Status.State != api.ClientReady {
+		t.Fatalf("Metadata reply = %+v; want %+v", got, want)
+	}
+	if got.Metadata.Labels["k"] != "v" {
+		t.Fatalf("Metadata labels not preserved: %+v", got.Metadata.Labels)
+	}
+}
+
+func TestClient_State_Roundtrip(t *testing.T) {
+	t.Parallel()
+	state := api.ClientAttached
+	core := &internalclient.ControllerTest{
+		StateFunc: func() (*api.ClientStatusMode, error) { return &state, nil },
+	}
+	sock := startTestServer(t, core)
+	c := rpcclient.NewUnix(sock)
+	t.Cleanup(func() { _ = c.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	got := api.ClientInitializing
+	if err := c.State(ctx, &got); err != nil {
+		t.Fatalf("State: %v", err)
+	}
+	if got != api.ClientAttached {
+		t.Fatalf("State reply = %v; want %v", got, api.ClientAttached)
+	}
+}
+
+func TestClient_Stop_PassesReason(t *testing.T) {
+	t.Parallel()
+	var gotArgs *api.StopArgs
+	done := make(chan struct{})
+	core := &internalclient.ControllerTest{
+		StopFunc: func(args *api.StopArgs) error {
+			gotArgs = args
+			close(done)
+			return nil
+		},
+	}
+	sock := startTestServer(t, core)
+	c := rpcclient.NewUnix(sock)
+	t.Cleanup(func() { _ = c.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := c.Stop(ctx, &api.StopArgs{Reason: "test"}); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("server Stop not invoked")
+	}
+	if gotArgs == nil || gotArgs.Reason != "test" {
+		t.Fatalf("Stop args = %+v; want Reason=%q", gotArgs, "test")
+	}
+}
+
+func TestClient_Detach_StillWorks(t *testing.T) {
+	t.Parallel()
+	called := make(chan struct{})
+	core := &internalclient.ControllerTest{
+		DetachFunc: func() error {
+			close(called)
+			return nil
+		},
+	}
+	sock := startTestServer(t, core)
+	c := rpcclient.NewUnix(sock)
+	t.Cleanup(func() { _ = c.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	if err := c.Detach(ctx); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+	select {
+	case <-called:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("server Detach not invoked")
+	}
+}

--- a/pkg/spawn/client.go
+++ b/pkg/spawn/client.go
@@ -76,9 +76,8 @@ type ClientOptions struct {
 
 // ClientHandle is a library-side handle on a spawned Client
 // subprocess. Consumers can observe lifecycle via WaitReady/WaitClose,
-// request shutdown via Close, and connect to SocketPath() for the
-// subset of ClientController RPCs currently exposed (Detach today;
-// Ping/State/Stop land in PR-E).
+// request shutdown via Close, and connect to SocketPath() to drive
+// the full ClientController RPC surface (Ping/Metadata/State/Stop/Detach).
 type ClientHandle struct {
 	doc        *api.ClientDoc
 	socketPath string
@@ -202,14 +201,10 @@ func (h *ClientHandle) SocketPath() string { return h.socketPath }
 // pointer is shared — callers must not mutate it.
 func (h *ClientHandle) Doc() *api.ClientDoc { return h.doc }
 
-// WaitReady blocks until the client's control socket file is visible
-// on disk. Until PR-E grows ClientController with a Ping RPC, socket
-// presence is the best readiness signal spawn can offer without
-// peeking at internal state. Caveat: the file appears the instant the
-// Unix listener binds, which is slightly before the client has fully
-// wired up its attach to the terminal. Callers that race into a
-// Detach() RPC immediately after WaitReady may observe a transient
-// connection refused; retry or use a small back-off until PR-E.
+// WaitReady blocks until the client's RPC server accepts a Ping on
+// its control socket. It returns early with ErrProcessExited if the
+// child dies before reaching Ready, ErrReadyTimeout if the internal
+// cap elapses, or ctx.Err() on cancellation.
 func (h *ClientHandle) WaitReady(ctx context.Context) error {
 	if h.proc.exited() {
 		return wrapProcessExited(h.proc.takeExitErr())
@@ -223,12 +218,24 @@ func (h *ClientHandle) WaitReady(ctx context.Context) error {
 		poll = defaultReadyPollInterval
 	}
 
+	rpc := clientrpc.NewUnix(h.socketPath)
+
 	for {
 		if h.proc.exited() {
 			return wrapProcessExited(h.proc.takeExitErr())
 		}
+
 		if _, err := os.Stat(h.socketPath); err == nil {
-			return nil
+			pingCtx, pingCancel := context.WithTimeout(readyCtx, poll)
+			pingErr := rpc.Ping(pingCtx, &api.PingMessage{Message: "PING"}, &api.PingMessage{})
+			pingCancel()
+			if pingErr == nil {
+				return nil
+			}
+			if h.opts.Logger != nil {
+				h.opts.Logger.DebugContext(readyCtx, "client not ready yet",
+					"socket", h.socketPath, "error", pingErr)
+			}
 		}
 
 		select {
@@ -251,25 +258,22 @@ func (h *ClientHandle) readyContext(ctx context.Context) (context.Context, conte
 	return context.WithTimeout(ctx, h.opts.ReadyTimeout)
 }
 
-// Close requests graceful shutdown: it first sends a Detach RPC over
-// the client's control socket (which causes the client to disconnect
-// from its terminal and exit), then escalates to SIGTERM and SIGKILL
-// if the child is still alive. Returns the process exit error (nil on
-// clean exit) or ctx.Err() if the caller's context is canceled
-// mid-shutdown.
-//
-// Once PR-E grows ClientController with an explicit Stop RPC, this
-// method will switch to it for a cleaner shutdown signal.
+// Close requests graceful shutdown: it first sends a Stop RPC over
+// the client's control socket (which causes the client to tear down
+// its terminal attachment and exit), then escalates to SIGTERM and
+// SIGKILL if the child is still alive. Returns the process exit
+// error (nil on clean exit) or ctx.Err() if the caller's context is
+// canceled mid-shutdown.
 func (h *ClientHandle) Close(ctx context.Context) error {
-	return h.proc.gracefulShutdown(ctx, h.opts.StopGracePeriod, h.sendDetachRPC)
+	return h.proc.gracefulShutdown(ctx, h.opts.StopGracePeriod, h.sendStopRPC)
 }
 
-func (h *ClientHandle) sendDetachRPC(ctx context.Context) error {
+func (h *ClientHandle) sendStopRPC(ctx context.Context) error {
 	if _, err := os.Stat(h.socketPath); err != nil {
 		return err
 	}
 	rpc := clientrpc.NewUnix(h.socketPath)
-	return rpc.Detach(ctx)
+	return rpc.Stop(ctx, &api.StopArgs{Reason: "spawn.Close"})
 }
 
 // WaitClose blocks until the client subprocess has fully exited or


### PR DESCRIPTION
## Summary
- Brings `ClientController` to parity with `TerminalController` so library consumers can observe and control a live `Client` process the same way they can a `Terminal` (umbrella #118, sub-PR E).
- `pkg/spawn.ClientHandle.WaitReady` now uses the new `Ping` RPC instead of polling for socket-file presence; `Close` uses the new `Stop` RPC instead of `Detach`.
- Mirrors the existing terminal-side patterns end-to-end: `pkg/api.ClientController` interface + method-name constants, server wrapper in `internal/client/clientrpc`, controller methods in `internal/client`, and matching client methods in `pkg/rpcclient/client`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/client/... ./pkg/rpcclient/... ./pkg/api/... ./pkg/spawn/...`
- [x] `go test -tags=integration ./cmd/sb/get/...`
- [x] `make sbsh-sb` and `file ./sbsh` confirms ELF binary

## Notes
Pre-existing failure on `origin/main`: `Test_HandleEvent_EvCmdExited` in `internal/terminal` hangs at `controller.go:264` (chan send blocked) and times out. Reproduced on a clean worktree of `origin/main` — unrelated to this change, which touches only `internal/client`, `pkg/api/client.go`, `pkg/rpcclient/client`, and `pkg/spawn/client.go`.

Refs umbrella: #118 (PR-E). Related: #72.

Closes #132