### PR TITLE
feat: add library-consumer example and reference doc

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,3 +43,9 @@ jobs:
 
       - name: Integration tests
         run: go test -tags=integration ./cmd/sb/get/...
+
+      - name: Build library-consumer example
+        working-directory: docs/examples/library-consumer
+        run: |
+          go build ./...
+          go vet ./...

--- a/docs/examples/library-consumer/.gitignore
+++ b/docs/examples/library-consumer/.gitignore
@@ -1,0 +1,1 @@
+/library-consumer

--- a/docs/examples/library-consumer/README.md
+++ b/docs/examples/library-consumer/README.md
@@ -1,0 +1,64 @@
+# library-consumer
+
+Minimal end-to-end demo of driving `sbsh` as a Go library from an external
+module.
+
+## What it does
+
+1. Builds a `TerminalSpec` inline via `pkg/builder` with a caller-supplied
+   `StateRoot` (no writes under `$HOME/.sbsh`).
+2. Spawns a detached `Terminal` subprocess via `pkg/spawn.NewTerminal`.
+3. Builds a `ClientDoc` in `AttachToTerminal` mode and spawns a `Client`
+   via `pkg/spawn.NewClient`.
+4. Drives the Terminal RPC surface via `pkg/rpcclient/terminal`:
+   `Subscribe` for live output, `Write` to inject a shell command,
+   then reads the marker back off the subscribe stream.
+5. Drives the Client RPC surface via `pkg/rpcclient/client`:
+   `State` to observe the client's lifecycle, then `Stop` to tear it
+   down cleanly.
+6. Closes both handles (`spawn.TerminalHandle.Close` /
+   `spawn.ClientHandle.Close`) as a deferred safety net.
+
+## Building
+
+The example is a **separate Go module** with a `replace` directive that
+points back at the repo root. Build it standalone:
+
+```bash
+cd docs/examples/library-consumer
+go build ./...
+```
+
+## Running
+
+You need the canonical `sbsh` + `sb` hardlink pair built first. From the
+repo root:
+
+```bash
+make sbsh-sb
+```
+
+Then run the example, pointing it at those binaries:
+
+```bash
+cd docs/examples/library-consumer
+go run . -sbsh "$(pwd)/../../../sbsh" -v
+```
+
+Flags:
+
+| Flag | Description |
+| --- | --- |
+| `-sbsh` | **Required.** Absolute path to the `sbsh` binary. |
+| `-sb` | Absolute path to the `sb` binary. Defaults to `$(dirname <sbsh>)/sb`. |
+| `-state-root` | Run path for sbsh state. Defaults to a fresh `$TMPDIR/sbsh-lib-example-*` directory (cleaned up on exit). |
+| `-v` | Log spawn/RPC internals at debug level. |
+
+## Why a separate module?
+
+A separate `go.mod` with `replace github.com/eminwux/sbsh => ../../../`
+guarantees the example only compiles against the library's public
+packages (`pkg/...`) — internal packages cannot leak in, because
+Go's visibility rules prevent external modules from importing
+`internal/`. The CI job build-tests this separate module so the
+public surface cannot silently rot.

--- a/docs/examples/library-consumer/go.mod
+++ b/docs/examples/library-consumer/go.mod
@@ -1,0 +1,13 @@
+module github.com/eminwux/sbsh/docs/examples/library-consumer
+
+go 1.24.5
+
+require github.com/eminwux/sbsh v0.0.0
+
+require (
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/sys v0.35.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+
+replace github.com/eminwux/sbsh => ../../../

--- a/docs/examples/library-consumer/go.sum
+++ b/docs/examples/library-consumer/go.sum
@@ -1,0 +1,14 @@
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/sync v0.16.0 h1:ycBJEhp9p4vXvUZNszeOq0kGTPghopOL8q0fq3vstxw=
+golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
+golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/term v0.34.0 h1:O/2T7POpk0ZZ7MAzMeWFSg6S5IpWd/RXDlM9hgM3DR4=
+golang.org/x/term v0.34.0/go.mod h1:5jC53AEywhIVebHgPVeg0mj8OD3VO9OzclacVrqpaAw=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/docs/examples/library-consumer/main.go
+++ b/docs/examples/library-consumer/main.go
@@ -1,0 +1,382 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// library-consumer is a minimal end-to-end demo of driving sbsh as a
+// Go library from an external module. It builds a TerminalSpec, spawns
+// a detached Terminal, spawns a Client that attaches to it, exchanges
+// one Write/Read round-trip over the Terminal RPC surface, drives a
+// State/Stop round-trip on the Client RPC surface, and tears both
+// processes down via spawn.Handle.Close.
+//
+// The whole run is rooted at a caller-supplied StateRoot and never
+// writes under $HOME/.sbsh.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/eminwux/sbsh/pkg/api"
+	"github.com/eminwux/sbsh/pkg/builder"
+	clientrpc "github.com/eminwux/sbsh/pkg/rpcclient/client"
+	terminalrpc "github.com/eminwux/sbsh/pkg/rpcclient/terminal"
+	"github.com/eminwux/sbsh/pkg/spawn"
+)
+
+type flags struct {
+	sbshPath  string
+	sbPath    string
+	stateRoot string
+	verbose   bool
+}
+
+func parseFlags() flags {
+	var f flags
+	flag.StringVar(&f.sbshPath, "sbsh", "", "absolute path to the sbsh binary (required)")
+	flag.StringVar(&f.sbPath, "sb", "", "absolute path to the sb binary (defaults to <dir(sbsh)>/sb)")
+	flag.StringVar(&f.stateRoot, "state-root", "",
+		"run path for sbsh state (defaults to a fresh directory under $TMPDIR)")
+	flag.BoolVar(&f.verbose, "v", false, "log spawn/RPC internals at debug level")
+	flag.Parse()
+	return f
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "library-consumer:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	f := parseFlags()
+
+	sbshPath, sbPath, err := resolveBinaries(f.sbshPath, f.sbPath)
+	if err != nil {
+		return err
+	}
+
+	stateRoot, cleanup, err := resolveStateRoot(f.stateRoot)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	logger := buildLogger(f.verbose)
+	logger.Info("library-consumer starting",
+		"sbsh", sbshPath, "sb", sbPath, "stateRoot", stateRoot)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	term, err := startTerminal(ctx, logger, stateRoot, sbshPath)
+	if err != nil {
+		return fmt.Errorf("start terminal: %w", err)
+	}
+	defer closeWithLog(ctx, logger, "terminal", term)
+
+	cli, err := startClient(ctx, logger, stateRoot, sbPath, term.Spec())
+	if err != nil {
+		return fmt.Errorf("start client: %w", err)
+	}
+	defer closeWithLog(ctx, logger, "client", cli)
+
+	if err := driveTerminalRPC(ctx, logger, term); err != nil {
+		return fmt.Errorf("terminal RPC round-trip: %w", err)
+	}
+
+	if err := driveClientRPC(ctx, logger, cli); err != nil {
+		return fmt.Errorf("client RPC round-trip: %w", err)
+	}
+
+	logger.Info("library-consumer completed successfully")
+	return nil
+}
+
+// resolveBinaries validates the sbsh/sb paths and fills sb from
+// filepath.Dir(sbsh)/sb when the caller omits it. Both paths must exist
+// and be regular files — spawn.NewTerminal/NewClient do not consult
+// $PATH, so we fail fast here rather than on the first exec.
+func resolveBinaries(sbsh, sb string) (string, string, error) {
+	if sbsh == "" {
+		return "", "", errors.New("-sbsh is required (absolute path to the sbsh binary)")
+	}
+	abs, err := filepath.Abs(sbsh)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve -sbsh: %w", err)
+	}
+	sbsh = abs
+	if err := mustBeRegularFile(sbsh); err != nil {
+		return "", "", fmt.Errorf("sbsh binary: %w", err)
+	}
+
+	if sb == "" {
+		sb = filepath.Join(filepath.Dir(sbsh), "sb")
+	}
+	absSb, err := filepath.Abs(sb)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve -sb: %w", err)
+	}
+	sb = absSb
+	if err := mustBeRegularFile(sb); err != nil {
+		return "", "", fmt.Errorf("sb binary: %w", err)
+	}
+	return sbsh, sb, nil
+}
+
+func mustBeRegularFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%q is not a regular file", path)
+	}
+	return nil
+}
+
+// resolveStateRoot returns an absolute run path plus a cleanup func
+// that removes it at shutdown when the example created it itself.
+// If the caller supplies a path we use it verbatim and leave it in
+// place — the caller is presumed to own that directory.
+func resolveStateRoot(supplied string) (string, func(), error) {
+	if supplied != "" {
+		abs, err := filepath.Abs(supplied)
+		if err != nil {
+			return "", func() {}, fmt.Errorf("resolve -state-root: %w", err)
+		}
+		if err := os.MkdirAll(abs, 0o700); err != nil {
+			return "", func() {}, fmt.Errorf("create -state-root: %w", err)
+		}
+		return abs, func() {}, nil
+	}
+	dir, err := os.MkdirTemp("", "sbsh-lib-example-*")
+	if err != nil {
+		return "", func() {}, fmt.Errorf("create temp state root: %w", err)
+	}
+	return dir, func() { _ = os.RemoveAll(dir) }, nil
+}
+
+func buildLogger(verbose bool) *slog.Logger {
+	level := slog.LevelInfo
+	if verbose {
+		level = slog.LevelDebug
+	}
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
+}
+
+// startTerminal builds a TerminalSpec inline (no profile lookup, no
+// $HOME/.sbsh access) and spawns the terminal as a detached subprocess.
+// It blocks until the terminal's control socket accepts RPC calls.
+func startTerminal(
+	ctx context.Context,
+	logger *slog.Logger,
+	stateRoot, sbshPath string,
+) (*spawn.TerminalHandle, error) {
+	spec, err := builder.BuildTerminalSpec(ctx, logger, stateRoot,
+		builder.WithName("library-consumer-example"),
+		builder.WithCommand([]string{"/bin/bash", "--norc", "--noprofile"}),
+		builder.WithEnv(map[string]string{"PS1": "example> "}),
+		builder.WithDisableSetPrompt(true),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("build terminal spec: %w", err)
+	}
+	logger.Info("terminal spec built",
+		"id", spec.ID, "name", spec.Name, "socket", spec.SocketFile)
+
+	term, err := spawn.NewTerminal(ctx, spec, spawn.TerminalOptions{
+		BinaryPath:   sbshPath,
+		ExtraArgs:    []string{"--run-path", stateRoot},
+		Logger:       logger,
+		ReadyTimeout: 15 * time.Second,
+		// Stdout/Stderr intentionally nil so the child's output goes to
+		// /dev/null; the capture file and log file under stateRoot hold
+		// the real detail.
+	})
+	if err != nil {
+		return nil, err
+	}
+	logger.Info("terminal spawned", "pid", term.PID(), "socket", term.SocketPath())
+
+	if err := term.WaitReady(ctx); err != nil {
+		_ = term.Close(ctx)
+		return nil, fmt.Errorf("waitReady: %w", err)
+	}
+	logger.Info("terminal ready")
+	return term, nil
+}
+
+// startClient builds a ClientDoc in AttachToTerminal mode, spawns the
+// client process, and blocks until its control socket is ready.
+func startClient(
+	ctx context.Context,
+	logger *slog.Logger,
+	stateRoot, sbPath string,
+	termSpec *api.TerminalSpec,
+) (*spawn.ClientHandle, error) {
+	doc, err := builder.BuildClientDoc(ctx, logger, stateRoot,
+		builder.WithClientName("library-consumer-client"),
+		builder.WithClientMode(api.AttachToTerminal),
+		// Attach by Name only. The underlying spawn helper would also
+		// accept ID, but the `sb attach` CLI currently requires a
+		// positional name (the --id flag is rejected alongside
+		// positional args and without them returns
+		// ErrNoTerminalIdentifier), so Name is the path that works
+		// end-to-end today.
+		builder.WithClientTerminalSpec(&api.TerminalSpec{
+			Name: termSpec.Name,
+		}),
+		// Disable the interactive detach keystroke — this client is
+		// RPC-driven, not TTY-driven.
+		builder.WithClientDetachKeystroke(false),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("build client doc: %w", err)
+	}
+	logger.Info("client doc built",
+		"id", doc.Spec.ID, "name", doc.Metadata.Name, "socket", doc.Spec.SockerCtrl)
+
+	cli, err := spawn.NewClient(ctx, doc, spawn.ClientOptions{
+		BinaryPath:   sbPath,
+		ExtraArgs:    []string{"--run-path", stateRoot},
+		Logger:       logger,
+		ReadyTimeout: 15 * time.Second,
+		// Stdin/Stdout/Stderr intentionally nil — this client is
+		// RPC-driven, not TTY-driven, and the per-client log under
+		// stateRoot holds the detail.
+	})
+	if err != nil {
+		return nil, err
+	}
+	logger.Info("client spawned", "pid", cli.PID(), "socket", cli.SocketPath())
+
+	if err := cli.WaitReady(ctx); err != nil {
+		_ = cli.Close(ctx)
+		return nil, fmt.Errorf("waitReady: %w", err)
+	}
+	logger.Info("client ready")
+	return cli, nil
+}
+
+// driveTerminalRPC demonstrates the Write/Read round-trip: it
+// subscribes to the terminal's live byte stream, writes one shell
+// command, and drains a bounded window of output until the marker
+// echo lands or the deadline elapses.
+func driveTerminalRPC(
+	ctx context.Context,
+	logger *slog.Logger,
+	term *spawn.TerminalHandle,
+) error {
+	trpc := terminalrpc.NewUnix(term.SocketPath(), logger)
+
+	subCtx, subCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer subCancel()
+	stream, err := trpc.Subscribe(
+		subCtx,
+		&api.SubscribeRequest{ClientID: api.ID("library-consumer")},
+		&api.Empty{},
+	)
+	if err != nil {
+		return fmt.Errorf("Subscribe: %w", err)
+	}
+	defer stream.Close()
+
+	const marker = "sbsh-library-consumer-marker"
+	payload := []byte(fmt.Sprintf("echo %s\n", marker))
+	writeCtx, writeCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer writeCancel()
+	if err := trpc.Write(writeCtx, &api.WriteRequest{Data: payload}); err != nil {
+		return fmt.Errorf("Write: %w", err)
+	}
+	logger.Info("wrote to terminal", "bytes", len(payload))
+
+	deadline := time.Now().Add(5 * time.Second)
+	_ = stream.SetReadDeadline(deadline)
+	var seen strings.Builder
+	buf := make([]byte, 4096)
+	for time.Now().Before(deadline) {
+		n, readErr := stream.Read(buf)
+		if n > 0 {
+			seen.Write(buf[:n])
+			if strings.Contains(seen.String(), marker) {
+				logger.Info("observed marker in terminal output", "marker", marker)
+				return nil
+			}
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				return errors.New("terminal stream closed before marker arrived")
+			}
+			return fmt.Errorf("read subscribe stream: %w", readErr)
+		}
+	}
+	return fmt.Errorf("marker %q not observed within deadline; got %q", marker, seen.String())
+}
+
+// driveClientRPC exercises ClientController.State and Stop. Calling
+// Stop tears the client process down cleanly; the handle's deferred
+// Close in main() then becomes a no-op safety net.
+func driveClientRPC(
+	ctx context.Context,
+	logger *slog.Logger,
+	cli *spawn.ClientHandle,
+) error {
+	crpc := clientrpc.NewUnix(cli.SocketPath())
+
+	stateCtx, stateCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer stateCancel()
+	var state api.ClientStatusMode
+	if err := crpc.State(stateCtx, &state); err != nil {
+		return fmt.Errorf("State: %w", err)
+	}
+	logger.Info("client state observed", "state", state.String())
+
+	stopCtx, stopCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer stopCancel()
+	if err := crpc.Stop(stopCtx, &api.StopArgs{Reason: "library-consumer done"}); err != nil {
+		return fmt.Errorf("Stop: %w", err)
+	}
+	logger.Info("client stop requested")
+	return nil
+}
+
+// handleCloser is the shape both TerminalHandle and ClientHandle
+// already satisfy; it lets us share the deferred-close helper below.
+type handleCloser interface {
+	Close(context.Context) error
+}
+
+// closeWithLog runs during defer and must not shadow the primary
+// error path. It uses a fresh short-deadline context so a caller's
+// cancelled ctx doesn't prevent graceful shutdown.
+func closeWithLog(_ context.Context, logger *slog.Logger, name string, h handleCloser) {
+	closeCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := h.Close(closeCtx); err != nil {
+		logger.Warn("close returned error", "handle", name, "error", err)
+		return
+	}
+	logger.Info("closed", "handle", name)
+}

--- a/docs/site/reference/library.md
+++ b/docs/site/reference/library.md
@@ -1,0 +1,217 @@
+# Go library reference
+
+sbsh ships a small public Go library so external programs can spawn,
+drive, and tear down `Terminal` and `Client` processes without shelling
+out to `sb` / `sbsh` or importing `internal/` packages. This page
+documents the supported surface and its stability promise.
+
+A complete, build-tested example lives at
+[`docs/examples/library-consumer/`](https://github.com/eminwux/sbsh/tree/main/docs/examples/library-consumer).
+
+## Supported packages
+
+The public library lives under [`github.com/eminwux/sbsh/pkg`](https://pkg.go.dev/github.com/eminwux/sbsh/pkg):
+
+| Package | Purpose |
+| --- | --- |
+| `pkg/api` | Declarative document types (`TerminalDoc`, `TerminalSpec`, `ClientDoc`, `TerminalProfileDoc`, …) and RPC payload types (`PingMessage`, `WriteRequest`, `SubscribeRequest`, `StopArgs`, …). Counterpart of the YAML/JSON manifests. |
+| `pkg/builder` | Construct a `TerminalSpec` or `ClientDoc` from a profile name plus inline overrides (`WithProfile`, `WithProfilesDir`, `WithCommand`, `WithEnv`, `WithClientMode`, …). No YAML round-trip. |
+| `pkg/spawn` | Launch detached `Terminal` and `Client` subprocesses (`NewTerminal`, `NewClient`). Returns `TerminalHandle` / `ClientHandle` with `PID`, `SocketPath`, `WaitReady`, `WaitClose`, `Close`. |
+| `pkg/discovery` | Enumerate live terminals/clients or look them up by ID/Name under a run path (`ScanTerminals`, `FindTerminalByID`, `FindTerminalByName`, `ScanClients`, `FindClientByName`). Load profiles from disk (`LoadProfilesFromDir`, `FindProfileByNameInDir`). |
+| `pkg/rpcclient/terminal` | JSON-RPC client for the `TerminalController` socket (`Ping`, `Resize`, `Attach`, `Detach`, `Metadata`, `State`, `Stop`, `Write`, `Subscribe`). |
+| `pkg/rpcclient/client` | JSON-RPC client for the `ClientController` socket (`Ping`, `Metadata`, `State`, `Stop`, `Detach`). |
+| `pkg/errors` | Curated error sentinels re-exported from `internal/errdefs`. Use `errors.Is` to branch on well-known failure modes without importing internal packages. |
+
+Nothing under `internal/` is part of the supported surface and
+Go's visibility rules prevent external modules from importing it.
+
+## StateRoot contract
+
+Every operation that touches disk derives its paths from a single
+**run path** (also called StateRoot in kukeon, `--run-path` on the
+CLI). External callers **must** supply this path explicitly — an
+empty run path returns `errors.ErrRunPathRequired`. There is no
+silent fallback to `$HOME/.sbsh`; the point of the parameter is to
+let callers run several isolated sbsh stacks on one host.
+
+Given a run path `R`, the stack writes:
+
+- `R/terminals/<id>/{metadata.json,socket,capture,log}` — one
+  directory per spawned terminal.
+- `R/clients/<id>/{metadata.json,socket,log}` — one directory
+  per spawned client.
+- `R/.sbsh/profiles.d/` — the default profile-lookup directory
+  when `WithProfilesDir` is not set. Override with
+  `WithProfilesDir(myPath)` to point anywhere else.
+
+Library consumers are expected to pass the same run path to every
+pkg call in a given operation, and to pass the child processes a
+matching `--run-path` flag. `pkg/spawn` does this for you via
+`TerminalOptions.ExtraArgs` / `ClientOptions.ExtraArgs`.
+
+## Binary-path contract
+
+`pkg/spawn` deliberately does **not** consult `$PATH`. Callers
+must set `TerminalOptions.BinaryPath` / `ClientOptions.BinaryPath`
+to an absolute path of an `sbsh` or `sb` binary that supports the
+relevant subcommands. This keeps state-root-style isolation from
+being silently broken by whatever happens to be first on the
+system path.
+
+Both binaries are produced by the canonical `make sbsh-sb` target:
+`sbsh` is the real ELF and `sb` is a hard link to it; argv[0]
+selects the subtree. Pass the `sbsh` path to `NewTerminal` and the
+`sb` path to `NewClient`.
+
+## Pre-v1 stability policy
+
+sbsh is pre-v1. The intent of this policy is to give library
+consumers — notably the kukeon integration that drives umbrella
+issue [#118](https://github.com/eminwux/sbsh/issues/118) — enough
+stability to ship without freezing the surface before v1 has been
+validated in anger.
+
+**What will not change between minor releases (0.x → 0.x+1):**
+
+- Wire schema of documents whose `apiVersion` is `sbsh/v1beta1`
+  (`TerminalProfileDoc`, `TerminalDoc`, `ClientDoc`, `ConfigurationDoc`).
+  Existing fields will not be removed, renamed, or re-typed within
+  the v1beta1 apiVersion; new fields may be added.
+- The identity of error sentinels re-exported from `pkg/errors`.
+  `errors.Is` against those names will continue to match errors
+  produced anywhere in sbsh.
+- The shape of exported interfaces in `pkg/api`
+  (`TerminalController`, `ClientController`): method removals and
+  signature-breaking changes will not happen within a minor
+  release.
+
+**What may change between minor releases:**
+
+- Option / `With*` function names and defaults in `pkg/builder` and
+  `pkg/spawn`. Callers should expect churn as the library ergonomics
+  settle.
+- Additions to the curated sentinel set in `pkg/errors`.
+- Additions to exported interfaces in `pkg/api` (new methods) and
+  additions of new request/response payload types.
+
+**What will not change without a deprecation cycle:**
+
+- Removal of any symbol currently documented in `pkg/api`,
+  `pkg/errors`, or any subpackage listed above. Removals will be
+  staged by marking the symbol deprecated in a minor release and
+  removing it no earlier than the next minor release.
+
+v1 will be cut when umbrella issue
+[#118](https://github.com/eminwux/sbsh/issues/118) closes and the
+library surface has shipped at least one downstream integration.
+At v1 the apiVersion advances out of `v1beta1` and the above "may
+change" list collapses into "will not change without a deprecation
+cycle". See the godoc for
+[`pkg/api`](https://pkg.go.dev/github.com/eminwux/sbsh/pkg/api)
+for the authoritative copy of this policy.
+
+## Walkthrough
+
+The steps below mirror
+[`docs/examples/library-consumer/main.go`](https://github.com/eminwux/sbsh/tree/main/docs/examples/library-consumer).
+
+### 1. Build a `TerminalSpec`
+
+```go
+spec, err := builder.BuildTerminalSpec(ctx, logger, stateRoot,
+    builder.WithName("library-consumer-example"),
+    builder.WithCommand([]string{"/bin/bash", "--norc", "--noprofile"}),
+    builder.WithEnv(map[string]string{"PS1": "example> "}),
+    builder.WithDisableSetPrompt(true),
+)
+```
+
+`runPath` is required; everything else has a sane default. Set
+`WithProfile(name)` + `WithProfilesDir(dir)` to load from a profiles
+directory. Inline `With*` values override profile values.
+
+### 2. Spawn the terminal
+
+```go
+term, err := spawn.NewTerminal(ctx, spec, spawn.TerminalOptions{
+    BinaryPath:   sbshPath,
+    ExtraArgs:    []string{"--run-path", stateRoot},
+    Logger:       logger,
+    ReadyTimeout: 15 * time.Second,
+})
+if err := term.WaitReady(ctx); err != nil { /* handle */ }
+```
+
+`WaitReady` blocks until the terminal's control socket accepts a
+Ping. It returns `ErrProcessExited` if the child dies before
+ready, `ErrReadyTimeout` on the internal cap, or `ctx.Err()` on
+cancellation.
+
+### 3. Spawn a client that attaches
+
+```go
+doc, err := builder.BuildClientDoc(ctx, logger, stateRoot,
+    builder.WithClientName("library-consumer-client"),
+    builder.WithClientMode(api.AttachToTerminal),
+    builder.WithClientTerminalSpec(&api.TerminalSpec{Name: spec.Name}),
+    builder.WithClientDetachKeystroke(false),
+)
+
+cli, err := spawn.NewClient(ctx, doc, spawn.ClientOptions{
+    BinaryPath:   sbPath,
+    ExtraArgs:    []string{"--run-path", stateRoot},
+    Logger:       logger,
+    ReadyTimeout: 15 * time.Second,
+})
+if err := cli.WaitReady(ctx); err != nil { /* handle */ }
+```
+
+### 4. Drive the Terminal RPC surface
+
+```go
+trpc := terminalrpc.NewUnix(term.SocketPath(), logger)
+
+// Subscribe BEFORE writing so no output is missed.
+stream, err := trpc.Subscribe(ctx,
+    &api.SubscribeRequest{ClientID: api.ID("library-consumer")},
+    &api.Empty{})
+defer stream.Close()
+
+err = trpc.Write(ctx, &api.WriteRequest{Data: []byte("echo hello\n")})
+// Read bytes off stream.Read(...) with a deadline.
+```
+
+`Subscribe` returns a live `net.Conn` that streams PTY output as raw
+bytes — no ANSI stripping, no line framing. Callers typically set
+a read deadline and scan for a known marker.
+
+### 5. Drive the Client RPC surface
+
+```go
+crpc := clientrpc.NewUnix(cli.SocketPath())
+var state api.ClientStatusMode
+_ = crpc.State(ctx, &state)            // observe lifecycle
+_ = crpc.Stop(ctx, &api.StopArgs{Reason: "done"}) // tear down client
+```
+
+### 6. Close the handles
+
+```go
+defer term.Close(ctx)
+defer cli.Close(ctx)
+```
+
+`Close` is idempotent: it sends a Stop RPC, escalates to SIGTERM
+and then SIGKILL if needed, and returns the process exit error
+(nil on clean exit). When `Stop` has already triggered shutdown
+the deferred `Close` becomes a safety net — expect a non-zero
+exit status to surface here because the child exited in response
+to the Stop signal.
+
+## See also
+
+- [Architecture: process model](../architecture/process-model.md) — how
+  Terminal and Client processes relate on the wire.
+- [Concepts: client](../concepts/client.md) — what a Client is and
+  what `AttachToTerminal` vs `RunNewTerminal` mean.
+- [`pkg/api` godoc](https://pkg.go.dev/github.com/eminwux/sbsh/pkg/api) — authoritative type documentation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,8 @@ nav:
       - cli/commands.md
       - cli/sbsh.md
       - cli/sb.md
+  - Library Reference:
+      - reference/library.md
   - Tutorials:
       - tutorials/create-your-first-profile.md
       - tutorials/share-a-terminal.md

--- a/pkg/spawn/terminal.go
+++ b/pkg/spawn/terminal.go
@@ -196,7 +196,7 @@ func (h *TerminalHandle) WaitReady(ctx context.Context) error {
 
 		if _, err := os.Stat(h.socketPath); err == nil {
 			pingCtx, pingCancel := context.WithTimeout(readyCtx, poll)
-			pingErr := rpc.Ping(pingCtx, &api.PingMessage{Message: "spawn.WaitReady"}, &api.PingMessage{})
+			pingErr := rpc.Ping(pingCtx, &api.PingMessage{Message: "PING"}, &api.PingMessage{})
 			pingCancel()
 			if pingErr == nil {
 				return nil


### PR DESCRIPTION
## Summary

- Adds `docs/examples/library-consumer/` — a standalone Go module (separate `go.mod` with `replace ../../../`) that drives an end-to-end sbsh lifecycle via the public `pkg/` surface: builds a `TerminalSpec` via `pkg/builder`, spawns a `Terminal` + attached `Client` via `pkg/spawn`, writes one shell command and reads it back off `Subscribe`, observes the client state and tears it down via `pkg/rpcclient/client`, and closes both handles. Runs under a caller-supplied StateRoot with zero writes under `$HOME/.sbsh`.
- Adds a CI step (`Build library-consumer example`) that `go build`s + `go vet`s the standalone module on every push/PR so the public surface cannot silently rot.
- Adds `docs/site/reference/library.md` documenting the supported packages, StateRoot / BinaryPath contracts, pre-v1 stability policy, and a step-by-step walkthrough linking the example; wires it into the mkdocs nav under **Library Reference**.
- Fixes a pre-existing bug in `pkg/spawn` surfaced by the example: `TerminalHandle.WaitReady` pinged the terminal server with `Message: "spawn.WaitReady"`, which the server rejects (`internal/terminal.Controller.Ping` only accepts `"PING"`). Every library `NewTerminal` call was therefore unable to pass readiness until the internal timeout fired. Aligned the ping message with the client-side path (`pkg/spawn/client.go` already uses `"PING"`). Without this fix the new example cannot meet the acceptance criterion "runs end-to-end".

## Test plan

- [x] `make sbsh-sb` — canonical binary builds, `file ./sbsh` is ELF.
- [x] `go build ./...` / `go vet ./...` on the root module.
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` — all packages green, including `pkg/spawn` and `pkg/builder`.
- [x] `go test -tags=integration ./cmd/sb/get/...` — green.
- [x] `E2E_BIN_DIR=$(pwd) go test -timeout=10m ./e2e` — green.
- [x] `cd docs/examples/library-consumer && go build ./... && go vet ./...` — standalone module compiles + vets clean.
- [x] `go run . -sbsh /path/to/sbsh` — full lifecycle completes with `library-consumer completed successfully`, marker round-trip observed, client state `Attached`, client `Stop` acknowledged. Verified no writes under `$HOME/.sbsh` via a `find $HOME/.sbsh -newer <marker>` baseline check.

Closes #134
Refs #118