### PR TITLE
fix(controller): atomic Close guard + closeReqCh priority fix deadlock (#138)

### DIFF
--- a/internal/client/controller.go
+++ b/internal/client/controller.go
@@ -222,13 +222,27 @@ func (s *Controller) Run(doc *api.ClientDoc) error {
 	s.logger.Info("controller ready, entering main event loop")
 	close(s.ctrlReadyCh)
 
-	go func() {
-		errC := <-s.closingCh
-		s.shuttingDown.Store(true)
-		s.logger.Warn("controller closing", "reason", errC)
-	}()
+	// shuttingDown is now flipped atomically via CompareAndSwap at the
+	// top of Close, so we no longer need a background goroutine to
+	// observe closingCh and set the flag. Leaving a watcher opened the
+	// same re-entrancy deadlock documented in issue #138 for the
+	// terminal controller.
 
 	for {
+		// closeReqCh takes precedence over ctx.Done so an internal
+		// shutdown (handleEvent -> Close) returns ErrCloseReq rather
+		// than racing with the ctx cancellation that Close itself just
+		// performed.
+		select {
+		case errClose := <-s.closeReqCh:
+			s.logger.Warn("close request received", "error", errClose)
+			if errClose == nil {
+				return nil
+			}
+			return fmt.Errorf("%w: %w", errdefs.ErrCloseReq, errClose)
+		default:
+		}
+
 		select {
 		case <-s.ctx.Done():
 			var errDone error
@@ -359,22 +373,27 @@ func (s *Controller) onClosed(_ api.ID, err error) {
 }
 
 func (s *Controller) Close(reason error) error {
-	if !s.shuttingDown.Load() {
-		s.logger.Info("initiating shutdown sequence", "reason", reason)
-		// Set closing reason
-		s.closingCh <- reason
-
-		// Notify terminal runner to close all terminals
-		_ = s.sr.Close(reason)
-
-		// Notify Run to exit
-		s.closeReqCh <- reason
-
-		// Mark controller as closed
-		close(s.closedCh)
-	} else {
+	// CompareAndSwap guarantees only the first caller enters the
+	// shutdown body. See terminal.Controller.Close for the full
+	// explanation (issue #138).
+	if !s.shuttingDown.CompareAndSwap(false, true) {
 		s.logger.Info("shutdown sequence already in progress, ignoring duplicate request", "reason", reason)
+		return nil
 	}
+
+	s.logger.Info("initiating shutdown sequence", "reason", reason)
+
+	// Set closing reason
+	s.closingCh <- reason
+
+	// Notify terminal runner to close all terminals
+	_ = s.sr.Close(reason)
+
+	// Notify Run to exit
+	s.closeReqCh <- reason
+
+	// Mark controller as closed
+	close(s.closedCh)
 	return nil
 }
 

--- a/internal/terminal/controller.go
+++ b/internal/terminal/controller.go
@@ -182,13 +182,27 @@ func (c *Controller) Run(spec *api.TerminalSpec) error {
 	c.logger.InfoContext(c.ctx, "controller ready")
 	close(c.ctrlReadyCh)
 
-	go func() {
-		err := <-c.closingCh
-		c.shuttingDown.Store(true)
-		c.logger.WarnContext(c.ctx, "controller closing", "reason", err)
-	}()
+	// shuttingDown is now flipped atomically at the top of Close via
+	// CompareAndSwap, so we no longer need a background goroutine to
+	// observe closingCh and set the flag. Leaving a watcher here opened
+	// a race where Close could be re-entered between the closingCh send
+	// and the Store — deadlocking on the one-shot closeReqCh buffer
+	// (issue #138).
 
 	for {
+		// closeReqCh takes precedence over ctx.Done so an internal
+		// shutdown (handleEvent -> onClosed -> Close) returns
+		// ErrCloseReq rather than racing with the ctx cancellation that
+		// Close itself just performed. Without this the random
+		// select-winner could surface ErrContextDone for a close we
+		// initiated ourselves (issue #138).
+		select {
+		case err := <-c.closeReqCh:
+			c.logger.WarnContext(c.ctx, "close request received", "err", err)
+			return fmt.Errorf("%w: %w", errdefs.ErrCloseReq, err)
+		default:
+		}
+
 		select {
 		case <-c.ctx.Done():
 			var err error
@@ -243,31 +257,42 @@ func (c *Controller) handleEvent(ev terminalrunner.Event) {
 }
 
 func (c *Controller) Close(reason error) error {
-	if !c.shuttingDown.Load() {
-		c.logger.InfoContext(c.ctx, "initiating shutdown sequence", "reason", reason)
-
-		// cancel the controller context so WaitReady unblocks
-		c.cancel(reason)
-
-		// Set closing reason
-		c.closingCh <- reason
-
-		// Notify terminal runner to close all terminals
-		c.srMu.RLock()
-		sr := c.sr
-		c.srMu.RUnlock()
-		if sr != nil {
-			_ = sr.Close(reason)
-		}
-
-		// Notify Run to exit
-		c.closeReqCh <- reason
-
-		// Mark controller as closed
-		close(c.closedCh)
-	} else {
+	// CompareAndSwap guarantees only the first caller enters the
+	// shutdown body. Previously Close guarded on shuttingDown.Load()
+	// and relied on a background watcher goroutine to flip the flag
+	// asynchronously; re-entry through Run's <-c.ctx.Done() branch
+	// (which also calls Close) could arrive before the watcher had
+	// been scheduled, causing two concurrent sends on the one-shot
+	// closeReqCh buffer and a deterministic deadlock (issue #138).
+	if !c.shuttingDown.CompareAndSwap(false, true) {
 		c.logger.WarnContext(c.ctx, "shutdown sequence already in progress, ignoring duplicate request", "reason", reason)
+		return nil
 	}
+
+	c.logger.InfoContext(c.ctx, "initiating shutdown sequence", "reason", reason)
+
+	// cancel the controller context so WaitReady unblocks
+	c.cancel(reason)
+
+	// Set closing reason for observers (WaitClose). The buffer is 1 and
+	// Close only runs once, so a non-blocking send is still safe but we
+	// keep the blocking form because the buffer is guaranteed empty on
+	// first entry.
+	c.closingCh <- reason
+
+	// Notify terminal runner to close all terminals
+	c.srMu.RLock()
+	sr := c.sr
+	c.srMu.RUnlock()
+	if sr != nil {
+		_ = sr.Close(reason)
+	}
+
+	// Notify Run to exit
+	c.closeReqCh <- reason
+
+	// Mark controller as closed
+	close(c.closedCh)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

`Test_HandleEvent_EvCmdExited` in `internal/terminal` deadlocked deterministically because `Close` relied on a watcher goroutine to flip `shuttingDown` asynchronously. When `EvCmdExited` triggered `Close`, the context cancel inside `Close` immediately woke `Run`'s `<-c.ctx.Done()` branch, which called `Close` again before the watcher had been scheduled. Both invocations saw `shuttingDown=false` and the second blocked forever on `closeReqCh` (buffer 1, already filled by the first caller; only reader was `Run`, sitting inside the second `Close`).

## Fix

1. **Atomic shutdown guard.** Replace `shuttingDown.Load()`-then-body with a single `CompareAndSwap` at the top of `Close`. The guard is now atomic with the body it guards, so re-entries return immediately instead of re-filling the one-shot channel.
2. **closeReqCh priority.** In `Run`'s main loop, prioritise `closeReqCh` over `ctx.Done` with a non-blocking pre-check. When `Close` cancels ctx and sends on `closeReqCh`, both branches become ready simultaneously; Go's default select picks randomly, which could surface `ErrContextDone` for a close we initiated ourselves. Deterministic priority makes the returned error reliable.
3. **Drop the watcher goroutine.** `closingCh -> shuttingDown.Store` goroutine is now redundant; `WaitClose` still reads `closingCh` for observability.
4. **Parallel fix in `internal/client/controller.go`** (flagged in the issue as "worth auditing in the same change").

Fixes #138

## Test plan

- [x] `go test -run '^Test_HandleEvent_EvCmdExited$' -timeout 30s ./internal/terminal/` — passes in 0.01s (was deadlocking with the 60s hard timeout)
- [x] `go test -timeout 120s -race ./internal/terminal/` — full terminal suite green with `-race`
- [x] `go test -timeout 120s -race ./internal/client/` — client controller suite green with `-race`
- [x] Traced both close callers (handleEvent/onClosed and Run's ctx.Done branch) to confirm CAS short-circuits the second entry