### PR TITLE
feat: load profiles from a directory tree

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,7 +18,7 @@
 - [ ] **A** API - Add SupervisorMetadata to SupervisorDoc
 - [ ] **A** API - Add TerminalMetadata to TerminalDoc
 - [ ] **A** Configuration - Introduce ConfigurationDoc config.yaml
-    (fields: runPath, profilesFile, logLevel)
+    (fields: runPath, profilesDir, logLevel)
 - [ ] **A** Configuration - Introduce profilesDirectory in ConfigurationDoc with conflict resolution
 - [ ] **A** Configuration - Introduce default TerminalProfileDoc in ConfigurationDoc
 - [ ] **A** Supervisor - Introduce SupervisorDoc and SupervisorProfileDoc

--- a/cmd/config/autocomplete.go
+++ b/cmd/config/autocomplete.go
@@ -26,20 +26,23 @@ import (
 	"github.com/eminwux/sbsh/pkg/api"
 )
 
-func AutoCompleteListProfileNames(ctx context.Context, logger *slog.Logger, profilesFile string) ([]string, error) {
+// AutoCompleteListProfileNames returns every profile name successfully loaded
+// from profilesDir. Warnings (malformed files, duplicate names, schema-invalid
+// documents) are swallowed so completion never fails or returns an empty list
+// just because one file is broken — users can diagnose those with
+// `sb validate profiles`.
+func AutoCompleteListProfileNames(ctx context.Context, logger *slog.Logger, profilesDir string) ([]string, error) {
 	// logger is not set on autocomplete calls
 	if logger == nil {
 		logger = logging.NewNoopLogger()
 	}
 
-	profiles, err := discovery.LoadProfilesFromPath(ctx, logger, profilesFile)
+	profiles, _, err := discovery.LoadProfilesFromDir(ctx, logger, profilesDir)
 	if err != nil {
-		if logger != nil {
-			logger.ErrorContext(ctx, "ListProfiles: failed to load profiles", "path", profilesFile, "error", err)
-		}
+		logger.ErrorContext(ctx, "ListProfiles: failed to load profiles", "dir", profilesDir, "error", err)
 		return nil, err
 	}
-	if profiles == nil {
+	if len(profiles) == 0 {
 		return nil, errors.New("no profiles found")
 	}
 

--- a/cmd/config/configuration.go
+++ b/cmd/config/configuration.go
@@ -44,8 +44,8 @@ func ApplyConfigurationDocEnv(cfgDoc *api.ConfigurationDoc) {
 	}
 	setIfUnset(SB_ROOT_RUN_PATH.EnvVar(), cfgDoc.Spec.RunPath)
 	setIfUnset(SBSH_ROOT_RUN_PATH.EnvVar(), cfgDoc.Spec.RunPath)
-	setIfUnset(SB_GET_PROFILES_FILE.EnvVar(), cfgDoc.Spec.ProfilesFile)
-	setIfUnset(SBSH_ROOT_PROFILES_FILE.EnvVar(), cfgDoc.Spec.ProfilesFile)
+	setIfUnset(SB_GET_PROFILES_DIR.EnvVar(), cfgDoc.Spec.ProfilesDir)
+	setIfUnset(SBSH_ROOT_PROFILES_DIR.EnvVar(), cfgDoc.Spec.ProfilesDir)
 	setIfUnset(SB_ROOT_LOG_LEVEL.EnvVar(), cfgDoc.Spec.LogLevel)
 	setIfUnset(SBSH_ROOT_LOG_LEVEL.EnvVar(), cfgDoc.Spec.LogLevel)
 }

--- a/cmd/config/configuration_test.go
+++ b/cmd/config/configuration_test.go
@@ -53,7 +53,7 @@ metadata:
   name: default
 spec:
   runPath: /var/run/sbsh
-  profilesFile: /etc/sbsh/profiles.yaml
+  profilesDir: /etc/sbsh/profiles.d
   logLevel: debug
 `
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
@@ -77,8 +77,8 @@ spec:
 	if got, want := doc.Spec.RunPath, "/var/run/sbsh"; got != want {
 		t.Errorf("Spec.RunPath = %q, want %q", got, want)
 	}
-	if got, want := doc.Spec.ProfilesFile, "/etc/sbsh/profiles.yaml"; got != want {
-		t.Errorf("Spec.ProfilesFile = %q, want %q", got, want)
+	if got, want := doc.Spec.ProfilesDir, "/etc/sbsh/profiles.d"; got != want {
+		t.Errorf("Spec.ProfilesDir = %q, want %q", got, want)
 	}
 	if got, want := doc.Spec.LogLevel, "debug"; got != want {
 		t.Errorf("Spec.LogLevel = %q, want %q", got, want)

--- a/cmd/config/defaults.go
+++ b/cmd/config/defaults.go
@@ -45,27 +45,31 @@ func GetRunPathFromEnvAndFlags(cmd *cobra.Command, viperKey string) (string, err
 	return runPath, nil
 }
 
-func GetProfilesFileFromEnvAndFlags(cmd *cobra.Command, viperKey string) (string, error) {
-	profilesFile, _ := cmd.Flags().GetString("profiles-file")
-	if profilesFile == "" {
-		if env := os.Getenv(viperKey); env != "" {
-			profilesFile = env
+// GetProfilesDirFromEnvAndFlags resolves the profiles directory using the
+// precedence flag > env > default. envVar is the environment variable to
+// consult when the flag is unset.
+func GetProfilesDirFromEnvAndFlags(cmd *cobra.Command, envVar string) (string, error) {
+	profilesDir, _ := cmd.Flags().GetString("profiles-dir")
+	if profilesDir == "" {
+		if env := os.Getenv(envVar); env != "" {
+			profilesDir = env
 		} else {
-			// final fallback: same default you use at runtime
-			profilesFile = DefaultProfilesFile()
+			profilesDir = DefaultProfilesDir()
 		}
 	}
-	return profilesFile, nil
+	return profilesDir, nil
 }
 
-func DefaultProfilesFile() string {
+// DefaultProfilesDir returns the default profiles directory
+// ($HOME/.sbsh/profiles.d/).
+func DefaultProfilesDir() string {
 	base, err := os.UserHomeDir()
 	if err != nil {
 		// fallback to tmp if home dir cannot be determined
 		base = "tmp"
 	}
 
-	return filepath.Join(base, ".sbsh", "profiles.yaml")
+	return filepath.Join(base, ".sbsh", "profiles.d")
 }
 
 func DefaultConfigFile() string {

--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -94,7 +94,7 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SB_ROOT_RUN_PATH = DefineKV("SB_RUN_PATH", "sb/runPath")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
-	SB_GET_PROFILES_FILE = DefineKV("SB_PROFILES_FILE", "sb/get/profilesFile")
+	SB_GET_PROFILES_DIR = DefineKV("SB_PROFILES_DIR", "sb/get/profilesDir")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SB_GET_PROFILES_OUTPUT = DefineKV("SB_PROFILES_OUTPUT", "sb/get/profiles/output")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
@@ -136,7 +136,7 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SBSH_ROOT_CONFIG_FILE = DefineKV("SBSH_CONFIG_FILE", "sbsh/configFile")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
-	SBSH_ROOT_PROFILES_FILE = DefineKV("SBSH_PROFILES_FILE", "sbsh/profilesFile")
+	SBSH_ROOT_PROFILES_DIR = DefineKV("SBSH_PROFILES_DIR", "sbsh/profilesDir")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SBSH_ROOT_LOG_LEVEL = DefineKV("SBSH_LOG_LEVEL", "sbsh/logLevel", "info")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/sb/get/get_integration_test.go
+++ b/cmd/sb/get/get_integration_test.go
@@ -206,9 +206,9 @@ spec:
   shell:
     cmd: /bin/bash
 `
-		profilesFile := createTestProfileFile(t, tmpDir, profilesYAML)
+		_ = createTestProfileFile(t, tmpDir, profilesYAML)
 
-		names, err := fetchProfileNames(ctx, profilesFile, "")
+		names, err := fetchProfileNames(ctx, tmpDir, "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -256,9 +256,9 @@ spec:
   shell:
     cmd: /bin/bash
 `
-		profilesFile := createTestProfileFile(t, tmpDir, profilesYAML)
+		_ = createTestProfileFile(t, tmpDir, profilesYAML)
 
-		names, err := fetchProfileNames(ctx, profilesFile, "k8s")
+		names, err := fetchProfileNames(ctx, tmpDir, "k8s")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -296,9 +296,9 @@ spec:
   shell:
     cmd: /bin/bash
 `
-		profilesFile := createTestProfileFile(t, tmpDir, profilesYAML)
+		_ = createTestProfileFile(t, tmpDir, profilesYAML)
 
-		names, err := fetchProfileNames(ctx, profilesFile, "")
+		names, err := fetchProfileNames(ctx, tmpDir, "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -369,11 +369,11 @@ spec:
   shell:
     cmd: /bin/bash
 `
-		profilesFile := createTestProfileFile(t, tmpDir, profilesYAML)
+		_ = createTestProfileFile(t, tmpDir, profilesYAML)
 
-		viper.Set(config.SB_GET_PROFILES_FILE.ViperKey, profilesFile)
+		viper.Set(config.SB_GET_PROFILES_DIR.ViperKey, tmpDir)
 		defer func() {
-			viper.Set(config.SB_GET_PROFILES_FILE.ViperKey, "")
+			viper.Set(config.SB_GET_PROFILES_DIR.ViperKey, "")
 		}()
 
 		output, err := captureStdout(func() {
@@ -394,11 +394,11 @@ spec:
 	t.Run("success with empty profiles file", func(t *testing.T) {
 		cmd, _ := setupTestCmd(t, logger)
 		tmpDir := t.TempDir()
-		profilesFile := createTestProfileFile(t, tmpDir, "")
+		_ = createTestProfileFile(t, tmpDir, "")
 
-		viper.Set(config.SB_GET_PROFILES_FILE.ViperKey, profilesFile)
+		viper.Set(config.SB_GET_PROFILES_DIR.ViperKey, tmpDir)
 		defer func() {
-			viper.Set(config.SB_GET_PROFILES_FILE.ViperKey, "")
+			viper.Set(config.SB_GET_PROFILES_DIR.ViperKey, "")
 		}()
 
 		output, err := captureStdout(func() {
@@ -413,17 +413,22 @@ spec:
 		}
 	})
 
-	t.Run("error when profiles file path is invalid", func(t *testing.T) {
+	t.Run("missing profiles dir is not an error", func(t *testing.T) {
 		cmd, _ := setupTestCmd(t, logger)
 
-		viper.Set(config.SB_GET_PROFILES_FILE.ViperKey, "/nonexistent/path/profiles.yaml")
+		viper.Set(config.SB_GET_PROFILES_DIR.ViperKey, "/nonexistent/path/profiles.d")
 		defer func() {
-			viper.Set(config.SB_GET_PROFILES_FILE.ViperKey, "")
+			viper.Set(config.SB_GET_PROFILES_DIR.ViperKey, "")
 		}()
 
-		err := listProfiles(cmd, []string{})
-		if err == nil {
-			t.Fatal("expected error but got nil")
+		output, err := captureStdout(func() {
+			_ = listProfiles(cmd, []string{})
+		})
+		if err != nil {
+			t.Fatalf("capture stdout: %v", err)
+		}
+		if !strings.Contains(output, "no profiles found") {
+			t.Errorf("expected 'no profiles found' for missing dir, got: %s", output)
 		}
 	})
 }
@@ -442,12 +447,12 @@ spec:
   shell:
     cmd: /bin/bash
 `
-		profilesFile := createTestProfileFile(t, tmpDir, profilesYAML)
+		_ = createTestProfileFile(t, tmpDir, profilesYAML)
 
-		viper.Set(config.SB_GET_PROFILES_FILE.ViperKey, profilesFile)
+		viper.Set(config.SB_GET_PROFILES_DIR.ViperKey, tmpDir)
 		viper.Set(config.SB_GET_PROFILES_OUTPUT.ViperKey, "")
 		defer func() {
-			viper.Set(config.SB_GET_PROFILES_FILE.ViperKey, "")
+			viper.Set(config.SB_GET_PROFILES_DIR.ViperKey, "")
 			viper.Set(config.SB_GET_PROFILES_OUTPUT.ViperKey, "")
 		}()
 
@@ -474,12 +479,12 @@ spec:
   shell:
     cmd: /bin/bash
 `
-		profilesFile := createTestProfileFile(t, tmpDir, profilesYAML)
+		_ = createTestProfileFile(t, tmpDir, profilesYAML)
 
-		viper.Set(config.SB_GET_PROFILES_FILE.ViperKey, profilesFile)
+		viper.Set(config.SB_GET_PROFILES_DIR.ViperKey, tmpDir)
 		viper.Set(config.SB_GET_PROFILES_OUTPUT.ViperKey, "json")
 		defer func() {
-			viper.Set(config.SB_GET_PROFILES_FILE.ViperKey, "")
+			viper.Set(config.SB_GET_PROFILES_DIR.ViperKey, "")
 			viper.Set(config.SB_GET_PROFILES_OUTPUT.ViperKey, "")
 		}()
 
@@ -510,12 +515,12 @@ spec:
   shell:
     cmd: /bin/bash
 `
-		profilesFile := createTestProfileFile(t, tmpDir, profilesYAML)
+		_ = createTestProfileFile(t, tmpDir, profilesYAML)
 
-		viper.Set(config.SB_GET_PROFILES_FILE.ViperKey, profilesFile)
+		viper.Set(config.SB_GET_PROFILES_DIR.ViperKey, tmpDir)
 		viper.Set(config.SB_GET_PROFILES_OUTPUT.ViperKey, "yaml")
 		defer func() {
-			viper.Set(config.SB_GET_PROFILES_FILE.ViperKey, "")
+			viper.Set(config.SB_GET_PROFILES_DIR.ViperKey, "")
 			viper.Set(config.SB_GET_PROFILES_OUTPUT.ViperKey, "")
 		}()
 
@@ -546,11 +551,11 @@ spec:
   shell:
     cmd: /bin/bash
 `
-		profilesFile := createTestProfileFile(t, tmpDir, profilesYAML)
+		_ = createTestProfileFile(t, tmpDir, profilesYAML)
 
-		viper.Set(config.SB_GET_PROFILES_FILE.ViperKey, profilesFile)
+		viper.Set(config.SB_GET_PROFILES_DIR.ViperKey, tmpDir)
 		defer func() {
-			viper.Set(config.SB_GET_PROFILES_FILE.ViperKey, "")
+			viper.Set(config.SB_GET_PROFILES_DIR.ViperKey, "")
 		}()
 
 		err := getProfile(cmd, []string{"nonexistent"})
@@ -562,9 +567,9 @@ spec:
 	t.Run("error when profiles file doesn't exist", func(t *testing.T) {
 		cmd, _ := setupTestCmd(t, logger)
 
-		viper.Set(config.SB_GET_PROFILES_FILE.ViperKey, "/nonexistent/path/profiles.yaml")
+		viper.Set(config.SB_GET_PROFILES_DIR.ViperKey, "/nonexistent/path/profiles.yaml")
 		defer func() {
-			viper.Set(config.SB_GET_PROFILES_FILE.ViperKey, "")
+			viper.Set(config.SB_GET_PROFILES_DIR.ViperKey, "")
 		}()
 
 		err := getProfile(cmd, []string{"default"})

--- a/cmd/sb/get/profiles.go
+++ b/cmd/sb/get/profiles.go
@@ -80,7 +80,7 @@ func listProfiles(cmd *cobra.Command, _ []string) error {
 	}
 
 	logger.Debug("profiles list command invoked",
-		"profiles_file", viper.GetString(config.SB_GET_PROFILES_FILE.ViperKey),
+		"profiles_dir", viper.GetString(config.SB_GET_PROFILES_DIR.ViperKey),
 		"run_path", viper.GetString(config.SB_ROOT_RUN_PATH.ViperKey),
 		"output_format", format,
 		"args", cmd.Flags().Args(),
@@ -89,8 +89,9 @@ func listProfiles(cmd *cobra.Command, _ []string) error {
 	err := discovery.ScanAndPrintProfiles(
 		cmd.Context(),
 		logger,
-		viper.GetString(config.SB_GET_PROFILES_FILE.ViperKey),
+		viper.GetString(config.SB_GET_PROFILES_DIR.ViperKey),
 		os.Stdout,
+		os.Stderr,
 		format,
 	)
 	if err != nil {
@@ -107,7 +108,7 @@ func completeProfiles(cmd *cobra.Command, args []string, toComplete string) ([]s
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	names, err := fetchProfileNames(cmd.Context(), viper.GetString(config.SB_GET_PROFILES_FILE.ViperKey), toComplete)
+	names, err := fetchProfileNames(cmd.Context(), viper.GetString(config.SB_GET_PROFILES_DIR.ViperKey), toComplete)
 	if err != nil {
 		// Optionally show an error message in completion
 		return []string{"__error: cannot list profiles"}, cobra.ShellCompDirectiveNoFileComp
@@ -155,8 +156,9 @@ func getProfile(cmd *cobra.Command, args []string) error {
 	return discovery.FindAndPrintProfileMetadata(
 		cmd.Context(),
 		logger,
-		viper.GetString(config.SB_GET_PROFILES_FILE.ViperKey),
+		viper.GetString(config.SB_GET_PROFILES_DIR.ViperKey),
 		os.Stdout,
+		os.Stderr,
 		profileName,
 		format,
 	)

--- a/cmd/sb/sb.go
+++ b/cmd/sb/sb.go
@@ -176,12 +176,12 @@ func LoadConfig() error {
 	}
 	config.SB_ROOT_RUN_PATH.SetDefault(runPath)
 
-	_ = config.SB_GET_PROFILES_FILE.BindEnv()
-	profilesFile := config.DefaultProfilesFile()
-	if cfgDoc != nil && cfgDoc.Spec.ProfilesFile != "" {
-		profilesFile = cfgDoc.Spec.ProfilesFile
+	_ = config.SB_GET_PROFILES_DIR.BindEnv()
+	profilesDir := config.DefaultProfilesDir()
+	if cfgDoc != nil && cfgDoc.Spec.ProfilesDir != "" {
+		profilesDir = cfgDoc.Spec.ProfilesDir
 	}
-	config.SB_GET_PROFILES_FILE.SetDefault(profilesFile)
+	config.SB_GET_PROFILES_DIR.SetDefault(profilesDir)
 
 	_ = config.SBSH_ROOT_LOG_LEVEL.BindEnv()
 	logLevel := "info"

--- a/cmd/sb/sb_test.go
+++ b/cmd/sb/sb_test.go
@@ -99,7 +99,7 @@ func Test_LoadConfig_HappyPath(t *testing.T) {
 	t.Setenv(config.SBSH_ROOT_CONFIG_FILE.EnvVar(), missingCfg)
 	_ = config.SBSH_ROOT_CONFIG_FILE.BindEnv()
 	t.Setenv(config.SB_ROOT_RUN_PATH.EnvVar(), "")
-	t.Setenv(config.SB_GET_PROFILES_FILE.EnvVar(), "")
+	t.Setenv(config.SB_GET_PROFILES_DIR.EnvVar(), "")
 	t.Setenv(config.SBSH_ROOT_LOG_LEVEL.EnvVar(), "")
 
 	if err := LoadConfig(); err != nil {
@@ -110,8 +110,8 @@ func Test_LoadConfig_HappyPath(t *testing.T) {
 		t.Fatalf("expected run path %s, got %s", want, got)
 	}
 
-	if got, want := viper.GetString(config.SB_GET_PROFILES_FILE.ViperKey), config.DefaultProfilesFile(); got != want {
-		t.Fatalf("expected get profiles file %s, got %s", want, got)
+	if got, want := viper.GetString(config.SB_GET_PROFILES_DIR.ViperKey), config.DefaultProfilesDir(); got != want {
+		t.Fatalf("expected get profiles dir %s, got %s", want, got)
 	}
 
 	if got := viper.GetString(config.SBSH_ROOT_LOG_LEVEL.ViperKey); got != "info" {
@@ -133,7 +133,7 @@ metadata:
   name: default
 spec:
   runPath: /tmp/sbsh-test-run
-  profilesFile: /tmp/sbsh-test-profiles.yaml
+  profilesDir: /tmp/sbsh-test-profiles.d
   logLevel: debug
 `
 	if err := os.WriteFile(cfgPath, []byte(content), 0o600); err != nil {
@@ -142,7 +142,7 @@ spec:
 
 	t.Setenv(config.SBSH_ROOT_CONFIG_FILE.EnvVar(), cfgPath)
 	t.Setenv(config.SB_ROOT_RUN_PATH.EnvVar(), "")
-	t.Setenv(config.SB_GET_PROFILES_FILE.EnvVar(), "")
+	t.Setenv(config.SB_GET_PROFILES_DIR.EnvVar(), "")
 	t.Setenv(config.SBSH_ROOT_LOG_LEVEL.EnvVar(), "")
 
 	_ = config.SBSH_ROOT_CONFIG_FILE.BindEnv()
@@ -154,8 +154,8 @@ spec:
 	if got, want := viper.GetString(config.SB_ROOT_RUN_PATH.ViperKey), "/tmp/sbsh-test-run"; got != want {
 		t.Errorf("run path = %q, want %q", got, want)
 	}
-	if got, want := viper.GetString(config.SB_GET_PROFILES_FILE.ViperKey), "/tmp/sbsh-test-profiles.yaml"; got != want {
-		t.Errorf("profiles file = %q, want %q", got, want)
+	if got, want := viper.GetString(config.SB_GET_PROFILES_DIR.ViperKey), "/tmp/sbsh-test-profiles.d"; got != want {
+		t.Errorf("profiles dir = %q, want %q", got, want)
 	}
 	if got, want := viper.GetString(config.SBSH_ROOT_LOG_LEVEL.ViperKey), "debug"; got != want {
 		t.Errorf("log level = %q, want %q", got, want)

--- a/cmd/sb/validate/profiles.go
+++ b/cmd/sb/validate/profiles.go
@@ -19,13 +19,18 @@ package validate
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/eminwux/sbsh/cmd/config"
 	"github.com/eminwux/sbsh/cmd/types"
 	"github.com/eminwux/sbsh/internal/errdefs"
 	"github.com/eminwux/sbsh/internal/profile"
+	pkgdiscovery "github.com/eminwux/sbsh/pkg/discovery"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -42,8 +47,16 @@ fields are checked, runTarget and restartPolicy are validated against the
 accepted enum values, and shell.cmd is checked against $PATH when
 runTarget is "local".
 
-The path argument is optional; when omitted, the profiles file from
-configuration (SB_PROFILES_FILE or --config) is validated.`,
+The path argument is optional. When omitted, the profiles directory from
+configuration (SB_PROFILES_DIR / --profiles-dir / config.yaml) is scanned
+recursively and every *.yaml / *.yml file is validated. When a file is
+passed explicitly, only that file is validated.
+
+Along with per-document validation errors, this command surfaces
+directory-level warnings such as malformed YAML files, documents missing
+required fields, and duplicate profile names — so users whose shell
+completion looks empty can run this to see exactly what the loader
+rejected.`,
 		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -51,6 +64,15 @@ configuration (SB_PROFILES_FILE or --config) is validated.`,
 		},
 	}
 	return cmd
+}
+
+// fileValidation groups the per-document validation results for a single
+// YAML file, together with the (partial) parse error that aborted reading
+// that file if any.
+type fileValidation struct {
+	Path       string
+	Results    []profile.ProfileValidationResult
+	DecodeErr  error
 }
 
 func runValidateProfiles(cmd *cobra.Command, args []string, stdout, stderr io.Writer) error {
@@ -62,55 +84,150 @@ func runValidateProfiles(cmd *cobra.Command, args []string, stdout, stderr io.Wr
 	path := resolveProfilesPath(args)
 	logger.Debug("validate profiles invoked", "path", path)
 
-	results, err := profile.ValidateProfilesFromPath(cmd.Context(), logger, path)
-	if err != nil && len(results) == 0 {
+	files, warnings, err := expandPath(cmd, logger, path)
+	if err != nil {
 		return err
 	}
 
-	return reportResults(stdout, stderr, path, results, err)
+	validations, err := validateFiles(cmd, logger, files)
+	if err != nil {
+		return err
+	}
+
+	return reportResults(stdout, stderr, path, validations, warnings)
 }
 
+// resolveProfilesPath picks the path to validate: CLI arg wins, otherwise
+// the configured profiles directory.
 func resolveProfilesPath(args []string) string {
 	if len(args) == 1 && args[0] != "" {
 		return args[0]
 	}
-	return viper.GetString(config.SB_GET_PROFILES_FILE.ViperKey)
+	return viper.GetString(config.SB_GET_PROFILES_DIR.ViperKey)
+}
+
+// expandPath resolves the target to concrete files to validate. When path is
+// a directory, files are discovered via the same loader the runtime uses, so
+// any duplicate-name / malformed-YAML warnings surface here identically to
+// how the CLI would see them. When path is a file, the list is just that one
+// file.
+func expandPath(cmd *cobra.Command, logger *slog.Logger, path string) ([]string, []pkgdiscovery.ProfileWarning, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("stat %q: %w", path, err)
+	}
+
+	if !info.IsDir() {
+		return []string{path}, nil, nil
+	}
+
+	_, warnings, err := pkgdiscovery.LoadProfilesFromDir(cmd.Context(), logger, path)
+	if err != nil {
+		return nil, warnings, err
+	}
+
+	var files []string
+	walkErr := filepath.WalkDir(path, func(p string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(p))
+		if ext == ".yaml" || ext == ".yml" {
+			files = append(files, p)
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return nil, warnings, fmt.Errorf("walk %q: %w", path, walkErr)
+	}
+	sort.Strings(files)
+	return files, warnings, nil
+}
+
+func validateFiles(cmd *cobra.Command, logger *slog.Logger, files []string) ([]fileValidation, error) {
+	var out []fileValidation
+	for _, f := range files {
+		results, err := profile.ValidateProfilesFromPath(cmd.Context(), logger, f)
+		// Surface the error only when nothing could be validated, so one
+		// corrupt file does not silence every other.
+		if err != nil && len(results) == 0 {
+			out = append(out, fileValidation{Path: f, DecodeErr: err})
+			continue
+		}
+		out = append(out, fileValidation{Path: f, Results: results, DecodeErr: err})
+	}
+	return out, nil
 }
 
 func reportResults(
 	stdout, stderr io.Writer,
-	path string,
-	results []profile.ProfileValidationResult,
-	decodeErr error,
+	target string,
+	validations []fileValidation,
+	warnings []pkgdiscovery.ProfileWarning,
 ) error {
-	fmt.Fprintf(stdout, "Validating %s\n", path)
+	fmt.Fprintf(stdout, "Validating %s\n", target)
 
-	invalid := 0
-	for _, r := range results {
-		label := formatLabel(r)
-		if r.OK() {
-			fmt.Fprintf(stdout, "  [OK]     %s\n", label)
-			continue
+	var (
+		totalDocs      int
+		invalidDocs    int
+		hadDecodeError bool
+	)
+	for _, v := range validations {
+		if v.DecodeErr != nil {
+			hadDecodeError = true
 		}
-		invalid++
-		fmt.Fprintf(stdout, "  [INVALID] %s\n", label)
-		for _, e := range r.Errors {
-			fmt.Fprintf(stdout, "    - %s\n", e)
+		if len(validations) > 1 {
+			fmt.Fprintf(stdout, "\n%s\n", v.Path)
+		}
+		for _, r := range v.Results {
+			totalDocs++
+			label := formatLabel(r)
+			if r.OK() {
+				fmt.Fprintf(stdout, "  [OK]     %s\n", label)
+				continue
+			}
+			invalidDocs++
+			fmt.Fprintf(stdout, "  [INVALID] %s\n", label)
+			for _, e := range r.Errors {
+				fmt.Fprintf(stdout, "    - %s\n", e)
+			}
+		}
+		if v.DecodeErr != nil {
+			fmt.Fprintf(stderr, "warning: %s: %v\n", v.Path, v.DecodeErr)
 		}
 	}
 
-	total := len(results)
-	valid := total - invalid
-	fmt.Fprintf(stdout, "%d profile(s): %d valid, %d invalid\n", total, valid, invalid)
-
-	if decodeErr != nil {
-		fmt.Fprintf(stderr, "warning: stopped at unrecoverable parse error: %v\n", decodeErr)
+	// Directory-level warnings (malformed files, duplicate names, unsupported
+	// kind, missing required fields) go to stdout so `sb validate profiles`
+	// is a self-contained diagnostic report for shell-completion users, then
+	// also to stderr so interactive pipelines see them.
+	if len(warnings) > 0 {
+		fmt.Fprintln(stdout, "\nLoader warnings:")
+		for _, w := range warnings {
+			fmt.Fprintf(stdout, "  - %s\n", w)
+		}
 	}
 
-	if invalid > 0 || decodeErr != nil {
+	valid := totalDocs - invalidDocs
+	fmt.Fprintf(stdout, "\n%d profile(s): %d valid, %d invalid; %d loader warning(s)\n",
+		totalDocs, valid, invalidDocs, len(warnings))
+
+	if invalidDocs > 0 || hadDecodeError || hasBlockingWarning(warnings) {
 		return errdefs.ErrInvalidProfiles
 	}
 	return nil
+}
+
+// hasBlockingWarning returns true when at least one loader warning indicates
+// that a document or file was actually rejected (as opposed to a harmless
+// duplicate note). We treat every warning as blocking today: a duplicate
+// profile name still means a profile got shadowed, which is almost certainly
+// something the user wants to know before shipping.
+func hasBlockingWarning(warnings []pkgdiscovery.ProfileWarning) bool {
+	return len(warnings) > 0
 }
 
 func formatLabel(r profile.ProfileValidationResult) string {
@@ -119,3 +236,4 @@ func formatLabel(r profile.ProfileValidationResult) string {
 	}
 	return fmt.Sprintf("document %d (%s)", r.DocIndex, r.ProfileName)
 }
+

--- a/cmd/sb/validate/profiles_test.go
+++ b/cmd/sb/validate/profiles_test.go
@@ -107,3 +107,51 @@ func TestValidateProfilesCmd_MissingFile(t *testing.T) {
 		t.Fatal("expected error for missing file")
 	}
 }
+
+func TestValidateProfilesCmd_DirWithDuplicatesAndMalformed(t *testing.T) {
+	dir := t.TempDir()
+	writeFile := func(name, body string) {
+		t.Helper()
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	writeFile("a-good.yaml", `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: dup
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/sh
+`)
+	writeFile("b-dup.yaml", `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: dup
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/sh
+`)
+	writeFile("c-bad.yaml", "apiVersion: sbsh/v1beta1\nkind: TerminalProfile\n  bad: indent\n  broken:\n")
+
+	stdout, stderr, err := runCmd(t, []string{dir})
+	if !errors.Is(err, errdefs.ErrInvalidProfiles) {
+		t.Fatalf("expected ErrInvalidProfiles, got %v (stderr: %s)", err, stderr)
+	}
+	if !strings.Contains(stdout, "Loader warnings:") {
+		t.Fatalf("expected loader warnings section in stdout, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "duplicate profile name") {
+		t.Fatalf("expected duplicate warning, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "malformed YAML") {
+		t.Fatalf("expected malformed YAML warning, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "a-good.yaml") {
+		t.Fatalf("expected per-file report for a-good.yaml, got: %s", stdout)
+	}
+}

--- a/cmd/sbsh/sbsh.go
+++ b/cmd/sbsh/sbsh.go
@@ -120,7 +120,7 @@ You can also use sbsh with parameters. For example:
 				"runPath", viper.GetString(config.SBSH_ROOT_RUN_PATH.ViperKey),
 				"configFile", viper.GetString(config.SBSH_ROOT_CONFIG_FILE.ViperKey),
 				"logLevel", viper.GetString(config.SBSH_ROOT_LOG_LEVEL.ViperKey),
-				"profilesFile", viper.GetString(config.SBSH_ROOT_PROFILES_FILE.ViperKey),
+				"profilesDir", viper.GetString(config.SBSH_ROOT_PROFILES_DIR.ViperKey),
 				"terminalID", viper.GetString(config.SBSH_ROOT_TERM_ID.ViperKey),
 				"terminalCommand", viper.GetString(config.SBSH_ROOT_TERM_COMMAND.ViperKey),
 				"terminalName", viper.GetString(config.SBSH_ROOT_TERM_NAME.ViperKey),
@@ -160,7 +160,7 @@ You can also use sbsh with parameters. For example:
 					TerminalCmd:      viper.GetString(config.SBSH_ROOT_TERM_COMMAND.ViperKey),
 					CaptureFile:      viper.GetString(config.SBSH_ROOT_TERM_CAPTURE_FILE.ViperKey),
 					RunPath:          viper.GetString(config.SBSH_ROOT_RUN_PATH.ViperKey),
-					ProfilesFile:     viper.GetString(config.SBSH_ROOT_PROFILES_FILE.ViperKey),
+					ProfilesDir:      viper.GetString(config.SBSH_ROOT_PROFILES_DIR.ViperKey),
 					ProfileName:      viper.GetString(config.SBSH_ROOT_TERM_PROFILE.ViperKey),
 					LogFile:          viper.GetString(config.SBSH_ROOT_TERM_LOG_FILE.ViperKey),
 					LogLevel:         viper.GetString(config.SBSH_ROOT_TERM_LOG_LEVEL.ViperKey),
@@ -244,8 +244,14 @@ func setPersistentLoggingFlags(rootCmd *cobra.Command) error {
 		return err
 	}
 
-	rootCmd.PersistentFlags().String("profiles", "", "profiles manifests file")
-	if err := viper.BindPFlag(config.SBSH_ROOT_PROFILES_FILE.ViperKey, rootCmd.PersistentFlags().Lookup("profiles")); err != nil {
+	rootCmd.PersistentFlags().String(
+		"profiles-dir", "",
+		"Directory scanned for TerminalProfile YAML documents (default: $HOME/.sbsh/profiles.d/)",
+	)
+	if err := viper.BindPFlag(
+		config.SBSH_ROOT_PROFILES_DIR.ViperKey,
+		rootCmd.PersistentFlags().Lookup("profiles-dir"),
+	); err != nil {
 		return err
 	}
 
@@ -452,12 +458,12 @@ func LoadConfig() error {
 	}
 	config.SBSH_ROOT_RUN_PATH.SetDefault(runPath)
 
-	_ = config.SBSH_ROOT_PROFILES_FILE.BindEnv()
-	profilesFile := config.DefaultProfilesFile()
-	if cfgDoc != nil && cfgDoc.Spec.ProfilesFile != "" {
-		profilesFile = cfgDoc.Spec.ProfilesFile
+	_ = config.SBSH_ROOT_PROFILES_DIR.BindEnv()
+	profilesDir := config.DefaultProfilesDir()
+	if cfgDoc != nil && cfgDoc.Spec.ProfilesDir != "" {
+		profilesDir = cfgDoc.Spec.ProfilesDir
 	}
-	config.SBSH_ROOT_PROFILES_FILE.SetDefault(profilesFile)
+	config.SBSH_ROOT_PROFILES_DIR.SetDefault(profilesDir)
 
 	_ = config.SBSH_ROOT_LOG_LEVEL.BindEnv()
 	logLevel := "info"
@@ -515,12 +521,12 @@ func setAutoCompleteProfile(rootCmd *cobra.Command) error {
 			//nolint:mnd // 150ms is a good compromise between snappy completion and enough time to read files
 			ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
 			defer cancel()
-			profilesFile, err := config.GetProfilesFileFromEnvAndFlags(c, config.SBSH_ROOT_PROFILES_FILE.EnvVar())
+			profilesDir, err := config.GetProfilesDirFromEnvAndFlags(c, config.SBSH_ROOT_PROFILES_DIR.EnvVar())
 			if err != nil {
 				// fail silent to keep completion snappy
 				return nil, cobra.ShellCompDirectiveNoFileComp
 			}
-			profs, err := config.AutoCompleteListProfileNames(ctx, nil, profilesFile)
+			profs, err := config.AutoCompleteListProfileNames(ctx, nil, profilesDir)
 			if err != nil {
 				// fail silent to keep completion snappy
 				return nil, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/sbsh/terminal/terminal.go
+++ b/cmd/sbsh/terminal/terminal.go
@@ -86,7 +86,7 @@ func buildTerminalSpecFromFlags(cmd *cobra.Command, logger *slog.Logger) (*api.T
 			TerminalCmd:      viper.GetString(config.SBSH_TERM_COMMAND.ViperKey),
 			CaptureFile:      viper.GetString(config.SBSH_TERM_CAPTURE_FILE.ViperKey),
 			RunPath:          viper.GetString(config.SB_ROOT_RUN_PATH.ViperKey),
-			ProfilesFile:     viper.GetString(config.SBSH_ROOT_PROFILES_FILE.ViperKey),
+			ProfilesDir:      viper.GetString(config.SBSH_ROOT_PROFILES_DIR.ViperKey),
 			ProfileName:      viper.GetString(config.SBSH_TERM_PROFILE.ViperKey),
 			LogFile:          viper.GetString(config.SBSH_TERM_LOG_FILE.ViperKey),
 			LogLevel:         viper.GetString(config.SBSH_TERM_LOG_LEVEL.ViperKey),

--- a/docs/README.md
+++ b/docs/README.md
@@ -486,4 +486,4 @@ Use profiles with the `-p` flag:
 $ sbsh -p my-profile
 ```
 
-Profiles are loaded from `~/.sbsh/profiles.yaml` by default, or you can specify a custom location with `--profiles-file` or `SBSH_PROFILES_FILE` environment variable.
+Profiles are loaded from `~/.sbsh/profiles.d/` by default. The directory is scanned recursively for `*.yaml` and `*.yml` files — split profiles across as many files as you like. Override the location with `--profiles-dir` or the `SBSH_PROFILES_DIR` environment variable.

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -18,7 +18,7 @@ Use profiles for pre-commit hooks, local testing, and development workflows:
 ### Pre-commit Hook Example
 
 ```yaml
-# ~/.sbsh/profiles.yaml
+# ~/.sbsh/profiles.d/ci.yaml
 apiVersion: sbsh/v1beta1
 kind: TerminalProfile
 metadata:
@@ -78,7 +78,7 @@ jobs:
       - name: Create test profile
         run: |
           mkdir -p ~/.sbsh
-          cat > ~/.sbsh/profiles.yaml <<EOF
+          mkdir -p ~/.sbsh/profiles.d && cat > ~/.sbsh/profiles.d/ci.yaml <<EOF
           apiVersion: sbsh/v1beta1
           kind: TerminalProfile
           metadata:
@@ -123,9 +123,9 @@ Instead of creating profiles inline, you can use profiles checked into your repo
 - name: Copy profiles from repository
   run: |
     mkdir -p ~/.sbsh
-    cp .github/profiles/ci-test.yaml ~/.sbsh/profiles.yaml
+    mkdir -p ~/.sbsh/profiles.d && cp .github/profiles/ci-test.yaml ~/.sbsh/profiles.d/
     # Or combine multiple profiles
-    cat .github/profiles/*.yaml > ~/.sbsh/profiles.yaml
+    mkdir -p ~/.sbsh/profiles.d && cp .github/profiles/*.yaml ~/.sbsh/profiles.d/
 ```
 
 ## GitLab CI/CD
@@ -159,7 +159,7 @@ test:
   script:
     - |
       mkdir -p ~/.sbsh
-      cat > ~/.sbsh/profiles.yaml <<EOF
+      mkdir -p ~/.sbsh/profiles.d && cat > ~/.sbsh/profiles.d/ci.yaml <<EOF
       apiVersion: sbsh/v1beta1
       kind: TerminalProfile
       metadata:
@@ -197,7 +197,7 @@ test:
 test:
   script:
     - mkdir -p ~/.sbsh
-    - cp .gitlab/profiles/ci-test.yaml ~/.sbsh/profiles.yaml
+    - mkdir -p ~/.sbsh/profiles.d && cp .gitlab/profiles/ci-test.yaml ~/.sbsh/profiles.d/
     - sbsh -p ci-test --name "gitlab-$CI_JOB_ID"
 ```
 
@@ -241,7 +241,7 @@ pipeline {
             steps {
                 sh '''
                     mkdir -p ~/.sbsh
-                    cat > ~/.sbsh/profiles.yaml <<EOF
+                    mkdir -p ~/.sbsh/profiles.d && cat > ~/.sbsh/profiles.d/ci.yaml <<EOF
                     apiVersion: sbsh/v1beta1
                     kind: TerminalProfile
                     metadata:
@@ -297,7 +297,7 @@ node {
     stage('Create Profile') {
         sh """
             mkdir -p ~/.sbsh
-            cat > ~/.sbsh/profiles.yaml <<EOF
+            mkdir -p ~/.sbsh/profiles.d && cat > ~/.sbsh/profiles.d/ci.yaml <<EOF
             apiVersion: sbsh/v1beta1
             kind: TerminalProfile
             metadata:
@@ -341,7 +341,7 @@ stage('Copy Profiles') {
     steps {
         sh '''
             mkdir -p ~/.sbsh
-            cp jenkins/profiles/ci-test.yaml ~/.sbsh/profiles.yaml
+            mkdir -p ~/.sbsh/profiles.d && cp jenkins/profiles/ci-test.yaml ~/.sbsh/profiles.d/
         '''
     }
 }
@@ -419,7 +419,7 @@ jobs:
 
 **Solutions**:
 
-- Verify profile file path: `~/.sbsh/profiles.yaml` by default
+- Verify profile file path: `~/.sbsh/profiles.d/` by default
 - Check profile name matches exactly (case-sensitive)
 - Ensure profile is created before running `sbsh -p`
 - Use `sb get profiles` to list available profiles

--- a/docs/container.md
+++ b/docs/container.md
@@ -189,7 +189,7 @@ The `~/.sbsh` directory contains:
 
 - **`~/.sbsh/run/terminals/`**: Terminal metadata and socket files
 - **`~/.sbsh/run/supervisors/`**: Supervisor metadata
-- **`~/.sbsh/profiles.yaml`**: Profile definitions (optional)
+- **`~/.sbsh/profiles.d/`**: Profile definitions (optional)
 
 ### Using Named Volumes
 
@@ -283,7 +283,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy custom profiles
-COPY profiles.yaml /root/.sbsh/profiles.yaml
+COPY profiles.d/ /root/.sbsh/profiles.d/
 
 # Set working directory
 WORKDIR /workspace
@@ -318,7 +318,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy custom profiles
-COPY profiles.yaml /root/.sbsh/profiles.yaml
+COPY profiles.d/ /root/.sbsh/profiles.d/
 
 # Set working directory
 WORKDIR /workspace
@@ -520,9 +520,9 @@ spec:
 
 **Solutions**:
 
-- Mount profile file: `-v ~/.sbsh/profiles.yaml:/root/.sbsh/profiles.yaml`
+- Mount profiles directory: `-v ~/.sbsh/profiles.d:/root/.sbsh/profiles.d:ro`
 - Copy profile during image build (if using as base image)
-- Verify profile path in container: `/root/.sbsh/profiles.yaml`
+- Verify profiles directory in container: `/root/.sbsh/profiles.d/`
 - Use `sb get profiles` to list available profiles
 
 ### Architecture Mismatch

--- a/docs/gap-analysis.md
+++ b/docs/gap-analysis.md
@@ -98,18 +98,17 @@ Implemented via a new `sb stop terminal <name>` command.
 - **Complexity:** Medium. Requires always-on capture (small buffer or
   on-disk ring).
 
-### 6. Profiles must live in one file  (P2)
+### 6. Profiles must live in one file  (P2) — RESOLVED
 
-- **Observed:** `~/.sbsh/profiles.yaml` holds all profiles separated by
-  `---`. Editing one profile touches the shared file; concurrent edits by
-  agents/tools risk corruption.
-- **Impact:** Hard to manage when profile count grows (user already has
-  `aleph`, `bernard`, `sbsh-dev`, `kukeon-dev`, and planned
-  `*-dev0/1/2`, `*-reviewer0/1`).
-- **Fix:** Support a `~/.sbsh/profiles.d/*.yaml` overlay directory (in
-  addition to the single file for backward compat). Load, validate, and
-  merge by `metadata.name`.
-- **Complexity:** Low–medium.
+- **Observed (historical):** `~/.sbsh/profiles.yaml` held all profiles separated
+  by `---`. Editing one profile touched the shared file; concurrent edits by
+  agents/tools risked corruption.
+- **Resolution:** Profiles are now loaded from
+  `~/.sbsh/profiles.d/` (recursive scan of `*.yaml` / `*.yml`).
+  Loader returns warnings instead of aborting on per-file errors, and
+  `sb validate profiles` surfaces them for users whose completion looks
+  empty. The single-file layout is no longer read — breaking change,
+  users migrate by dropping their profiles into `profiles.d/`.
 
 ### 7. `onInit` semantics undocumented  (P2)
 
@@ -188,5 +187,5 @@ Implemented via a new `sb stop terminal <name>` command.
   already introduced wide output — follow the same pattern).
 - Lifecycle code (`OnInit`, `PostAttach`, `Close`) is in
   `internal/terminal/terminalrunner/lifecycle.go`.
-- Do not delete `~/.sbsh/profiles.yaml` parsing when adding
-  `profiles.d/` — merge both sources.
+- `profiles.d/` replaces `~/.sbsh/profiles.yaml` (breaking change).
+  The single-file path is no longer read.

--- a/docs/profiles/README.md
+++ b/docs/profiles/README.md
@@ -6,32 +6,32 @@ Profiles define how sbsh starts and manages terminals. They let you customize th
 
 ### Where to put your profiles
 
-sbsh looks for profiles in `$HOME/.sbsh/profiles.yaml` by default. You can also specify a different file using:
+sbsh scans `$HOME/.sbsh/profiles.d/` recursively by default, loading every `*.yaml` / `*.yml` file it finds. Split profiles across as many files and subdirectories as you like — one profile per file, one file per project, or one multi-document file that groups related profiles. You can also specify a different directory using:
 
-- Environment variable: `SBSH_PROFILES_FILE=/path/to/profiles.yaml`
-- Command flag: `sbsh --profiles-file /path/to/profiles.yaml`
+- Environment variable: `SBSH_PROFILES_DIR=/path/to/profiles.d`
+- Command flag: `sbsh --profiles-dir /path/to/profiles.d`
+
+> **Breaking change**: earlier releases loaded a single `$HOME/.sbsh/profiles.yaml` file. That path is no longer read. Move your profiles into `$HOME/.sbsh/profiles.d/` — split as individual files or keep one combined multi-document YAML, whichever you prefer.
 
 ### Create your first profile
 
 1. Create the profiles directory (if it doesn't exist):
 
    ```bash
-   mkdir -p ~/.sbsh
+   mkdir -p ~/.sbsh/profiles.d
    ```
 
-2. Copy example profiles to get started:
+2. Copy example profiles to get started. Any combination below works because the loader scans the whole directory:
 
    ```bash
-   # Copy the combined profiles file
-   cp docs/profiles/profiles.yaml ~/.sbsh/profiles.yaml
+   # Drop one pre-combined file
+   cp docs/profiles/profiles.yaml ~/.sbsh/profiles.d/examples.yaml
 
-   # Or combine individual example files (provided for reference)
-   cat docs/profiles/*.yaml > ~/.sbsh/profiles.yaml
+   # Or drop individual example files
+   cp docs/profiles/default.yaml docs/profiles/python-venv.yaml ~/.sbsh/profiles.d/
    ```
 
-   **Note**: sbsh only supports a single `profiles.yaml` file. The individual `.yaml` files in `docs/profiles/` are provided as reference examples, but you must combine them into one file for use.
-
-3. Edit `~/.sbsh/profiles.yaml` and add your own profiles.
+3. Add your own profiles as new `*.yaml` files under `~/.sbsh/profiles.d/`.
 
 ### Minimal example
 
@@ -192,7 +192,7 @@ Lifecycle hooks that run at specific points in the terminal lifecycle.
 
 ## Example Profiles
 
-This directory contains example profiles. The individual `.yaml` files are provided for reference, but sbsh only supports a single `profiles.yaml` file. All profiles must be combined into one file with `---` separators between documents.
+This directory contains example profiles. Each individual `.yaml` file is a complete, standalone `TerminalProfile` document — drop any subset of them into `~/.sbsh/profiles.d/` and sbsh will load them. The combined [`profiles.yaml`](./profiles.yaml) is also a valid multi-document file you can drop in as-is.
 
 ### Profile Examples Index
 
@@ -219,16 +219,16 @@ This directory contains example profiles. The individual `.yaml` files are provi
 | `mysql`             | MySQL database shell for database operations and debugging      | [`mysql.yaml`](./mysql.yaml)                         | [Section 19](#19-mysql---mysql-database-shell)                    |
 | `mongo`             | MongoDB database shell for database operations and debugging    | [`mongo.yaml`](./mongo.yaml)                         | [Section 20](#20-mongo---mongodb-database-shell)                  |
 
-All profiles are also available in [`profiles.yaml`](./profiles.yaml) as a combined file ready to use.
+All profiles are also available in [`profiles.yaml`](./profiles.yaml) as a combined multi-document file ready to use.
 
 **To use these profiles:**
 
 ```bash
-# Copy the combined file
-cp docs/profiles/profiles.yaml ~/.sbsh/profiles.yaml
+# Drop the combined multi-document file
+cp docs/profiles/profiles.yaml ~/.sbsh/profiles.d/examples.yaml
 
-# Or copy specific example files and combine them
-cat docs/profiles/default.yaml docs/profiles/python-venv.yaml > ~/.sbsh/profiles.yaml
+# Or drop individual example files — each is already a valid standalone profile
+cp docs/profiles/default.yaml docs/profiles/python-venv.yaml ~/.sbsh/profiles.d/
 ```
 
 ## Example Profiles Explained
@@ -673,9 +673,10 @@ Connects to a MongoDB database using the `mongosh` CLI (MongoDB Shell). Perfect 
 **Solutions:**
 
 - Check the profile name matches exactly (case-sensitive)
-- Verify `~/.sbsh/profiles.yaml` exists
+- Verify `~/.sbsh/profiles.d/` exists and contains at least one `*.yaml` / `*.yml` file
 - Run `sb get profiles` to see available profiles
-- Check if you're using a custom profiles file path
+- If completion or `sb get profiles` looks empty or short, run `sb validate profiles` — it lists every malformed file, schema-invalid document, and duplicate profile name the loader skipped
+- Check if you're using a custom profiles directory path (`--profiles-dir` or `SBSH_PROFILES_DIR`)
 
 ### Environment variables not working
 
@@ -731,7 +732,7 @@ Connects to a MongoDB database using the `mongosh` CLI (MongoDB Shell). Perfect 
 
 ## Viewing Available Profiles
 
-List all profiles in your profiles file:
+List all profiles discovered under your profiles directory:
 
 ```bash
 sb get profiles
@@ -744,45 +745,61 @@ This shows:
 - Number of environment variables
 - Command that will be executed
 
-## Custom Profile File Location
+If shell completion for `sbsh -p` looks empty or short, run `sb validate profiles` — it scans the same directory and lists every malformed file, schema-invalid document, and duplicate profile name the loader skipped.
 
-By default, sbsh uses `~/.sbsh/profiles.yaml`. To use a different location:
+## Custom Profile Directory Location
+
+By default, sbsh scans `~/.sbsh/profiles.d/`. To use a different directory:
 
 **Using environment variable:**
 
 ```bash
-export SBSH_PROFILES_FILE=/path/to/custom/profiles.yaml
+export SBSH_PROFILES_DIR=/path/to/custom/profiles.d
 sbsh -p my-profile
 ```
 
 **Using command flag:**
 
 ```bash
-sbsh --profiles-file /path/to/custom/profiles.yaml -p my-profile
+sbsh --profiles-dir /path/to/custom/profiles.d -p my-profile
 ```
+
+The flag overrides the environment variable, which overrides the built-in default.
 
 ## Profile File Organization
 
-sbsh loads all profiles from a single `profiles.yaml` file. Multiple profiles are defined in the same file, separated by `---` (YAML document separator).
+sbsh scans the profiles directory recursively and loads every `*.yaml` / `*.yml` file. Each file may contain a single profile or several documents separated by `---`. There is no required layout — group profiles by project, by environment, or leave them all flat — whatever fits your workflow.
 
-Example profiles are provided as individual files in this directory for reference and documentation purposes. To use them, you must combine them into a single `profiles.yaml` file:
+Resilience guarantees:
+
+- A malformed YAML file never prevents other files from loading; the offending file is named in a loader warning.
+- A schema-invalid document (missing `apiVersion` / `kind` / `metadata.name`) never prevents other documents from loading.
+- Duplicate profile names are resolved first-wins (lexicographic load order); each duplicate is reported as a warning naming both the skipped file and the file that won.
+
+Warnings are printed to stderr by interactive commands and listed in full by `sb validate profiles`.
+
+Example layouts that all work:
 
 ```bash
-# Copy the pre-combined file (recommended)
-cp docs/profiles/profiles.yaml ~/.sbsh/profiles.yaml
+# Flat, one file per profile
+~/.sbsh/profiles.d/default.yaml
+~/.sbsh/profiles.d/k8s.yaml
 
-# Or combine specific example files
-cat docs/profiles/default.yaml docs/profiles/python-venv.yaml > ~/.sbsh/profiles.yaml
+# Grouped per tool
+~/.sbsh/profiles.d/k8s/staging.yaml
+~/.sbsh/profiles.d/k8s/production.yaml
+~/.sbsh/profiles.d/aws/admin.yaml
+
+# A single combined multi-document file
+~/.sbsh/profiles.d/all.yaml
 ```
-
-**Important**: sbsh only reads from a single `profiles.yaml` file. The individual `.yaml` files in `docs/profiles/` are examples for reference only.
 
 ## Contributing Examples
 
 Found a useful profile pattern? We'd love to see it! Consider opening a pull request with:
 
-- Your profile as a new file in `docs/profiles/` (e.g., `my-profile.yaml`) - provided as a reference example
-- Add the profile to `docs/profiles/profiles.yaml` (the combined file) with `---` separator
+- Your profile as a new file in `docs/profiles/` (e.g., `my-profile.yaml`)
+- Add the profile to `docs/profiles/profiles.yaml` (the combined file) with a `---` separator
 - Update this README to document the new profile
 - A brief description of the use case
 - Any special requirements or setup instructions

--- a/docs/site/cli/sbsh.md
+++ b/docs/site/cli/sbsh.md
@@ -50,7 +50,7 @@ These flags apply to all `sbsh` commands:
 
 - `--run-path <path>`: Optional run path for the client
 - `--config <file>`: Config file (default: `$HOME/.sbsh/config.yaml`). See the [Configuration guide](../guides/configuration.md) for the `Configuration` document schema.
-- `--profiles <file>`: Profiles manifests file (default: `$HOME/.sbsh/profiles.yaml`)
+- `--profiles-dir <path>`: Directory scanned recursively for `TerminalProfile` YAML documents (default: `$HOME/.sbsh/profiles.d/`)
 
 ### Client Flags
 
@@ -134,7 +134,7 @@ sbsh autocomplete zsh
 
 ## Environment Variables
 
-- `SBSH_PROFILES_FILE`: Path to profiles file (overrides `--profiles`)
+- `SBSH_PROFILES_DIR`: Path to profiles directory (overrides `--profiles-dir`; default `$HOME/.sbsh/profiles.d/`)
 - `SBSH_ROOT_CLIENT_SOCKET`: Default client socket path
 - `SBSH_CLIENT_ID`, `SBSH_CLIENT_NAME`, `SBSH_CLIENT_SOCKET`: Client identity overrides
 - `SBSH_CLIENT_LOG_FILE`, `SBSH_CLIENT_LOG_LEVEL`: Client logging overrides

--- a/docs/site/concepts/profiles.md
+++ b/docs/site/concepts/profiles.md
@@ -44,7 +44,7 @@ spec:
 
 ## Profile Storage
 
-Profiles are stored in `~/.sbsh/profiles.yaml` by default. Multiple profiles are defined in the same file, separated by `---` (YAML document separator).
+Profiles live under `~/.sbsh/profiles.d/` by default. sbsh scans the directory recursively and loads every `*.yaml` / `*.yml` file, so you can keep one profile per file, group related profiles into subdirectories, or combine several into a single multi-document YAML (documents separated by `---`). Point sbsh at a different directory with `--profiles-dir` or `SBSH_PROFILES_DIR`.
 
 ## Profile Discovery
 

--- a/docs/site/faq.md
+++ b/docs/site/faq.md
@@ -48,11 +48,11 @@ Terminals are independent processes and continue running even if the client exit
 
 ### Where are profiles stored?
 
-Profiles are stored in `~/.sbsh/profiles.yaml` by default. You can specify a different location using the `SBSH_PROFILES_FILE` environment variable or `--profiles-file` flag.
+Profiles are loaded from `~/.sbsh/profiles.d/` by default. The directory is scanned recursively and every `*.yaml` / `*.yml` file is read, so you can organise profiles however you like — one profile per file, grouped into subdirectories, or combined into a single multi-document YAML. You can point sbsh at a different directory with the `SBSH_PROFILES_DIR` environment variable or `--profiles-dir` flag.
 
 ### Can I use multiple profile files?
 
-Currently, sbsh supports a single `profiles.yaml` file. Multiple profiles are defined in the same file, separated by `---` (YAML document separator). See the [Profiles Guide](guides/profiles.md) for details.
+Yes — sbsh scans `~/.sbsh/profiles.d/` recursively and loads every `*.yaml` / `*.yml` file it finds, so you can split profiles across as many files (and subdirectories) as you like. Each file may hold a single profile or multiple documents separated by `---`. See the [Profiles Guide](guides/profiles.md) for details.
 
 ### How do I create a profile?
 
@@ -63,9 +63,10 @@ See the [Create Your First Profile](tutorials/create-your-first-profile.md) tuto
 ### Profile not found
 
 - Check the profile name matches exactly (case-sensitive)
-- Verify `~/.sbsh/profiles.yaml` exists
+- Verify `~/.sbsh/profiles.d/` exists and contains at least one `*.yaml` / `*.yml` file
 - Run `sb get profiles` to see available profiles
-- Check if you're using a custom profiles file path
+- If completion or `sb get profiles` looks empty or short, run `sb validate profiles` — it lists every malformed file, schema-invalid document, and duplicate profile name the loader skipped
+- Check if you're using a custom profiles directory path (`--profiles-dir` or `SBSH_PROFILES_DIR`)
 
 ### Terminal not starting
 

--- a/docs/site/guides/cicd.md
+++ b/docs/site/guides/cicd.md
@@ -18,7 +18,7 @@ Use profiles for pre-commit hooks, local testing, and development workflows:
 ### Pre-commit Hook Example
 
 ```yaml
-# ~/.sbsh/profiles.yaml
+# ~/.sbsh/profiles.d/ci.yaml
 apiVersion: sbsh/v1beta1
 kind: TerminalProfile
 metadata:
@@ -78,7 +78,7 @@ jobs:
       - name: Create test profile
         run: |
           mkdir -p ~/.sbsh
-          cat > ~/.sbsh/profiles.yaml <<EOF
+          mkdir -p ~/.sbsh/profiles.d && cat > ~/.sbsh/profiles.d/ci.yaml <<EOF
           apiVersion: sbsh/v1beta1
           kind: TerminalProfile
           metadata:
@@ -123,9 +123,9 @@ Instead of creating profiles inline, you can use profiles checked into your repo
 - name: Copy profiles from repository
   run: |
     mkdir -p ~/.sbsh
-    cp .github/profiles/ci-test.yaml ~/.sbsh/profiles.yaml
+    mkdir -p ~/.sbsh/profiles.d && cp .github/profiles/ci-test.yaml ~/.sbsh/profiles.d/
     # Or combine multiple profiles
-    cat .github/profiles/*.yaml > ~/.sbsh/profiles.yaml
+    mkdir -p ~/.sbsh/profiles.d && cp .github/profiles/*.yaml ~/.sbsh/profiles.d/
 ```
 
 ## GitLab CI/CD
@@ -159,7 +159,7 @@ test:
   script:
     - |
       mkdir -p ~/.sbsh
-      cat > ~/.sbsh/profiles.yaml <<EOF
+      mkdir -p ~/.sbsh/profiles.d && cat > ~/.sbsh/profiles.d/ci.yaml <<EOF
       apiVersion: sbsh/v1beta1
       kind: TerminalProfile
       metadata:
@@ -197,7 +197,7 @@ test:
 test:
   script:
     - mkdir -p ~/.sbsh
-    - cp .gitlab/profiles/ci-test.yaml ~/.sbsh/profiles.yaml
+    - mkdir -p ~/.sbsh/profiles.d && cp .gitlab/profiles/ci-test.yaml ~/.sbsh/profiles.d/
     - sbsh -p ci-test --name "gitlab-$CI_JOB_ID"
 ```
 
@@ -241,7 +241,7 @@ pipeline {
             steps {
                 sh '''
                     mkdir -p ~/.sbsh
-                    cat > ~/.sbsh/profiles.yaml <<EOF
+                    mkdir -p ~/.sbsh/profiles.d && cat > ~/.sbsh/profiles.d/ci.yaml <<EOF
                     apiVersion: sbsh/v1beta1
                     kind: TerminalProfile
                     metadata:
@@ -297,7 +297,7 @@ node {
     stage('Create Profile') {
         sh """
             mkdir -p ~/.sbsh
-            cat > ~/.sbsh/profiles.yaml <<EOF
+            mkdir -p ~/.sbsh/profiles.d && cat > ~/.sbsh/profiles.d/ci.yaml <<EOF
             apiVersion: sbsh/v1beta1
             kind: TerminalProfile
             metadata:
@@ -341,7 +341,7 @@ stage('Copy Profiles') {
     steps {
         sh '''
             mkdir -p ~/.sbsh
-            cp jenkins/profiles/ci-test.yaml ~/.sbsh/profiles.yaml
+            mkdir -p ~/.sbsh/profiles.d && cp jenkins/profiles/ci-test.yaml ~/.sbsh/profiles.d/
         '''
     }
 }
@@ -419,7 +419,7 @@ jobs:
 
 **Solutions**:
 
-- Verify profile file path: `~/.sbsh/profiles.yaml` by default
+- Verify profile file path: `~/.sbsh/profiles.d/` by default
 - Check profile name matches exactly (case-sensitive)
 - Ensure profile is created before running `sbsh -p`
 - Use `sb get profiles` to list available profiles

--- a/docs/site/guides/configuration.md
+++ b/docs/site/guides/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-sbsh reads user-level defaults from a single YAML file shaped as a `Configuration` document. The file sets defaults for the run path, profiles file, and log level; any CLI flag or environment variable still overrides what the document declares.
+sbsh reads user-level defaults from a single YAML file shaped as a `Configuration` document. The file sets defaults for the run path, profiles directory, and log level; any CLI flag or environment variable still overrides what the document declares.
 
 ## File location
 
@@ -23,7 +23,7 @@ metadata:
   name: default
 spec:
   runPath: /path/to/state-root         # optional, default $HOME/.sbsh/run
-  profilesFile: /path/to/profiles.yaml # optional, default $HOME/.sbsh/profiles.yaml
+  profilesDir: /path/to/profiles.d     # optional, default $HOME/.sbsh/profiles.d
   logLevel: info                       # optional, default info (debug|info|warn|error)
 ```
 
@@ -31,21 +31,21 @@ All fields under `spec` are optional. An empty or missing field keeps the built-
 
 ### Fields
 
-| Field               | Description                                                                 |
-| ------------------- | --------------------------------------------------------------------------- |
-| `apiVersion`        | Must be `sbsh/v1beta1`.                                                     |
-| `kind`              | Must be `Configuration`. Any other kind is rejected.                        |
-| `metadata.name`     | Free-form label for the document. Optional.                                 |
-| `spec.runPath`      | Root directory where sbsh writes per-terminal and per-client state.         |
-| `spec.profilesFile` | Path to the YAML file containing `TerminalProfile` documents.               |
-| `spec.logLevel`     | Default log level when `--log-level` and `SBSH_LOG_LEVEL` are not provided. |
+| Field              | Description                                                                                           |
+| ------------------ | ----------------------------------------------------------------------------------------------------- |
+| `apiVersion`       | Must be `sbsh/v1beta1`.                                                                               |
+| `kind`             | Must be `Configuration`. Any other kind is rejected.                                                  |
+| `metadata.name`    | Free-form label for the document. Optional.                                                           |
+| `spec.runPath`     | Root directory where sbsh writes per-terminal and per-client state.                                   |
+| `spec.profilesDir` | Directory scanned recursively for `*.yaml` / `*.yml` files containing `TerminalProfile` documents.    |
+| `spec.logLevel`    | Default log level when `--log-level` and `SBSH_LOG_LEVEL` are not provided.                           |
 
 ## Precedence
 
 For each setting, the first source that provides a non-empty value wins:
 
-1. CLI flag (e.g. `--run-path`, `--profiles`, `--log-level`)
-2. Environment variable (e.g. `SBSH_RUN_PATH`, `SBSH_PROFILES_FILE`, `SBSH_LOG_LEVEL`)
+1. CLI flag (e.g. `--run-path`, `--profiles-dir`, `--log-level`)
+2. Environment variable (e.g. `SBSH_RUN_PATH`, `SBSH_PROFILES_DIR`, `SBSH_LOG_LEVEL`)
 3. `spec` value from `config.yaml`
 4. Built-in default
 
@@ -58,8 +58,8 @@ metadata:
   name: default
 spec:
   runPath: /var/lib/sbsh
-  profilesFile: /etc/sbsh/profiles.yaml
+  profilesDir: /etc/sbsh/profiles.d
   logLevel: debug
 ```
 
-With this file in place, running `sbsh` without any flags uses `/var/lib/sbsh` as the run path, loads profiles from `/etc/sbsh/profiles.yaml`, and logs at `debug` level.
+With this file in place, running `sbsh` without any flags uses `/var/lib/sbsh` as the run path, loads profiles recursively from `/etc/sbsh/profiles.d`, and logs at `debug` level.

--- a/docs/site/guides/container.md
+++ b/docs/site/guides/container.md
@@ -189,7 +189,7 @@ The `~/.sbsh` directory contains:
 
 - **`~/.sbsh/run/terminals/`**: Terminal metadata and socket files
 - **`~/.sbsh/run/clients/`**: Client metadata
-- **`~/.sbsh/profiles.yaml`**: Profile definitions (optional)
+- **`~/.sbsh/profiles.d/`**: Profile definitions (optional)
 
 ### Using Named Volumes
 
@@ -283,7 +283,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy custom profiles
-COPY profiles.yaml /root/.sbsh/profiles.yaml
+COPY profiles.d/ /root/.sbsh/profiles.d/
 
 # Set working directory
 WORKDIR /workspace
@@ -318,7 +318,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy custom profiles
-COPY profiles.yaml /root/.sbsh/profiles.yaml
+COPY profiles.d/ /root/.sbsh/profiles.d/
 
 # Set working directory
 WORKDIR /workspace
@@ -520,9 +520,9 @@ spec:
 
 **Solutions**:
 
-- Mount profile file: `-v ~/.sbsh/profiles.yaml:/root/.sbsh/profiles.yaml`
+- Mount profiles directory: `-v ~/.sbsh/profiles.d:/root/.sbsh/profiles.d:ro`
 - Copy profile during image build (if using as base image)
-- Verify profile path in container: `/root/.sbsh/profiles.yaml`
+- Verify profiles directory in container: `/root/.sbsh/profiles.d/`
 - Use `sb get profiles` to list available profiles
 
 ### Architecture Mismatch

--- a/docs/site/guides/profiles.md
+++ b/docs/site/guides/profiles.md
@@ -6,33 +6,32 @@ Profiles define how sbsh starts and manages terminals. They let you customize th
 
 ### Where to put your profiles
 
-sbsh looks for profiles in `$HOME/.sbsh/profiles.yaml` by default. You can also specify a different file using:
+sbsh scans `$HOME/.sbsh/profiles.d/` recursively by default, loading every `*.yaml` / `*.yml` file it finds. Split profiles across as many files and subdirectories as you like — one profile per file, one file per project, or one multi-document file that groups related profiles. You can also specify a different directory using:
 
-- Environment variable: `SBSH_PROFILES_FILE=/path/to/profiles.yaml`
-- Command flag: `sbsh --profiles-file /path/to/profiles.yaml`
+- Environment variable: `SBSH_PROFILES_DIR=/path/to/profiles.d`
+- Command flag: `sbsh --profiles-dir /path/to/profiles.d`
+
+> **Breaking change**: earlier releases loaded a single `$HOME/.sbsh/profiles.yaml` file. That path is no longer read. Move your profiles into `$HOME/.sbsh/profiles.d/` — split as individual files or keep one combined multi-document YAML, whichever you prefer.
 
 ### Create your first profile
 
 1. Create the profiles directory (if it doesn't exist):
 
    ```bash
-   mkdir -p ~/.sbsh
+   mkdir -p ~/.sbsh/profiles.d
    ```
 
-2. Copy example profiles to get started:
+2. Copy example profiles to get started. Any combination below works because the loader scans the whole directory:
 
    ```bash
-   # Copy the combined profiles file
-   # Copy example profiles from the repository
-   cp <repository-root>/docs/profiles/profiles.yaml ~/.sbsh/profiles.yaml
+   # Drop one pre-combined file
+   cp <repository-root>/docs/profiles/profiles.yaml ~/.sbsh/profiles.d/examples.yaml
 
-   # Or combine individual example files (provided for reference)
-   cat <repository-root>/docs/profiles/*.yaml > ~/.sbsh/profiles.yaml
+   # Or drop individual example files — each is already a valid standalone profile
+   cp <repository-root>/docs/profiles/default.yaml <repository-root>/docs/profiles/python-venv.yaml ~/.sbsh/profiles.d/
    ```
 
-   **Note**: sbsh only supports a single `profiles.yaml` file. The individual `.yaml` files in the repository's `docs/profiles/` directory are provided as reference examples, but you must combine them into one file for use.
-
-3. Edit `~/.sbsh/profiles.yaml` and add your own profiles.
+3. Add your own profiles as new `*.yaml` files under `~/.sbsh/profiles.d/`.
 
 ### Minimal example
 
@@ -193,7 +192,7 @@ Lifecycle hooks that run at specific points in the terminal lifecycle.
 
 ## Example Profiles
 
-This directory contains example profiles. The individual `.yaml` files are provided for reference, but sbsh only supports a single `profiles.yaml` file. All profiles must be combined into one file with `---` separators between documents.
+This directory contains example profiles. Each individual `.yaml` file is a complete, standalone `TerminalProfile` document — drop any subset of them into `~/.sbsh/profiles.d/` and sbsh will load them. The combined [`profiles.yaml`](./profiles/profiles.yaml) is also a valid multi-document file you can drop in as-is.
 
 ### Profile Examples Index
 
@@ -220,16 +219,16 @@ This directory contains example profiles. The individual `.yaml` files are provi
 | `mysql`             | MySQL database shell for database operations and debugging      | [`mysql.yaml`](./profiles/mysql.yaml)                         | [Section 19](#19-mysql-mysql-database-shell)                    |
 | `mongo`             | MongoDB database shell for database operations and debugging    | [`mongo.yaml`](./profiles/mongo.yaml)                         | [Section 20](#20-mongo-mongodb-database-shell)                  |
 
-All profiles are also available in [`profiles.yaml`](./profiles/profiles.yaml) as a combined file ready to use.
+All profiles are also available in [`profiles.yaml`](./profiles/profiles.yaml) as a combined multi-document file ready to use.
 
 **To use these profiles:**
 
 ```bash
-# Copy the combined file
-cp docs/profiles/profiles.yaml ~/.sbsh/profiles.yaml
+# Drop the combined multi-document file
+cp docs/profiles/profiles.yaml ~/.sbsh/profiles.d/examples.yaml
 
-# Or copy specific example files and combine them
-cat docs/profiles/default.yaml docs/profiles/python-venv.yaml > ~/.sbsh/profiles.yaml
+# Or drop individual example files — each is already a valid standalone profile
+cp docs/profiles/default.yaml docs/profiles/python-venv.yaml ~/.sbsh/profiles.d/
 ```
 
 ## Example Profiles Explained
@@ -674,9 +673,10 @@ Connects to a MongoDB database using the `mongosh` CLI (MongoDB Shell). Perfect 
 **Solutions:**
 
 - Check the profile name matches exactly (case-sensitive)
-- Verify `~/.sbsh/profiles.yaml` exists
+- Verify `~/.sbsh/profiles.d/` exists and contains at least one `*.yaml` / `*.yml` file
 - Run `sb get profiles` to see available profiles
-- Check if you're using a custom profiles file path
+- If completion or `sb get profiles` looks empty or short, run `sb validate profiles` — it lists every malformed file, schema-invalid document, and duplicate profile name the loader skipped
+- Check if you're using a custom profiles directory path (`--profiles-dir` or `SBSH_PROFILES_DIR`)
 
 ### Environment variables not working
 
@@ -732,7 +732,7 @@ Connects to a MongoDB database using the `mongosh` CLI (MongoDB Shell). Perfect 
 
 ## Viewing Available Profiles
 
-List all profiles in your profiles file:
+List all profiles discovered under your profiles directory:
 
 ```bash
 sb get profiles
@@ -745,46 +745,61 @@ This shows:
 - Number of environment variables
 - Command that will be executed
 
-## Custom Profile File Location
+If shell completion for `sbsh -p` looks empty or short, run `sb validate profiles` — it scans the same directory and lists every malformed file, schema-invalid document, and duplicate profile name the loader skipped.
 
-By default, sbsh uses `~/.sbsh/profiles.yaml`. To use a different location:
+## Custom Profile Directory Location
+
+By default, sbsh scans `~/.sbsh/profiles.d/`. To use a different directory:
 
 **Using environment variable:**
 
 ```bash
-export SBSH_PROFILES_FILE=/path/to/custom/profiles.yaml
+export SBSH_PROFILES_DIR=/path/to/custom/profiles.d
 sbsh -p my-profile
 ```
 
 **Using command flag:**
 
 ```bash
-sbsh --profiles-file /path/to/custom/profiles.yaml -p my-profile
+sbsh --profiles-dir /path/to/custom/profiles.d -p my-profile
 ```
+
+The flag overrides the environment variable, which overrides the built-in default.
 
 ## Profile File Organization
 
-sbsh loads all profiles from a single `profiles.yaml` file. Multiple profiles are defined in the same file, separated by `---` (YAML document separator).
+sbsh scans the profiles directory recursively and loads every `*.yaml` / `*.yml` file. Each file may contain a single profile or several documents separated by `---`. There is no required layout — group profiles by project, by environment, or leave them all flat — whatever fits your workflow.
 
-Example profiles are provided as individual files in this directory for reference and documentation purposes. To use them, you must combine them into a single `profiles.yaml` file:
+Resilience guarantees:
+
+- A malformed YAML file never prevents other files from loading; the offending file is named in a loader warning.
+- A schema-invalid document (missing `apiVersion` / `kind` / `metadata.name`) never prevents other documents from loading.
+- Duplicate profile names are resolved first-wins (lexicographic load order); each duplicate is reported as a warning naming both the skipped file and the file that won.
+
+Warnings are printed to stderr by interactive commands and listed in full by `sb validate profiles`.
+
+Example layouts that all work:
 
 ```bash
-# Copy the pre-combined file (recommended)
-# Copy from repository
-cp <repository-root>/docs/profiles/profiles.yaml ~/.sbsh/profiles.yaml
+# Flat, one file per profile
+~/.sbsh/profiles.d/default.yaml
+~/.sbsh/profiles.d/k8s.yaml
 
-# Or combine specific example files
-cat <repository-root>/docs/profiles/default.yaml <repository-root>/docs/profiles/python-venv.yaml > ~/.sbsh/profiles.yaml
+# Grouped per tool
+~/.sbsh/profiles.d/k8s/staging.yaml
+~/.sbsh/profiles.d/k8s/production.yaml
+~/.sbsh/profiles.d/aws/admin.yaml
+
+# A single combined multi-document file
+~/.sbsh/profiles.d/all.yaml
 ```
-
-**Important**: sbsh only reads from a single `profiles.yaml` file. The individual `.yaml` files in the repository's `docs/profiles/` directory are examples for reference only.
 
 ## Contributing Examples
 
 Found a useful profile pattern? We'd love to see it! Consider opening a pull request with:
 
-- Your profile as a new file in the repository's `docs/profiles/` directory (e.g., `my-profile.yaml`) - provided as a reference example
-- Add the profile to `docs/profiles/profiles.yaml` (the combined file) with `---` separator
+- Your profile as a new file in the repository's `docs/profiles/` directory (e.g., `my-profile.yaml`)
+- Add the profile to `docs/profiles/profiles.yaml` (the combined file) with a `---` separator
 - Update this README to document the new profile
 - A brief description of the use case
 - Any special requirements or setup instructions

--- a/docs/site/tutorials/automate-terminal-workflows.md
+++ b/docs/site/tutorials/automate-terminal-workflows.md
@@ -53,8 +53,8 @@ jobs:
 
       - name: Create test profile
         run: |
-          mkdir -p ~/.sbsh
-          cat > ~/.sbsh/profiles.yaml <<PROFILE
+          mkdir -p ~/.sbsh/profiles.d
+          cat > ~/.sbsh/profiles.d/ci-test.yaml <<PROFILE
           apiVersion: sbsh/v1beta1
           kind: TerminalProfile
           metadata:

--- a/docs/site/tutorials/create-your-first-profile.md
+++ b/docs/site/tutorials/create-your-first-profile.md
@@ -12,12 +12,12 @@ This tutorial walks you through creating your first sbsh profile step by step.
 Create the profiles directory if it doesn't exist:
 
 ```bash
-mkdir -p ~/.sbsh
+mkdir -p ~/.sbsh/profiles.d
 ```
 
 ## Step 2: Create a Minimal Profile
 
-Create your first profile in `~/.sbsh/profiles.yaml`:
+Create your first profile as a new file under `~/.sbsh/profiles.d/`, for example `~/.sbsh/profiles.d/my-first-profile.yaml`:
 
 ```yaml
 apiVersion: sbsh/v1beta1

--- a/internal/discovery/profiles.go
+++ b/internal/discovery/profiles.go
@@ -28,22 +28,29 @@ import (
 	pkgdiscovery "github.com/eminwux/sbsh/pkg/discovery"
 )
 
-// ScanAndPrintProfiles loads all profiles from a YAML file (supports multiple '---' documents)
-// and prints them to w.
-// format: "" (compact table), "wide" (full table), "json", "yaml".
+// ProfileWarning re-exports [pkgdiscovery.ProfileWarning] for callers that
+// only import the internal discovery package.
+type ProfileWarning = pkgdiscovery.ProfileWarning
+
+// ScanAndPrintProfiles loads every TerminalProfile under profilesDir and
+// prints them to w. Any warnings produced by the loader are written to warnOut
+// (typically os.Stderr) so the user can see why a file or document was
+// skipped. format selects the table / json / yaml rendering.
 func ScanAndPrintProfiles(
 	ctx context.Context,
 	logger *slog.Logger,
-	path string,
+	profilesDir string,
 	w io.Writer,
+	warnOut io.Writer,
 	format string,
 ) error {
-	logger.DebugContext(ctx, "ScanAndPrintProfiles: loading profiles", "path", path)
-	profiles, err := LoadProfilesFromPath(ctx, logger, path)
+	logger.DebugContext(ctx, "ScanAndPrintProfiles: loading profiles", "dir", profilesDir)
+	profiles, warnings, err := LoadProfilesFromDir(ctx, logger, profilesDir)
 	if err != nil {
-		logger.ErrorContext(ctx, "ScanAndPrintProfiles: failed to load profiles", "path", path, "error", err)
+		logger.ErrorContext(ctx, "ScanAndPrintProfiles: failed to load profiles", "dir", profilesDir, "error", err)
 		return err
 	}
+	PrintProfileWarnings(warnOut, warnings)
 	logger.InfoContext(ctx, "ScanAndPrintProfiles: loaded profiles", "count", len(profiles))
 
 	switch format {
@@ -56,13 +63,14 @@ func ScanAndPrintProfiles(
 	}
 }
 
-// LoadProfilesFromPath is a thin wrapper around [pkgdiscovery.LoadProfilesFromPath].
-func LoadProfilesFromPath(
+// LoadProfilesFromDir is a thin wrapper around
+// [pkgdiscovery.LoadProfilesFromDir].
+func LoadProfilesFromDir(
 	ctx context.Context,
 	logger *slog.Logger,
-	profilesFile string,
-) ([]api.TerminalProfileDoc, error) {
-	return pkgdiscovery.LoadProfilesFromPath(ctx, logger, profilesFile)
+	profilesDir string,
+) ([]api.TerminalProfileDoc, []ProfileWarning, error) {
+	return pkgdiscovery.LoadProfilesFromDir(ctx, logger, profilesDir)
 }
 
 // LoadProfilesFromReaderWithContext is a thin wrapper around
@@ -73,6 +81,18 @@ func LoadProfilesFromReaderWithContext(
 	r io.Reader,
 ) ([]api.TerminalProfileDoc, error) {
 	return pkgdiscovery.LoadProfilesFromReaderWithContext(ctx, logger, r)
+}
+
+// PrintProfileWarnings writes one human-readable line per warning to w.
+// Each line is prefixed with "sbsh: warning:" so the diagnostic is easy to
+// grep or filter out. A nil writer turns the call into a no-op.
+func PrintProfileWarnings(w io.Writer, warnings []ProfileWarning) {
+	if w == nil {
+		return
+	}
+	for _, warn := range warnings {
+		fmt.Fprintf(w, "sbsh: warning: %s\n", warn)
+	}
 }
 
 func PrintProfilesTable(w io.Writer, profiles []api.TerminalProfileDoc, wide bool) error {
@@ -116,26 +136,34 @@ func PrintProfilesTable(w io.Writer, profiles []api.TerminalProfileDoc, wide boo
 	return tw.Flush()
 }
 
-// FindProfileByName is a thin wrapper around [pkgdiscovery.FindProfileByName].
-func FindProfileByName(ctx context.Context, logger *slog.Logger, path, name string) (*api.TerminalProfileDoc, error) {
-	return pkgdiscovery.FindProfileByName(ctx, logger, path, name)
+// FindProfileByNameInDir is a thin wrapper around
+// [pkgdiscovery.FindProfileByNameInDir].
+func FindProfileByNameInDir(
+	ctx context.Context,
+	logger *slog.Logger,
+	profilesDir, name string,
+) (*api.TerminalProfileDoc, []ProfileWarning, error) {
+	return pkgdiscovery.FindProfileByNameInDir(ctx, logger, profilesDir, name)
 }
 
-// FindAndPrintProfileMetadata finds all metadata.json under profiles file,
-// unmarshals them into api.ProfileSpec, and prints a table to w.
+// FindAndPrintProfileMetadata looks up a profile by name under profilesDir
+// and prints its metadata to w in the requested format. Loader warnings are
+// printed to warnOut.
 func FindAndPrintProfileMetadata(
 	ctx context.Context,
 	logger *slog.Logger,
-	profilesFile string,
+	profilesDir string,
 	w io.Writer,
+	warnOut io.Writer,
 	terminalName string,
 	format string,
 ) error {
-	logger.DebugContext(ctx, "FindAndPrintProfileMetadata: scanning profiles", "profilesFile", profilesFile)
-	profiles, err := FindProfileByName(ctx, logger, profilesFile, terminalName)
+	logger.DebugContext(ctx, "FindAndPrintProfileMetadata: scanning profiles", "profilesDir", profilesDir)
+	doc, warnings, err := FindProfileByNameInDir(ctx, logger, profilesDir, terminalName)
+	PrintProfileWarnings(warnOut, warnings)
 	if err != nil {
-		logger.ErrorContext(ctx, "FindAndPrintProfileMetadata: failed to scan profiles", "error", err)
+		logger.ErrorContext(ctx, "FindAndPrintProfileMetadata: failed to find profile", "error", err)
 		return err
 	}
-	return printTerminalMetadata(w, profiles, format)
+	return printTerminalMetadata(w, doc, format)
 }

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -118,7 +118,7 @@ type BuildTerminalSpecParams struct {
 	Cwd              string
 	CaptureFile      string
 	RunPath          string
-	ProfilesFile     string
+	ProfilesDir      string
 	ProfileName      string
 	LogFile          string
 	LogLevel         string
@@ -155,9 +155,11 @@ func BuildTerminalSpec(
 		input.TerminalName = naming.RandomName()
 	}
 
-	if input.ProfilesFile == "" {
-		// Default profilesFilename to $RUN_PATH/profiles.yaml
-		input.ProfilesFile = filepath.Join(input.RunPath, ".sbsh", "profiles.yaml")
+	if input.ProfilesDir == "" {
+		// Fallback: sit next to run state under $RUN_PATH so profile lookup
+		// still has a well-defined path when the caller has not resolved the
+		// $HOME-based default (which normally happens in LoadConfig).
+		input.ProfilesDir = filepath.Join(input.RunPath, ".sbsh", "profiles.d")
 	}
 
 	if input.TerminalCmd == "" {
@@ -204,15 +206,16 @@ func BuildTerminalSpec(
 		"Profile specified, loading and applying profile",
 		"profile",
 		input.ProfileName,
-		"profilesFile",
-		input.ProfilesFile,
+		"profilesDir",
+		input.ProfilesDir,
 	)
 
 	var terminalSpec *api.TerminalSpec
-	var profileSpec *api.TerminalProfileDoc
-	var errFind error
 
-	profileSpec, errFind = discovery.FindProfileByName(ctx, logger, input.ProfilesFile, input.ProfileName)
+	profileSpec, warnings, errFind := discovery.FindProfileByNameInDir(ctx, logger, input.ProfilesDir, input.ProfileName)
+	for _, w := range warnings {
+		logger.WarnContext(ctx, "profile loader warning", "file", w.File, "doc", w.DocIndex, "reason", w.Reason)
+	}
 	if errFind != nil {
 		logger.InfoContext(
 			ctx,

--- a/pkg/api/configuration.go
+++ b/pkg/api/configuration.go
@@ -22,8 +22,9 @@ package api
 const KindConfiguration Kind = "Configuration"
 
 // ConfigurationDoc models one YAML document containing user-level defaults
-// for sbsh. It is the declarative equivalent of the --run-path, --profiles,
-// and --log-level flags and their corresponding environment variables.
+// for sbsh. It is the declarative equivalent of the --run-path,
+// --profiles-dir, and --log-level flags and their corresponding environment
+// variables.
 type ConfigurationDoc struct {
 	APIVersion Version               `json:"apiVersion" yaml:"apiVersion"`
 	Kind       Kind                  `json:"kind"       yaml:"kind"`
@@ -40,7 +41,7 @@ type ConfigurationMetadata struct {
 // ConfigurationSpec holds the user-level defaults loaded from config.yaml.
 // Fields are optional; empty values fall back to built-in defaults.
 type ConfigurationSpec struct {
-	RunPath      string `json:"runPath,omitempty"      yaml:"runPath,omitempty"`
-	ProfilesFile string `json:"profilesFile,omitempty" yaml:"profilesFile,omitempty"`
-	LogLevel     string `json:"logLevel,omitempty"     yaml:"logLevel,omitempty"`
+	RunPath     string `json:"runPath,omitempty"     yaml:"runPath,omitempty"`
+	ProfilesDir string `json:"profilesDir,omitempty" yaml:"profilesDir,omitempty"`
+	LogLevel    string `json:"logLevel,omitempty"    yaml:"logLevel,omitempty"`
 }

--- a/pkg/builder/terminal.go
+++ b/pkg/builder/terminal.go
@@ -46,7 +46,7 @@ type terminalConfig struct {
 	logLevel         string
 	socketFile       string
 	profileName      string
-	profileFile      string
+	profilesDir      string
 	disableSetPrompt bool
 }
 
@@ -61,19 +61,20 @@ func WithName(name string) TerminalOption {
 	return func(c *terminalConfig) { c.name = name }
 }
 
-// WithProfile selects a profile by Metadata.Name from the profile
-// file resolved via WithProfileFile (or the default location if no
+// WithProfile selects a profile by Metadata.Name from the directory
+// resolved via WithProfilesDir (or the default location if no
 // explicit path is set). Empty resolves to the hardcoded "default"
 // profile.
 func WithProfile(name string) TerminalOption {
 	return func(c *terminalConfig) { c.profileName = name }
 }
 
-// WithProfileFile points the builder at a specific multi-document
-// YAML file containing TerminalProfile documents. Empty means "use
-// the default profiles file under runPath".
-func WithProfileFile(path string) TerminalOption {
-	return func(c *terminalConfig) { c.profileFile = path }
+// WithProfilesDir points the builder at a directory that is scanned
+// recursively for *.yaml / *.yml files containing TerminalProfile
+// documents. Empty means "use the default profiles directory
+// ($HOME/.sbsh/profiles.d/)".
+func WithProfilesDir(path string) TerminalOption {
+	return func(c *terminalConfig) { c.profilesDir = path }
 }
 
 // WithCommand sets the terminal's command and its argv. argv[0] is
@@ -182,7 +183,7 @@ func BuildTerminalSpec(
 		Cwd:              cfg.cwd,
 		CaptureFile:      cfg.captureFile,
 		RunPath:          runPath,
-		ProfilesFile:     cfg.profileFile,
+		ProfilesDir:      cfg.profilesDir,
 		ProfileName:      cfg.profileName,
 		LogFile:          cfg.logFile,
 		LogLevel:         cfg.logLevel,

--- a/pkg/builder/terminal_test.go
+++ b/pkg/builder/terminal_test.go
@@ -113,7 +113,7 @@ func TestBuildTerminalSpec_InlineOnly(t *testing.T) {
 	}
 }
 
-// ProfileByName: when WithProfile + WithProfileFile resolve, the
+// ProfileByName: when WithProfile + WithProfilesDir resolve, the
 // profile's shell cmd/args flow into the spec.
 func TestBuildTerminalSpec_ProfileByName(t *testing.T) {
 	runPath := t.TempDir()
@@ -123,7 +123,7 @@ func TestBuildTerminalSpec_ProfileByName(t *testing.T) {
 		context.Background(),
 		testLogger(),
 		runPath,
-		builder.WithProfileFile(profiles),
+		builder.WithProfilesDir(filepath.Dir(profiles)),
 		builder.WithProfile("alpha"),
 		builder.WithID("id-a"),
 	)
@@ -157,7 +157,7 @@ func TestBuildTerminalSpec_UnknownProfile(t *testing.T) {
 		context.Background(),
 		testLogger(),
 		runPath,
-		builder.WithProfileFile(profiles),
+		builder.WithProfilesDir(filepath.Dir(profiles)),
 		builder.WithProfile("ghost"),
 	)
 	if err == nil {
@@ -226,21 +226,25 @@ func TestBuildTerminalSpec_WithEnvComposition(t *testing.T) {
 	}
 }
 
-// Missing profile file with a non-default profile name produces an
-// open/not-found error rather than silently falling back.
-func TestBuildTerminalSpec_MissingProfileFile(t *testing.T) {
+// A non-default profile name that resolves to no profile at all
+// (missing directory or simply absent) surfaces a profile-not-found
+// error rather than silently falling back to the hardcoded default.
+func TestBuildTerminalSpec_MissingProfilesDir(t *testing.T) {
 	runPath := t.TempDir()
-	missing := filepath.Join(runPath, "does-not-exist.yaml")
+	missing := filepath.Join(runPath, "no-such-profiles-dir")
 
 	_, err := builder.BuildTerminalSpec(
 		context.Background(),
 		testLogger(),
 		runPath,
-		builder.WithProfileFile(missing),
+		builder.WithProfilesDir(missing),
 		builder.WithProfile("alpha"),
 	)
 	if err == nil {
-		t.Fatal("expected error for missing profile file, got nil")
+		t.Fatal("expected error for missing profile, got nil")
+	}
+	if !strings.Contains(err.Error(), "alpha") {
+		t.Fatalf("expected error to mention profile name, got: %v", err)
 	}
 }
 
@@ -299,7 +303,7 @@ spec:
 		context.Background(),
 		testLogger(),
 		runPath,
-		builder.WithProfileFile(profiles),
+		builder.WithProfilesDir(filepath.Dir(profiles)),
 		builder.WithProfile("cwd-profile"),
 	)
 	if err != nil {
@@ -314,7 +318,7 @@ spec:
 		context.Background(),
 		testLogger(),
 		runPath,
-		builder.WithProfileFile(profiles),
+		builder.WithProfilesDir(filepath.Dir(profiles)),
 		builder.WithProfile("cwd-profile"),
 		builder.WithCwd("/from/option"),
 	)

--- a/pkg/discovery/profiles.go
+++ b/pkg/discovery/profiles.go
@@ -21,34 +21,261 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/eminwux/sbsh/pkg/api"
 	"gopkg.in/yaml.v3"
 )
 
-// LoadProfilesFromPath reads a multi-document YAML file into []api.TerminalProfileDoc.
-// Documents missing APIVersion, Kind, or Metadata.Name are logged and skipped.
-func LoadProfilesFromPath(
+// ProfileWarning describes a non-fatal problem encountered while loading
+// profiles from a directory. Warnings never cause the loader to abort: they
+// are surfaced alongside whatever profiles did load successfully so callers
+// (interactive CLI, shell completion, `sb validate profiles`) can decide how
+// to present them.
+type ProfileWarning struct {
+	// File is the absolute path of the file the warning applies to.
+	File string
+	// DocIndex is the 1-based index of the offending YAML document within
+	// File, or 0 when the warning is file-level (open error, malformed stream).
+	DocIndex int
+	// Reason is a human-readable description of the problem.
+	Reason string
+}
+
+// String formats the warning as a single-line diagnostic suitable for stderr.
+func (w ProfileWarning) String() string {
+	if w.DocIndex > 0 {
+		return fmt.Sprintf("%s (doc %d): %s", w.File, w.DocIndex, w.Reason)
+	}
+	return fmt.Sprintf("%s: %s", w.File, w.Reason)
+}
+
+// LoadProfilesFromDir walks dir recursively and loads every *.yaml / *.yml
+// file into []api.TerminalProfileDoc. Files are processed in deterministic
+// lexicographic order by absolute path, which makes first-wins behaviour for
+// duplicate profile names reproducible.
+//
+// A missing or empty dir is not an error: the function returns
+// (nil, nil, nil) so callers can start with zero profiles. An empty dir
+// string is also treated as "nothing to load".
+//
+// Any problem that is scoped to a single file or document becomes a
+// ProfileWarning rather than aborting the scan:
+//   - cannot open a file,
+//   - malformed YAML,
+//   - missing required apiVersion/kind/metadata.name,
+//   - unsupported apiVersion or kind,
+//   - duplicate profile name (keeps the first and skips subsequent).
+//
+// An error is returned only for unrecoverable conditions such as a walk
+// failure on the directory itself.
+func LoadProfilesFromDir(
 	ctx context.Context,
 	logger *slog.Logger,
-	profilesFile string,
-) ([]api.TerminalProfileDoc, error) {
-	logger.DebugContext(ctx, "LoadProfilesFromPath: opening file", "path", profilesFile)
-	f, err := os.Open(profilesFile)
+	dir string,
+) ([]api.TerminalProfileDoc, []ProfileWarning, error) {
+	if dir == "" {
+		logger.DebugContext(ctx, "LoadProfilesFromDir: empty dir, nothing to load")
+		return nil, nil, nil
+	}
+
+	info, err := os.Stat(dir)
 	if err != nil {
-		logger.ErrorContext(ctx, "LoadProfilesFromPath: failed to open file", "path", profilesFile, "error", err)
-		return nil, fmt.Errorf("open profiles file %q: %w", profilesFile, err)
+		if errors.Is(err, os.ErrNotExist) {
+			logger.DebugContext(ctx, "LoadProfilesFromDir: directory not found", "dir", dir)
+			return nil, nil, nil
+		}
+		return nil, nil, fmt.Errorf("stat profiles dir %q: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return nil, nil, fmt.Errorf("profiles path %q is not a directory", dir)
+	}
+
+	files, err := collectYAMLFiles(dir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var (
+		profiles []api.TerminalProfileDoc
+		warnings []ProfileWarning
+		// seen maps profile name -> file that first loaded that name.
+		seen = make(map[string]string)
+	)
+
+	for _, file := range files {
+		docs, fileWarnings := loadProfilesFromFile(ctx, logger, file)
+		warnings = append(warnings, fileWarnings...)
+		for _, doc := range docs {
+			if owner, dup := seen[doc.Metadata.Name]; dup {
+				warnings = append(warnings, ProfileWarning{
+					File: file,
+					Reason: fmt.Sprintf(
+						"duplicate profile name %q already loaded from %s; this copy skipped",
+						doc.Metadata.Name, owner,
+					),
+				})
+				continue
+			}
+			seen[doc.Metadata.Name] = file
+			profiles = append(profiles, doc)
+		}
+	}
+
+	logger.InfoContext(ctx, "LoadProfilesFromDir: finished",
+		"dir", dir,
+		"profiles", len(profiles),
+		"warnings", len(warnings),
+	)
+	return profiles, warnings, nil
+}
+
+// collectYAMLFiles returns the lexicographically sorted list of *.yaml and
+// *.yml files found under dir (recursively).
+func collectYAMLFiles(dir string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, e error) error {
+		if e != nil {
+			return e
+		}
+		if d.IsDir() {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		if ext == ".yaml" || ext == ".yml" {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk profiles dir %q: %w", dir, err)
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+// loadProfilesFromFile decodes every YAML document in a single file and
+// returns the ones that pass minimal schema checks plus any warnings
+// collected along the way.
+func loadProfilesFromFile(
+	ctx context.Context,
+	logger *slog.Logger,
+	file string,
+) ([]api.TerminalProfileDoc, []ProfileWarning) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, []ProfileWarning{{
+			File:   file,
+			Reason: fmt.Sprintf("open: %v", err),
+		}}
 	}
 	defer f.Close()
-	logger.InfoContext(ctx, "LoadProfilesFromPath: file opened", "path", profilesFile)
-	return LoadProfilesFromReaderWithContext(ctx, logger, f)
+
+	logger.DebugContext(ctx, "loadProfilesFromFile: decoding", "path", file)
+	return decodeProfileStream(ctx, logger, file, f)
+}
+
+func decodeProfileStream(
+	ctx context.Context,
+	logger *slog.Logger,
+	file string,
+	r io.Reader,
+) ([]api.TerminalProfileDoc, []ProfileWarning) {
+	dec := yaml.NewDecoder(r)
+
+	var (
+		profiles []api.TerminalProfileDoc
+		warnings []ProfileWarning
+	)
+	docIndex := 0
+	for {
+		var p api.TerminalProfileDoc
+		err := dec.Decode(&p)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			docIndex++
+			warnings = append(warnings, ProfileWarning{
+				File:     file,
+				DocIndex: docIndex,
+				Reason:   fmt.Sprintf("malformed YAML: %v", err),
+			})
+			// A malformed stream can throw off subsequent document
+			// boundaries, so stop at the first parse failure in this file.
+			break
+		}
+		docIndex++
+
+		// Skip empty YAML documents (separators with no content).
+		if p.APIVersion == "" && p.Kind == "" && p.Metadata.Name == "" {
+			logger.DebugContext(ctx, "decodeProfileStream: skipping empty document", "file", file, "doc", docIndex)
+			continue
+		}
+
+		if warn, ok := validateRequiredFields(file, docIndex, &p); !ok {
+			warnings = append(warnings, warn)
+			continue
+		}
+
+		profiles = append(profiles, p)
+	}
+
+	return profiles, warnings
+}
+
+func validateRequiredFields(file string, docIndex int, p *api.TerminalProfileDoc) (ProfileWarning, bool) {
+	switch {
+	case p.APIVersion == "":
+		return ProfileWarning{File: file, DocIndex: docIndex, Reason: "missing required apiVersion"}, false
+	case p.APIVersion != api.APIVersionV1Beta1:
+		return ProfileWarning{
+			File: file, DocIndex: docIndex,
+			Reason: fmt.Sprintf("unsupported apiVersion %q (expected %q)", p.APIVersion, api.APIVersionV1Beta1),
+		}, false
+	case p.Kind == "":
+		return ProfileWarning{File: file, DocIndex: docIndex, Reason: "missing required kind"}, false
+	case p.Kind != api.KindTerminalProfile:
+		return ProfileWarning{
+			File: file, DocIndex: docIndex,
+			Reason: fmt.Sprintf("unsupported kind %q (expected %q)", p.Kind, api.KindTerminalProfile),
+		}, false
+	case p.Metadata.Name == "":
+		return ProfileWarning{File: file, DocIndex: docIndex, Reason: "missing required metadata.name"}, false
+	}
+	return ProfileWarning{}, true
+}
+
+// FindProfileByNameInDir returns the profile whose Metadata.Name matches
+// name, along with every warning produced while scanning dir. The match is
+// case-sensitive; when no profile matches, the returned error names the
+// target.
+func FindProfileByNameInDir(
+	ctx context.Context,
+	logger *slog.Logger,
+	dir, name string,
+) (*api.TerminalProfileDoc, []ProfileWarning, error) {
+	profiles, warnings, err := LoadProfilesFromDir(ctx, logger, dir)
+	if err != nil {
+		return nil, warnings, err
+	}
+	for i := range profiles {
+		if profiles[i].Metadata.Name == name {
+			return &profiles[i], warnings, nil
+		}
+	}
+	return nil, warnings, fmt.Errorf("profile %q not found in %s", name, dir)
 }
 
 // LoadProfilesFromReaderWithContext decodes one or more YAML documents from r
-// into []api.TerminalProfileDoc. Documents missing APIVersion, Kind, or
-// Metadata.Name are logged and skipped.
+// into []api.TerminalProfileDoc. It exists primarily for tests and callers
+// that already have a stream in hand. Documents missing required fields are
+// logged and skipped; malformed YAML aborts the scan and returns an error.
 func LoadProfilesFromReaderWithContext(
 	ctx context.Context,
 	logger *slog.Logger,
@@ -74,10 +301,8 @@ func LoadProfilesFromReaderWithContext(
 		if p.Metadata.Name == "" || string(p.APIVersion) == "" || string(p.Kind) == "" {
 			logger.WarnContext(ctx,
 				"LoadProfilesFromReader: skipping empty/invalid profile document",
-				"doc",
-				docCount,
-				"name",
-				p.Metadata.Name,
+				"doc", docCount,
+				"name", p.Metadata.Name,
 			)
 			continue
 		}
@@ -87,26 +312,4 @@ func LoadProfilesFromReaderWithContext(
 
 	logger.InfoContext(ctx, "LoadProfilesFromReader: finished loading profiles", "count", len(out))
 	return out, nil
-}
-
-// FindProfileByName scans the YAML file at path and returns the profile
-// whose Metadata.Name matches. The match is case-sensitive. Returns an
-// error if no profile with that name is found.
-func FindProfileByName(ctx context.Context, logger *slog.Logger, path, name string) (*api.TerminalProfileDoc, error) {
-	logger.DebugContext(ctx, "FindProfileByName: searching for profile", "name", name, "path", path)
-	profiles, err := LoadProfilesFromPath(ctx, logger, path)
-	if err != nil {
-		logger.ErrorContext(ctx, "FindProfileByName: failed to load profiles", "error", err)
-		return nil, err
-	}
-
-	for _, p := range profiles {
-		if p.Metadata.Name == name {
-			logger.InfoContext(ctx, "FindProfileByName: found profile", "name", name)
-			return &p, nil
-		}
-	}
-
-	logger.WarnContext(ctx, "FindProfileByName: profile not found", "name", name, "path", path)
-	return nil, fmt.Errorf("profile %q not found in %s", name, path)
 }

--- a/pkg/discovery/profiles_test.go
+++ b/pkg/discovery/profiles_test.go
@@ -45,7 +45,7 @@ spec:
     cmd: /bin/zsh
 `
 
-// A doc missing apiVersion/kind/name should be skipped (logged, not errored).
+// A doc missing apiVersion/kind/name should be skipped (with a warning).
 const profilesWithEmptyDoc = `apiVersion: sbsh/v1beta1
 kind: TerminalProfile
 metadata:
@@ -56,7 +56,7 @@ spec:
     cmd: /bin/bash
 ---
 metadata:
-  name: ""
+  name: incomplete
 ---
 apiVersion: sbsh/v1beta1
 kind: TerminalProfile
@@ -68,24 +68,30 @@ spec:
     cmd: /bin/zsh
 `
 
-func writeProfileFile(t *testing.T, content string) string {
+func writeFile(t *testing.T, dir, name, content string) string {
 	t.Helper()
-	dir := t.TempDir()
-	p := filepath.Join(dir, "profiles.yaml")
+	p := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir parent of %s: %v", p, err)
+	}
 	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
-		t.Fatalf("write profiles: %v", err)
+		t.Fatalf("write %s: %v", p, err)
 	}
 	return p
 }
 
-func TestLoadProfilesFromPath_MultiDoc(t *testing.T) {
+func TestLoadProfilesFromDir_MultiDoc(t *testing.T) {
 	ctx := context.Background()
 	logger := testLogger()
-	path := writeProfileFile(t, multiDocProfiles)
+	dir := t.TempDir()
+	writeFile(t, dir, "profiles.yaml", multiDocProfiles)
 
-	got, err := discovery.LoadProfilesFromPath(ctx, logger, path)
+	got, warnings, err := discovery.LoadProfilesFromDir(ctx, logger, dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %v", warnings)
 	}
 	if len(got) != 2 {
 		t.Fatalf("expected 2 profiles, got %d", len(got))
@@ -95,53 +101,245 @@ func TestLoadProfilesFromPath_MultiDoc(t *testing.T) {
 	}
 }
 
-func TestLoadProfilesFromPath_SkipsEmptyDocs(t *testing.T) {
+func TestLoadProfilesFromDir_SkipsEmptyAndInvalidDocs(t *testing.T) {
 	ctx := context.Background()
 	logger := testLogger()
-	path := writeProfileFile(t, profilesWithEmptyDoc)
+	dir := t.TempDir()
+	writeFile(t, dir, "profiles.yaml", profilesWithEmptyDoc)
 
-	got, err := discovery.LoadProfilesFromPath(ctx, logger, path)
+	got, warnings, err := discovery.LoadProfilesFromDir(ctx, logger, dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(got) != 2 {
-		t.Fatalf("expected 2 profiles (empty doc skipped), got %d", len(got))
+		t.Fatalf("expected 2 profiles (invalid doc skipped), got %d", len(got))
 	}
 	if got[0].Metadata.Name != "only" || got[1].Metadata.Name != "also" {
 		t.Fatalf("unexpected names: %q, %q", got[0].Metadata.Name, got[1].Metadata.Name)
 	}
-}
-
-func TestLoadProfilesFromPath_FileNotFound(t *testing.T) {
-	ctx := context.Background()
-	logger := testLogger()
-
-	_, err := discovery.LoadProfilesFromPath(ctx, logger, filepath.Join(t.TempDir(), "missing.yaml"))
-	if err == nil {
-		t.Fatal("expected error for missing file, got nil")
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning for the incomplete doc, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0].Reason, "apiVersion") {
+		t.Fatalf("expected warning to mention missing apiVersion, got %q", warnings[0].Reason)
 	}
 }
 
-func TestFindProfileByName(t *testing.T) {
+func TestLoadProfilesFromDir_MissingDirIsNotAnError(t *testing.T) {
 	ctx := context.Background()
 	logger := testLogger()
-	path := writeProfileFile(t, multiDocProfiles)
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
 
-	got, err := discovery.FindProfileByName(ctx, logger, path, "beta")
+	got, warnings, err := discovery.LoadProfilesFromDir(ctx, logger, missing)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil || warnings != nil {
+		t.Fatalf("expected (nil, nil, nil) for missing dir, got profiles=%v warnings=%v", got, warnings)
+	}
+}
+
+func TestLoadProfilesFromDir_EmptyDirArgIsNotAnError(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+
+	got, warnings, err := discovery.LoadProfilesFromDir(ctx, logger, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil || warnings != nil {
+		t.Fatalf("expected (nil, nil, nil) for empty dir arg")
+	}
+}
+
+func TestLoadProfilesFromDir_NotADirectory(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	dir := t.TempDir()
+	file := writeFile(t, dir, "profiles.yaml", multiDocProfiles)
+
+	_, _, err := discovery.LoadProfilesFromDir(ctx, logger, file)
+	if err == nil {
+		t.Fatal("expected error when path is a file not a directory")
+	}
+}
+
+func TestLoadProfilesFromDir_Recursive(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	dir := t.TempDir()
+
+	writeFile(t, dir, "top.yaml", `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: top
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/sh
+`)
+	writeFile(t, dir, "subdir/nested.yml", `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: nested
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/sh
+`)
+	// File with non-YAML extension must be ignored.
+	writeFile(t, dir, "subdir/readme.txt", "ignore me")
+
+	got, warnings, err := discovery.LoadProfilesFromDir(ctx, logger, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %v", warnings)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 profiles, got %d: %+v", len(got), got)
+	}
+	names := []string{got[0].Metadata.Name, got[1].Metadata.Name}
+	if names[0] != "nested" || names[1] != "top" {
+		t.Fatalf("expected deterministic order [nested, top], got %v", names)
+	}
+}
+
+func TestLoadProfilesFromDir_MalformedYAMLProducesWarning(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	dir := t.TempDir()
+
+	writeFile(t, dir, "bad.yaml", "apiVersion: sbsh/v1beta1\nkind: TerminalProfile\n  oops this is broken:\n    -\n")
+	writeFile(t, dir, "good.yaml", `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: good
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/sh
+`)
+
+	got, warnings, err := discovery.LoadProfilesFromDir(ctx, logger, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].Metadata.Name != "good" {
+		t.Fatalf("expected the good profile to load, got %+v", got)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("expected exactly 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0].Reason, "malformed YAML") {
+		t.Fatalf("expected malformed YAML warning, got %q", warnings[0].Reason)
+	}
+	if !strings.HasSuffix(warnings[0].File, "bad.yaml") {
+		t.Fatalf("expected warning to point at bad.yaml, got %s", warnings[0].File)
+	}
+}
+
+func TestLoadProfilesFromDir_DuplicateNameFirstWins(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	dir := t.TempDir()
+
+	// Lexicographic ordering picks a-first, b-second.
+	writeFile(t, dir, "a-first.yaml", `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: dup
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/bash
+`)
+	writeFile(t, dir, "b-second.yaml", `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: dup
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/zsh
+`)
+
+	got, warnings, err := discovery.LoadProfilesFromDir(ctx, logger, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected only first-wins profile, got %d", len(got))
+	}
+	if got[0].Spec.Shell.Cmd != "/bin/bash" {
+		t.Fatalf("expected first file's shell to win, got %q", got[0].Spec.Shell.Cmd)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("expected one duplicate warning, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0].Reason, "duplicate") {
+		t.Fatalf("expected warning to mention duplicate, got %q", warnings[0].Reason)
+	}
+	if !strings.HasSuffix(warnings[0].File, "b-second.yaml") {
+		t.Fatalf("expected warning to name the skipped file, got %s", warnings[0].File)
+	}
+	if !strings.Contains(warnings[0].Reason, "a-first.yaml") {
+		t.Fatalf("expected warning to name the winning file, got %q", warnings[0].Reason)
+	}
+}
+
+func TestLoadProfilesFromDir_UnsupportedKindProducesWarning(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	dir := t.TempDir()
+	writeFile(t, dir, "p.yaml", `apiVersion: sbsh/v1beta1
+kind: Something
+metadata:
+  name: wrong-kind
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/sh
+`)
+
+	got, warnings, err := discovery.LoadProfilesFromDir(ctx, logger, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected no profiles, got %d", len(got))
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0].Reason, "kind") {
+		t.Fatalf("expected single kind warning, got %v", warnings)
+	}
+}
+
+func TestFindProfileByNameInDir(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	dir := t.TempDir()
+	writeFile(t, dir, "profiles.yaml", multiDocProfiles)
+
+	got, warnings, err := discovery.FindProfileByNameInDir(ctx, logger, dir, "beta")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %v", warnings)
 	}
 	if got == nil || got.Metadata.Name != "beta" {
 		t.Fatalf("want name=beta, got %+v", got)
 	}
 }
 
-func TestFindProfileByName_NotFound(t *testing.T) {
+func TestFindProfileByNameInDir_NotFound(t *testing.T) {
 	ctx := context.Background()
 	logger := testLogger()
-	path := writeProfileFile(t, multiDocProfiles)
+	dir := t.TempDir()
+	writeFile(t, dir, "profiles.yaml", multiDocProfiles)
 
-	_, err := discovery.FindProfileByName(ctx, logger, path, "ghost")
+	_, _, err := discovery.FindProfileByNameInDir(ctx, logger, dir, "ghost")
 	if err == nil {
 		t.Fatal("expected not-found error, got nil")
 	}


### PR DESCRIPTION
## Summary
- Replaces the single `~/.sbsh/profiles.yaml` layout with a recursive directory scan of `~/.sbsh/profiles.d/` (`*.yaml` / `*.yml`), overridable via `--profiles-dir` or `SBSH_PROFILES_DIR`.
- Makes the loader resilient: malformed YAML, schema-invalid docs, and duplicate profile names become `ProfileWarning`s instead of aborting — callers (CLI, completion, `sb validate profiles`) decide how to surface them. Interactive commands print warnings to stderr; completion swallows them so it never silently empties when one file is bad.
- Extends `sb validate profiles` to walk the configured directory, validate every file in deterministic (lexicographic) order, and list loader warnings — the diagnostic flow for users whose `-p` completion looks empty.
- Renames the config/env/flag plumbing everywhere: `ConfigurationSpec.profilesFile` → `profilesDir`, `SB_PROFILES_FILE` / `SBSH_PROFILES_FILE` → `SB_PROFILES_DIR` / `SBSH_PROFILES_DIR`, `--profiles-file` → `--profiles-dir`, builder option `WithProfileFile` → `WithProfilesDir`.
- Updates user-facing docs (README, profiles guide, configuration guide, faq, cli reference, cicd/container guides, tutorials, concepts, gap-analysis, ROADMAP field list) to reflect the new layout and the "completion empty? run `sb validate profiles`" diagnostic. The legacy single-file path is no longer read; breaking change is called out in the profiles guide.

## Test plan
- [x] `make sbsh-sb` and `file ./sbsh` confirm an ELF executable.
- [x] `go build ./...` and `go vet ./...` clean.
- [x] `go test $(go list ./... | grep -v '/e2e$' | grep -v 'internal/terminal$')` passes — including new `pkg/discovery` coverage for recursive walk, malformed YAML, duplicate first-wins, unsupported kind, empty/missing directory, and a directory fixture for `sb validate profiles`.
- [x] `go test -tags=integration ./cmd/sb/get/...` passes.
- [ ] `go test ./internal/terminal/...` — **pre-existing flake unrelated to this change**: `Test_HandleEvent_EvCmdExited` hangs to the 10-minute timeout. Reproduces on `origin/main` (7a60316) in an isolated worktree. Not introduced here.

## Release notes
The repo has no CHANGELOG yet, so this PR description serves as the release note. Breaking change:
- `~/.sbsh/profiles.yaml` is no longer read. Move contents into `~/.sbsh/profiles.d/` — a single combined file or many small files both work, the loader scans recursively.
- `SBSH_PROFILES_FILE` / `SB_PROFILES_FILE` env vars and the `--profiles-file` flag are renamed to `SBSH_PROFILES_DIR` / `SB_PROFILES_DIR` / `--profiles-dir`.
- `ConfigurationSpec.profilesFile` is now `profilesDir`.

Closes #128