### PR TITLE
feat: add pkg/errors sentinels and pkg/api stability doc (#133)

### DIFF
--- a/pkg/api/doc.go
+++ b/pkg/api/doc.go
@@ -1,0 +1,81 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package api defines the declarative document types that external
+// library consumers use to address sbsh objects: TerminalDoc,
+// TerminalSpec, TerminalProfileDoc, ClientDoc, ConfigurationDoc, and the
+// request/response payloads exchanged over the JSON-RPC control channel.
+//
+// This package is the type-system counterpart of the YAML/JSON manifests
+// that the sbsh CLI accepts on its own command line. Library callers use
+// it together with pkg/builder (to construct specs/docs), pkg/spawn (to
+// run terminals and clients as subprocesses), pkg/discovery (to enumerate
+// live objects under a run path), pkg/rpcclient (to drive them over
+// their control sockets), and pkg/errors (to branch on well-known
+// sentinels).
+//
+// # Pre-v1 stability policy
+//
+// sbsh is pre-v1. The intent of this policy is to give library
+// consumers — notably the kukeon integration that drives umbrella
+// issue #118 — enough stability to ship without freezing the surface
+// before v1 has been validated in anger.
+//
+// Packages covered by this policy:
+//
+//   - pkg/api
+//   - pkg/builder
+//   - pkg/discovery
+//   - pkg/errors
+//   - pkg/rpcclient (and its /client and /terminal subpackages)
+//   - pkg/spawn
+//
+// What will not change between minor releases (0.x → 0.x+1):
+//
+//   - Wire schema of documents whose apiVersion is sbsh/v1beta1
+//     (TerminalProfileDoc, TerminalDoc, ClientDoc, ConfigurationDoc).
+//     Existing fields will not be removed, renamed, or re-typed within
+//     the v1beta1 apiVersion; new fields may be added.
+//   - The identity of error sentinels re-exported from pkg/errors.
+//     errors.Is against those names will continue to match errors
+//     produced anywhere in sbsh.
+//   - The shape of exported interfaces in pkg/api
+//     (TerminalController, ClientController): method removals and
+//     signature-breaking changes will not happen within a minor
+//     release.
+//
+// What may change between minor releases:
+//
+//   - Option/With* function names and defaults in pkg/builder and
+//     pkg/spawn. These are deliberately flagged pre-v1 by their own
+//     doc.go files; callers should expect churn as the library
+//     ergonomics settle.
+//   - Additions to the curated sentinel set in pkg/errors.
+//   - Additions to exported interfaces in pkg/api (new methods), and
+//     additions of new request/response payload types.
+//
+// What will not change without a deprecation cycle:
+//
+//   - Removal of any symbol currently documented in pkg/api,
+//     pkg/errors, or the subpackages listed above. Removals will be
+//     staged by marking the symbol deprecated in a minor release and
+//     removing it no earlier than the next minor release.
+//
+// v1 will be cut when the umbrella issue #118 closes and the library
+// surface has shipped at least one downstream integration. At v1 the
+// apiVersion advances out of v1beta1 and the above "may change" list
+// collapses into "will not change without a deprecation cycle".
+package api

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,101 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package errors exposes the curated set of error sentinels that external
+// sbsh library consumers are expected to branch on with errors.Is.
+//
+// Each name in this package is a direct alias for an internal sentinel in
+// internal/errdefs: identity is preserved, so
+//
+//	errors.Is(err, sbsherrors.ErrTerminalNotFoundByID)
+//
+// matches errors produced anywhere in the sbsh codebase without requiring
+// consumers to import internal/ packages (which Go's internal-visibility
+// rules forbid anyway).
+//
+// Stability: pre-v1. The set of re-exports in this package may grow
+// between minor releases as additional branching points are identified,
+// but existing names will not change meaning until v1.
+package errors
+
+import "github.com/eminwux/sbsh/internal/errdefs"
+
+// Terminal and client lookup sentinels. Returned by pkg/discovery and the
+// discovery paths underneath pkg/spawn / pkg/rpcclient when the caller
+// asked for a specific terminal or client that does not exist.
+var (
+	// ErrTerminalNotFoundByID is returned when a terminal is looked up by
+	// ID and no terminal with that ID exists under the discovery run path.
+	ErrTerminalNotFoundByID = errdefs.ErrTerminalNotFoundByID
+
+	// ErrTerminalNotFoundByName is returned when a terminal is looked up
+	// by name and no terminal with that name exists under the discovery
+	// run path.
+	ErrTerminalNotFoundByName = errdefs.ErrTerminalNotFoundByName
+
+	// ErrTerminalNotFound is the generic "terminal not found" sentinel
+	// returned by operations that accept either an ID or a name and
+	// could not resolve either.
+	ErrTerminalNotFound = errdefs.ErrTerminalNotFound
+
+	// ErrClientNotFound is returned when a client lookup does not match
+	// any live client under the discovery run path.
+	ErrClientNotFound = errdefs.ErrClientNotFound
+)
+
+// Lifecycle sentinels. Returned from stop / wait operations on a terminal
+// or client.
+var (
+	// ErrStopTerminal is returned when a stop request fails for a reason
+	// other than timeout (e.g. the underlying signal could not be
+	// delivered). Callers that want to distinguish "graceful stop did not
+	// complete in time" from "stop failed outright" should branch on
+	// ErrStopTimeout first, then fall back to ErrStopTerminal.
+	ErrStopTerminal = errdefs.ErrStopTerminal
+
+	// ErrStopTimeout is returned when a terminal did not exit within the
+	// configured stop timeout. This is distinct from ErrStopTerminal
+	// because callers may want to escalate (e.g. issue a forced stop)
+	// only on timeout, not on hard failure.
+	ErrStopTimeout = errdefs.ErrStopTimeout
+
+	// ErrWaitOnReady is returned when waiting for a terminal or client
+	// to become Ready fails (context cancelled, child exited before
+	// ready, etc). Intended for library callers that want to fail fast
+	// on readiness-related spawn failures rather than inspect the full
+	// state machine.
+	ErrWaitOnReady = errdefs.ErrWaitOnReady
+)
+
+// Streaming sentinels. Returned from subscribe-style RPCs when the
+// consumer cannot keep up with the producer.
+var (
+	// ErrSubscriberLagged is returned to a subscriber that fell behind
+	// the producer's ring buffer and was disconnected. Callers typically
+	// reconnect and resume from the latest offset.
+	ErrSubscriberLagged = errdefs.ErrSubscriberLagged
+)
+
+// Configuration sentinels. Returned when a required configuration value
+// is missing from the caller's spec / environment.
+var (
+	// ErrRunPathRequired is returned when an operation needs the sbsh
+	// run path (socket/state directory) and neither the spec, the
+	// environment, nor the default resolution could produce one.
+	// External library callers must provide StateRoot explicitly; they
+	// should treat this as a programming error.
+	ErrRunPathRequired = errdefs.ErrRunPathRequired
+)

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,0 +1,90 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package errors_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/eminwux/sbsh/internal/errdefs"
+	sbsherrors "github.com/eminwux/sbsh/pkg/errors"
+)
+
+// TestSentinelIdentity asserts that each curated re-export in pkg/errors
+// is the same sentinel value as its internal/errdefs counterpart. This is
+// the "identity preserved" contract promised to external library callers:
+// errors.Is(err, sbsherrors.ErrX) must match errors produced with
+// errdefs.ErrX anywhere in the codebase.
+func TestSentinelIdentity(t *testing.T) {
+	cases := []struct {
+		name     string
+		reexport error
+		internal error
+	}{
+		{"ErrTerminalNotFoundByID", sbsherrors.ErrTerminalNotFoundByID, errdefs.ErrTerminalNotFoundByID},
+		{"ErrTerminalNotFoundByName", sbsherrors.ErrTerminalNotFoundByName, errdefs.ErrTerminalNotFoundByName},
+		{"ErrTerminalNotFound", sbsherrors.ErrTerminalNotFound, errdefs.ErrTerminalNotFound},
+		{"ErrClientNotFound", sbsherrors.ErrClientNotFound, errdefs.ErrClientNotFound},
+		{"ErrStopTerminal", sbsherrors.ErrStopTerminal, errdefs.ErrStopTerminal},
+		{"ErrStopTimeout", sbsherrors.ErrStopTimeout, errdefs.ErrStopTimeout},
+		{"ErrWaitOnReady", sbsherrors.ErrWaitOnReady, errdefs.ErrWaitOnReady},
+		{"ErrSubscriberLagged", sbsherrors.ErrSubscriberLagged, errdefs.ErrSubscriberLagged},
+		{"ErrRunPathRequired", sbsherrors.ErrRunPathRequired, errdefs.ErrRunPathRequired},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.reexport != tc.internal {
+				t.Fatalf("pkg/errors.%s != internal/errdefs.%s: identity not preserved",
+					tc.name, tc.name)
+			}
+			if !errors.Is(tc.reexport, tc.internal) {
+				t.Errorf("errors.Is(pkg/errors.%s, errdefs.%s) = false, want true", tc.name, tc.name)
+			}
+			if !errors.Is(tc.internal, tc.reexport) {
+				t.Errorf("errors.Is(errdefs.%s, pkg/errors.%s) = false, want true", tc.name, tc.name)
+			}
+		})
+	}
+}
+
+// TestWrappedErrorsMatchReexport asserts that an error produced internally
+// (wrapped with %w around an errdefs sentinel) is matched by errors.Is
+// against the pkg/errors re-export — i.e. consumers do not have to reach
+// into internal/errdefs to branch on sbsh errors.
+func TestWrappedErrorsMatchReexport(t *testing.T) {
+	cases := []struct {
+		name     string
+		internal error
+		reexport error
+	}{
+		{"ErrTerminalNotFoundByID", errdefs.ErrTerminalNotFoundByID, sbsherrors.ErrTerminalNotFoundByID},
+		{"ErrStopTerminal", errdefs.ErrStopTerminal, sbsherrors.ErrStopTerminal},
+		{"ErrSubscriberLagged", errdefs.ErrSubscriberLagged, sbsherrors.ErrSubscriberLagged},
+		{"ErrRunPathRequired", errdefs.ErrRunPathRequired, sbsherrors.ErrRunPathRequired},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wrapped := fmt.Errorf("operation failed: %w", tc.internal)
+			if !errors.Is(wrapped, tc.reexport) {
+				t.Errorf("errors.Is(wrapped, pkg/errors.%s) = false, want true", tc.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- New `pkg/errors` re-exports the curated sentinel set external library consumers need to branch on (terminal/client not-found, stop outcomes, readiness, subscriber-lag, run-path required) without importing `internal/errdefs`.
- Identity is preserved by direct assignment (`var ErrX = errdefs.ErrX`), so `errors.Is(err, pkgerrors.ErrX)` matches errors produced anywhere in sbsh — covered by `errors_test.go` (direct comparison, `errors.Is` both directions, and through `fmt.Errorf("%w", ...)` wrapping).
- New `pkg/api/doc.go` documents the pre-v1 stability policy for the public library surface: which invariants hold across 0.x minor releases (v1beta1 wire schema, sentinel identity, controller interfaces), which are explicitly pre-v1 churn (builder/spawn options), and what will require a deprecation cycle.
- Module-hygiene audit: walked every exported signature under `pkg/api`, `pkg/builder`, `pkg/discovery`, `pkg/errors`, `pkg/rpcclient/*`, `pkg/spawn`. No `internal/*` types appear in exported positions; the existing `internal/` imports in `pkg/builder`, `pkg/discovery`, and `pkg/rpcclient/terminal` are confined to unexported fields/locals.

Refs #118 (PR-F). Does not close umbrella.

## Test plan

- [x] `make sbsh-sb` — canonical build; `file ./sbsh` is ELF executable
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/errors/... -v` — new sentinel identity suite passes
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` — all green except pre-existing `Test_HandleEvent_EvCmdExited` hang (issue #108, fix open in #139); reproduced identically on `origin/main` in an isolated worktree
- [x] `go test -tags=integration ./cmd/sb/get/...`

Closes #133