### PR TITLE
feat: PID-1 reaper, signal forwarder, and graceful shutdown

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -204,4 +204,6 @@ var (
 	SBSH_TERM_SPEC = DefineKV("SBSH_TERM_SPEC", "sbsh.terminal.spec")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SBSH_TERM_DISABLE_SET_PROMPT = DefineKV("SBSH_TERM_DISABLE_SET_PROMPT", "sbsh.terminal.disableSetPrompt")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SBSH_TERM_SHUTDOWN_GRACE = DefineKV("SBSH_TERM_SHUTDOWN_GRACE", "sbsh.terminal.shutdownGrace")
 )

--- a/cmd/sbsh/terminal/terminal.go
+++ b/cmd/sbsh/terminal/terminal.go
@@ -92,6 +92,7 @@ func buildTerminalSpecFromFlags(cmd *cobra.Command, logger *slog.Logger) (*api.T
 			LogLevel:         viper.GetString(config.SBSH_TERM_LOG_LEVEL.ViperKey),
 			SocketFile:       viper.GetString(config.SBSH_TERM_SOCKET.ViperKey),
 			DisableSetPrompt: viper.GetBool(config.SBSH_TERM_DISABLE_SET_PROMPT.ViperKey),
+			ShutdownGrace:    viper.GetDuration(config.SBSH_TERM_SHUTDOWN_GRACE.ViperKey),
 		},
 	)
 
@@ -363,6 +364,13 @@ func setupTerminalCmdFlags(terminalCmd *cobra.Command) {
 
 	terminalCmd.Flags().Bool("disable-set-prompt", false, "Disable setting the prompt")
 	_ = viper.BindPFlag(config.SBSH_TERM_DISABLE_SET_PROMPT.ViperKey, terminalCmd.Flags().Lookup("disable-set-prompt"))
+
+	terminalCmd.Flags().Duration(
+		"shutdown-grace",
+		profile.DefaultShutdownGrace,
+		"How long to wait after SIGTERM before escalating to SIGKILL on the child",
+	)
+	_ = viper.BindPFlag(config.SBSH_TERM_SHUTDOWN_GRACE.ViperKey, terminalCmd.Flags().Lookup("shutdown-grace"))
 }
 
 func runTerminal(

--- a/internal/initmode/initmode.go
+++ b/internal/initmode/initmode.go
@@ -1,0 +1,58 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package initmode reports whether the current sbsh process should take on
+// PID-1 responsibilities (zombie reaping, signal forwarding). It exists so
+// those code paths can be exercised from tests without actually being PID 1.
+package initmode
+
+import (
+	"os"
+	"sync/atomic"
+)
+
+// override, when non-zero, forces IsInit to return true (1) or false (2)
+// regardless of os.Getpid(). Tests flip this via Enable.
+var override atomic.Int32
+
+// IsInit reports whether this process should act as container init. Default
+// is os.Getpid() == 1. Tests can force the value via Enable.
+func IsInit() bool {
+	switch override.Load() {
+	case 1:
+		return true
+	case 2:
+		return false
+	default:
+		return os.Getpid() == 1
+	}
+}
+
+// Enable forces IsInit to return on. It must be called before any subsystem
+// that reads IsInit has started. Passing false forces IsInit off.
+func Enable(on bool) {
+	if on {
+		override.Store(1)
+	} else {
+		override.Store(2)
+	}
+}
+
+// Reset clears any Enable override, returning IsInit to the os.Getpid()
+// default. Intended for test teardown.
+func Reset() {
+	override.Store(0)
+}

--- a/internal/initmode/initmode_test.go
+++ b/internal/initmode/initmode_test.go
@@ -1,0 +1,53 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package initmode
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIsInit_DefaultMatchesPID(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	want := os.Getpid() == 1
+	if got := IsInit(); got != want {
+		t.Fatalf("IsInit()=%v, want %v (pid=%d)", got, want, os.Getpid())
+	}
+}
+
+func TestEnable_ForcesValue(t *testing.T) {
+	Reset()
+	t.Cleanup(Reset)
+
+	Enable(true)
+	if !IsInit() {
+		t.Fatalf("Enable(true): IsInit()=false, want true")
+	}
+
+	Enable(false)
+	if IsInit() {
+		t.Fatalf("Enable(false): IsInit()=true, want false")
+	}
+
+	Reset()
+	want := os.Getpid() == 1
+	if got := IsInit(); got != want {
+		t.Fatalf("after Reset: IsInit()=%v, want %v", got, want)
+	}
+}

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -23,6 +23,7 @@ import (
 	"log/slog"
 	"path/filepath"
 	"sort"
+	"time"
 
 	"github.com/eminwux/sbsh/internal/defaults"
 	"github.com/eminwux/sbsh/internal/discovery"
@@ -125,6 +126,7 @@ type BuildTerminalSpecParams struct {
 	SocketFile       string
 	EnvVars          []string
 	DisableSetPrompt bool
+	ShutdownGrace    time.Duration
 }
 
 // BuildTerminalSpec builds a TerminalSpec from command-line inputs and/or a profile.
@@ -269,7 +271,14 @@ func addInputValuesToTerminal(terminalSpec *api.TerminalSpec, input *BuildTermin
 	terminalSpec.Env = append(terminalSpec.Env, input.EnvVars...)
 	// Inverted logic: when DisableSetPrompt is true, SetPrompt is false
 	terminalSpec.SetPrompt = !input.DisableSetPrompt
+	if input.ShutdownGrace > 0 {
+		terminalSpec.ShutdownGrace = input.ShutdownGrace
+	}
 }
+
+// DefaultShutdownGrace matches Kubernetes terminationGracePeriodSeconds so
+// kukeon-injected PID-1 sbsh exits predictably under `kuke stop cell`.
+const DefaultShutdownGrace = 30 * time.Second
 
 // GetDefaultHardcodedProfile constructs a default TerminalProfileDoc using command-line or terminal defaults.
 // Used when no profile is found; logs the fallback and builds the profile from BuildTerminalSpecParams.

--- a/internal/terminal/terminalrunner/lifecycle.go
+++ b/internal/terminal/terminalrunner/lifecycle.go
@@ -17,13 +17,16 @@
 package terminalrunner
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/creack/pty"
+	"github.com/eminwux/sbsh/internal/profile"
 	"github.com/eminwux/sbsh/pkg/api"
 )
 
@@ -72,6 +75,89 @@ func (sr *Exec) waitOnTerminal() {
 	trySendEvent(sr.logger, sr.evCh, Event{ID: sr.id, Type: EvCmdExited, Err: err, When: time.Now()})
 }
 
+// watchChildExit waits for the tracked child to exit and publishes the
+// "process exited" close request. When PID-1 init mode is on, the reaper has
+// already consumed the SIGCHLD, so os/exec.Cmd.Wait would race and may see
+// ECHILD instead of the real status. The reaper's TrackedExitCh is the
+// authoritative signal in that case; outside init mode, cmd.Wait() is.
+func (sr *Exec) watchChildExit() {
+	pid := 0
+	if sr.cmd != nil && sr.cmd.Process != nil {
+		pid = sr.cmd.Process.Pid
+	}
+	sr.logger.Debug("watching child process", "parent_pid", os.Getpid(), "child_pid", pid)
+
+	var exitErr error
+	if sr.initMode && sr.reaper != nil {
+		code, ok := <-sr.reaper.TrackedExitCh()
+		if ok {
+			exitErr = fmt.Errorf("shell process exited: code=%d", code)
+		} else {
+			exitErr = errors.New("shell process exited")
+		}
+		// Release the os.Process handle so Go doesn't hold on to the
+		// kernel reference now that the reaper has already reaped the
+		// PID. A subsequent cmd.Wait() would return ECHILD — we skip it.
+		if sr.cmd != nil && sr.cmd.Process != nil {
+			_ = sr.cmd.Process.Release()
+		}
+	} else {
+		_ = sr.cmd.Wait()
+		exitErr = errors.New("the shell process has exited")
+	}
+
+	sr.logger.Info("child process has exited", "parent_pid", os.Getpid(), "child_pid", pid)
+	sr.markChildDone()
+	// waitOnTerminal reads from closeReqCh; send is allowed to block
+	// briefly if Close is racing.
+	select {
+	case sr.closeReqCh <- exitErr:
+	case <-sr.ctx.Done():
+	}
+}
+
+// shutdownChild runs the graceful shutdown sequence for the tracked child:
+//
+//  1. If the child has already exited, return immediately.
+//  2. Send SIGTERM to the child's process group.
+//  3. Wait up to grace for child exit.
+//  4. If still alive, send SIGKILL to the process group.
+//
+// Grace <= 0 falls back to the package default. Must only be called after
+// startPty has run (cmd and cmd.Process are set).
+func (sr *Exec) shutdownChild(grace time.Duration) {
+	if sr.cmd == nil || sr.cmd.Process == nil {
+		return
+	}
+	if sr.childDone() {
+		return
+	}
+	if grace <= 0 {
+		grace = profile.DefaultShutdownGrace
+	}
+
+	pid := sr.cmd.Process.Pid
+	// Setsid: true ensures pgid == pid for the child.
+	if err := syscall.Kill(-pid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
+		sr.logger.Warn("could not SIGTERM child process group", "id", sr.id, "pid", pid, "err", err)
+	}
+
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	select {
+	case <-sr.childDoneCh:
+		sr.logger.Debug("child exited within grace period", "id", sr.id, "grace", grace)
+		return
+	case <-timer.C:
+		sr.logger.Warn("child did not exit within grace, escalating to SIGKILL",
+			"id", sr.id, "pid", pid, "grace", grace)
+	}
+
+	if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		sr.logger.Warn("could not SIGKILL child process group", "id", sr.id, "pid", pid, "err", err)
+	}
+}
+
 func (sr *Exec) Close(reason error) error {
 	sr.logger.Info("closing terminal", "id", sr.id, "reason", reason)
 
@@ -79,9 +165,24 @@ func (sr *Exec) Close(reason error) error {
 		sr.logger.Error("failed to update terminal state", "id", sr.id, "err", err)
 	}
 
+	// Graceful shutdown of the child before tearing anything else down:
+	// SIGTERM -> wait up to ShutdownGrace -> SIGKILL. This runs regardless
+	// of PID-1 status; removing the always-hard-kill default is correct in
+	// every mode.
+	sr.shutdownChild(sr.metadata.Spec.ShutdownGrace)
+
 	sr.ctxCancel()
 
 	sr.logger.Debug("terminal closed", "id", sr.id)
+
+	// Tear down PID-1 helpers (no-ops outside init mode).
+	if sr.stopSignalForwarder != nil {
+		sr.stopSignalForwarder()
+		sr.stopSignalForwarder = nil
+	}
+	if sr.reaper != nil {
+		sr.reaper.Stop()
+	}
 
 	// stop accepting
 	if sr.lnCtrl != nil {
@@ -104,12 +205,6 @@ func (sr *Exec) Close(reason error) error {
 	// close all output subscribers
 	sr.closeAllSubscribers()
 
-	// kill PTY child and close PTY master as needed
-	if sr.cmd != nil && sr.cmd.Process != nil {
-		if err := sr.cmd.Process.Kill(); err != nil {
-			sr.logger.Warn("could not kill cmd process", "id", sr.id, "err", err)
-		}
-	}
 	if sr.ptmx != nil {
 		var err error
 		sr.closePTY.Do(func() {

--- a/internal/terminal/terminalrunner/lifecycle_shutdown_test.go
+++ b/internal/terminal/terminalrunner/lifecycle_shutdown_test.go
@@ -1,0 +1,175 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrunner
+
+import (
+	"io"
+	"log/slog"
+	"os/exec"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// newShutdownTestExec constructs a minimal Exec suitable for exercising
+// shutdownChild without spinning up the full runner (no PTY, no RPC, no
+// metadata). The caller is responsible for calling cmd.Start before invoking
+// Close-path helpers; after cmd.Start, the background goroutine watches for
+// exit and fires markChildDone exactly once.
+func newShutdownTestExec(t *testing.T, cmd *exec.Cmd) *Exec {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	sr := &Exec{
+		logger:        logger,
+		id:            "test",
+		cmd:           cmd,
+		childDoneCh:   make(chan struct{}),
+		childDoneOnce: &sync.Once{},
+	}
+	return sr
+}
+
+// startWaiter spawns a goroutine that Waits on the child and fires
+// markChildDone once. This stands in for the runner's watchChildExit under
+// test; the runner does the same on non-init mode.
+func startWaiter(sr *Exec) <-chan *exec.ExitError {
+	done := make(chan *exec.ExitError, 1)
+	go func() {
+		err := sr.cmd.Wait()
+		exitErr, _ := err.(*exec.ExitError)
+		done <- exitErr
+		sr.markChildDone()
+	}()
+	return done
+}
+
+// TestShutdownChild_HappyPath: child exits on SIGTERM before grace; no
+// SIGKILL fallback fires. We infer "no SIGKILL" from the child's exit
+// status: SIGTERM (signal 15) versus SIGKILL (signal 9).
+func TestShutdownChild_HappyPath(t *testing.T) {
+	// Trap TERM, exit 0 cleanly on receipt. Uses "sleep & wait" so sh does
+	// not tail-call-exec sleep.
+	cmd := exec.Command("/bin/sh", "-c", `trap 'exit 0' TERM; sleep 10 & wait`)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	sr := newShutdownTestExec(t, cmd)
+	sr.metadata.Spec.ShutdownGrace = 2 * time.Second
+
+	waitErr := startWaiter(sr)
+	// Shell startup grace: ensure `trap 'exit 0' TERM` is installed before
+	// we signal.
+	time.Sleep(100 * time.Millisecond)
+
+	start := time.Now()
+	sr.shutdownChild(sr.metadata.Spec.ShutdownGrace)
+	elapsed := time.Since(start)
+
+	if elapsed >= sr.metadata.Spec.ShutdownGrace {
+		t.Fatalf("shutdownChild took %v; expected well under %v (grace), indicating SIGTERM was not honored",
+			elapsed, sr.metadata.Spec.ShutdownGrace)
+	}
+
+	select {
+	case ee := <-waitErr:
+		if ee != nil {
+			// Non-zero exit — acceptable (signals may alter exit
+			// code conventions), but the child should not have
+			// been killed by SIGKILL.
+			if ws, ok := ee.Sys().(syscall.WaitStatus); ok {
+				if ws.Signaled() && ws.Signal() == syscall.SIGKILL {
+					t.Fatalf("child was killed by SIGKILL despite graceful-shutdown trap")
+				}
+			}
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("child did not exit after shutdownChild returned")
+	}
+}
+
+// TestShutdownChild_Escalation: child ignores SIGTERM; shutdownChild must
+// escalate to SIGKILL at grace expiry and the child's exit status must
+// reflect that.
+func TestShutdownChild_Escalation(t *testing.T) {
+	// trap '' TERM installs an "ignore" disposition. SIGTERM will be
+	// ignored; only SIGKILL (uncatchable) takes the process down.
+	cmd := exec.Command("/bin/sh", "-c", `trap '' TERM; sleep 30 & wait`)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	sr := newShutdownTestExec(t, cmd)
+	sr.metadata.Spec.ShutdownGrace = 150 * time.Millisecond
+
+	waitErr := startWaiter(sr)
+	// Give the shell a moment to process `trap '' TERM` before we start
+	// signaling. Without this, SIGTERM can arrive during shell startup,
+	// before the trap is installed, and the shell dies with default
+	// disposition — masking the escalation path under test.
+	time.Sleep(100 * time.Millisecond)
+
+	start := time.Now()
+	sr.shutdownChild(sr.metadata.Spec.ShutdownGrace)
+	elapsed := time.Since(start)
+
+	if elapsed < sr.metadata.Spec.ShutdownGrace {
+		t.Fatalf("shutdownChild returned in %v; expected at least %v (child ignores SIGTERM)",
+			elapsed, sr.metadata.Spec.ShutdownGrace)
+	}
+
+	select {
+	case ee := <-waitErr:
+		if ee == nil {
+			t.Fatalf("child exited cleanly; expected SIGKILL death")
+		}
+		ws, ok := ee.Sys().(syscall.WaitStatus)
+		if !ok {
+			t.Fatalf("unexpected exit state: %T %v", ee.Sys(), ee)
+		}
+		// On Linux, the child may exit due to its *process group*
+		// receiving SIGKILL (the sleep child dies via SIGKILL, the
+		// parent shell's `wait` returns with status 128+9, and the
+		// shell itself exits — not necessarily via SIGKILL. So we
+		// accept either: the shell killed by SIGKILL, or the shell
+		// exited with 137/143.
+		if ws.Signaled() {
+			if ws.Signal() != syscall.SIGKILL {
+				t.Fatalf("child signaled with %v; want SIGKILL", ws.Signal())
+			}
+		} else {
+			code := ws.ExitStatus()
+			//nolint:mnd // shell-conventional 128+SIGKILL
+			if code != 128+int(syscall.SIGKILL) {
+				t.Fatalf("child exited with code %d; want 128+SIGKILL (%d) or signaled by SIGKILL",
+					code, 128+int(syscall.SIGKILL))
+			}
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("child did not exit after SIGKILL")
+	}
+
+	// Ensure the runner did not synthesize a TerminalState api.Exited
+	// transition via updateTerminalState on a nil metadata path; the
+	// escape hatch is to touch Spec.ShutdownGrace which is set above.
+	_ = api.Exited
+}

--- a/internal/terminal/terminalrunner/reaper_linux.go
+++ b/internal/terminal/terminalrunner/reaper_linux.go
@@ -1,0 +1,173 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package terminalrunner
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+)
+
+// reaper drains SIGCHLD for the whole PID namespace by looping
+// Wait4(-1, WNOHANG) on each signal. It is only active when sbsh is acting as
+// container init (see internal/initmode). The tracked child's exit status is
+// routed to a registered callback so the normal "child exited" path in
+// startPty still fires exactly once even though the kernel-level SIGCHLD was
+// consumed here instead of by os/exec.Cmd.Wait.
+type reaper struct {
+	logger *slog.Logger
+
+	sigCh chan os.Signal
+	stop  chan struct{}
+	done  chan struct{}
+
+	mu             sync.Mutex
+	trackedPid     int
+	trackedOnce    sync.Once
+	trackedExitCh  chan int // buffered 1; receives exit code for trackedPid
+	trackedStopped bool
+}
+
+// newReaper constructs a reaper but does not start it. Call Start to install
+// the signal handler and kick off the loop.
+func newReaper(logger *slog.Logger) *reaper {
+	return &reaper{
+		logger:        logger,
+		sigCh:         make(chan os.Signal, 16),
+		stop:          make(chan struct{}),
+		done:          make(chan struct{}),
+		trackedExitCh: make(chan int, 1),
+	}
+}
+
+// Start installs the SIGCHLD handler and begins the drain loop. Safe to call
+// exactly once.
+func (r *reaper) Start() {
+	signal.Notify(r.sigCh, syscall.SIGCHLD)
+	// Prime the pump: drain any SIGCHLDs that fired before Notify was
+	// installed. Harmless if there are none.
+	go r.loop()
+}
+
+// Stop tears down the reaper and waits for the loop to exit. Unreaped
+// descendants (there should be none after a clean shutdown) are not waited on.
+func (r *reaper) Stop() {
+	select {
+	case <-r.stop:
+		// already stopped
+		return
+	default:
+	}
+	close(r.stop)
+	signal.Stop(r.sigCh)
+	<-r.done
+}
+
+// RegisterChild tells the reaper which PID corresponds to the tracked
+// terminal child. Must be called at most once per reaper instance; subsequent
+// calls are ignored to make the Start / RegisterChild / Wait ordering robust
+// against races.
+func (r *reaper) RegisterChild(pid int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.trackedPid != 0 {
+		return
+	}
+	r.trackedPid = pid
+}
+
+// TrackedExitCh returns a channel that receives the exit code of the
+// registered tracked child, exactly once, when the reaper reaps it. The
+// channel is buffered so the reaper never blocks delivering.
+func (r *reaper) TrackedExitCh() <-chan int {
+	return r.trackedExitCh
+}
+
+// drainOnce runs a single WNOHANG Wait4 sweep, returning the number of
+// children reaped. Exported for tests.
+func (r *reaper) drainOnce() int {
+	reaped := 0
+	for {
+		var status syscall.WaitStatus
+		pid, err := syscall.Wait4(-1, &status, syscall.WNOHANG, nil)
+		switch {
+		case pid > 0:
+			reaped++
+			r.handleReaped(pid, status)
+			continue
+		case pid == 0:
+			// No more children ready to be reaped right now.
+			return reaped
+		case errors.Is(err, syscall.ECHILD):
+			// No children at all (normal once the tracked child is gone).
+			return reaped
+		case errors.Is(err, syscall.EINTR):
+			continue
+		default:
+			r.logger.Warn("reaper: wait4 error", "err", err)
+			return reaped
+		}
+	}
+}
+
+func (r *reaper) handleReaped(pid int, status syscall.WaitStatus) {
+	r.mu.Lock()
+	tracked := r.trackedPid
+	stopped := r.trackedStopped
+	r.mu.Unlock()
+
+	if tracked != 0 && pid == tracked && !stopped {
+		exitCode := status.ExitStatus()
+		if status.Signaled() {
+			// 128 + signal number is the shell-conventional encoding.
+			//nolint:mnd // shell-conventional encoding of signal death
+			exitCode = 128 + int(status.Signal())
+		}
+		r.trackedOnce.Do(func() {
+			r.mu.Lock()
+			r.trackedStopped = true
+			r.mu.Unlock()
+			r.trackedExitCh <- exitCode
+			close(r.trackedExitCh)
+		})
+		r.logger.Info("reaper: tracked child exited", "pid", pid, "exit", exitCode)
+		return
+	}
+
+	r.logger.Debug("reaper: reaped orphan", "pid", pid, "status", status)
+}
+
+func (r *reaper) loop() {
+	defer close(r.done)
+	// Initial drain catches pre-Notify SIGCHLDs.
+	r.drainOnce()
+	for {
+		select {
+		case <-r.stop:
+			// Final drain before exit.
+			r.drainOnce()
+			return
+		case <-r.sigCh:
+			r.drainOnce()
+		}
+	}
+}

--- a/internal/terminal/terminalrunner/reaper_linux_test.go
+++ b/internal/terminal/terminalrunner/reaper_linux_test.go
@@ -1,0 +1,100 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package terminalrunner
+
+import (
+	"io"
+	"log/slog"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// discardLogger returns a slog.Logger that drops every record so tests do not
+// spam the go-test output.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestReaper_DrainsOrphan verifies that a child whose os/exec.Cmd we never
+// Wait on is still reaped by the reaper's WNOHANG loop.
+func TestReaper_DrainsOrphan(t *testing.T) {
+	r := newReaper(discardLogger())
+	r.Start()
+	defer r.Stop()
+
+	// Spawn a short-lived child we intentionally do not Wait on. The
+	// reaper is expected to pick up its SIGCHLD and reap it.
+	cmd := exec.Command("/bin/sh", "-c", "exit 0")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start orphan child: %v", err)
+	}
+
+	// Release so os/exec does not hold a reference that we then race.
+	pid := cmd.Process.Pid
+	_ = cmd.Process.Release()
+
+	// Poll: within 2s the reaper should have reaped the child, so
+	// syscall.Kill(pid, 0) (existence probe) returns ESRCH.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		err := syscall.Kill(pid, 0)
+		if err == syscall.ESRCH {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("orphan pid %d still exists after 2s; reaper did not drain it", pid)
+}
+
+// TestReaper_TrackedExitResolvesRace verifies that when the reaper consumes
+// the tracked child's SIGCHLD (the race described in the acceptance
+// criteria), the real exit code is still delivered via TrackedExitCh — the
+// normal "cmd.Wait() ECHILD" failure mode is masked.
+func TestReaper_TrackedExitResolvesRace(t *testing.T) {
+	r := newReaper(discardLogger())
+	r.Start()
+	defer r.Stop()
+
+	cmd := exec.Command("/bin/sh", "-c", "exit 7")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	r.RegisterChild(cmd.Process.Pid)
+
+	select {
+	case code, ok := <-r.TrackedExitCh():
+		if !ok {
+			t.Fatalf("TrackedExitCh closed without delivering a code")
+		}
+		if code != 7 {
+			t.Fatalf("tracked exit code = %d, want 7", code)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for reaper to deliver tracked exit")
+	}
+
+	// Do NOT call cmd.Wait — the reaper has already consumed SIGCHLD.
+	// Release to drop the os.Process handle cleanly.
+	_ = cmd.Process.Release()
+}

--- a/internal/terminal/terminalrunner/reaper_other.go
+++ b/internal/terminal/terminalrunner/reaper_other.go
@@ -1,0 +1,32 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package terminalrunner
+
+import "log/slog"
+
+// reaper is a no-op on non-Linux builds. The PID-1 init-mode paths are only
+// reachable on Linux because that is the only OS sbsh supports as a container
+// PID 1.
+type reaper struct{}
+
+func newReaper(_ *slog.Logger) *reaper          { return &reaper{} }
+func (r *reaper) Start()                        {}
+func (r *reaper) Stop()                         {}
+func (r *reaper) RegisterChild(_ int)           {}
+func (r *reaper) TrackedExitCh() <-chan int     { return nil }

--- a/internal/terminal/terminalrunner/signals_linux.go
+++ b/internal/terminal/terminalrunner/signals_linux.go
@@ -1,0 +1,89 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package terminalrunner
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+)
+
+// forwardedSignals is the minimum set the PID-1 forwarder relays to the
+// tracked child's process group. SIGWINCH is intentionally omitted: PTY
+// resize already has its own dedicated path.
+var forwardedSignals = []os.Signal{
+	syscall.SIGTERM,
+	syscall.SIGINT,
+	syscall.SIGHUP,
+	syscall.SIGQUIT,
+}
+
+// startSignalForwarder installs a goroutine that forwards forwardedSignals to
+// the child's process group (negative pid). pgid must be positive; the
+// forwarder negates it before syscall.Kill. Returns a stop function; safe to
+// call multiple times.
+func startSignalForwarder(logger *slog.Logger, pgid int) func() {
+	if pgid <= 0 {
+		logger.Warn("signal forwarder: invalid pgid, skipping", "pgid", pgid)
+		return func() {}
+	}
+
+	sigCh := make(chan os.Signal, len(forwardedSignals))
+	signal.Notify(sigCh, forwardedSignals...)
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			case sig, ok := <-sigCh:
+				if !ok {
+					return
+				}
+				sysSig, castOK := sig.(syscall.Signal)
+				if !castOK {
+					logger.Warn("signal forwarder: non-syscall signal", "sig", sig)
+					continue
+				}
+				if err := syscall.Kill(-pgid, sysSig); err != nil && !errors.Is(err, syscall.ESRCH) {
+					logger.Warn("signal forwarder: kill failed",
+						"pgid", pgid, "sig", sysSig, "err", err)
+					continue
+				}
+				logger.Debug("signal forwarder: relayed signal", "pgid", pgid, "sig", sysSig)
+			}
+		}
+	}()
+
+	var stopOnce sync.Once
+	return func() {
+		stopOnce.Do(func() {
+			signal.Stop(sigCh)
+			close(stop)
+			<-done
+		})
+	}
+}

--- a/internal/terminal/terminalrunner/signals_linux_test.go
+++ b/internal/terminal/terminalrunner/signals_linux_test.go
@@ -1,0 +1,140 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package terminalrunner
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestSignalForwarder_TargetsProcessGroup verifies the forwarder delivers
+// the observed signal to -pgid, reaching the process-group leader AND a
+// sibling (subshell) in the same pgroup. Uses SIGHUP to avoid colliding
+// with the Go test runner's SIGTERM/SIGINT handling.
+func TestSignalForwarder_TargetsProcessGroup(t *testing.T) {
+	// Leader script: installs a HUP trap, spawns a subshell sibling in the
+	// same pgroup that also traps HUP, then waits on it. On SIGHUP to the
+	// pgroup, both traps fire.
+	dir := t.TempDir()
+	leaderMarker := filepath.Join(dir, "leader")
+	siblingMarker := filepath.Join(dir, "sibling")
+
+	// Subshell uses "sleep & wait" so the shell does not tail-call-exec
+	// sleep (dash optimizes "exec sleep" when sleep is the last command,
+	// which would leave no shell alive to run the SIGHUP trap).
+	// Markers are written to disk so the test does not depend on stdout
+	// flush ordering of the subshell vs. the leader.
+	script := `
+trap 'touch "$LEADER"' HUP
+(trap 'touch "$SIBLING"; exit 0' HUP; sleep 10 & wait) &
+child=$!
+echo ready
+wait $child
+echo done
+exit 0
+`
+	leader := exec.Command("/bin/sh", "-c", script)
+	leader.Env = append(os.Environ(), "LEADER="+leaderMarker, "SIBLING="+siblingMarker)
+	leader.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	stdout, err := leader.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	if err := leader.Start(); err != nil {
+		t.Fatalf("start leader: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Kill(-leader.Process.Pid, syscall.SIGKILL)
+		_, _ = leader.Process.Wait()
+	})
+	pgid := leader.Process.Pid
+
+	reader := bufio.NewReader(stdout)
+	if line, _ := reader.ReadString('\n'); line != "ready\n" {
+		t.Fatalf("leader did not emit ready; got %q", line)
+	}
+
+	stop := startSignalForwarder(discardLogger(), pgid)
+	t.Cleanup(stop)
+
+	// Send SIGHUP to our own process. signal.Notify in the forwarder
+	// catches it; the relay targets -pgid; default termination is
+	// suppressed because the handler is registered.
+	if err := syscall.Kill(os.Getpid(), syscall.SIGHUP); err != nil {
+		t.Fatalf("self-kill SIGHUP: %v", err)
+	}
+
+	_ = collectLinesUntil(t, reader, 3*time.Second, "done")
+
+	if !fileExists(leaderMarker) {
+		t.Fatalf("leader did not receive SIGHUP (marker %s absent)", leaderMarker)
+	}
+	if !fileExists(siblingMarker) {
+		t.Fatalf("sibling did not receive SIGHUP (marker %s absent)", siblingMarker)
+	}
+}
+
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+// collectLinesUntil reads lines until the sentinel line (trimmed) is seen or
+// the deadline elapses; returns all accumulated output.
+func collectLinesUntil(t *testing.T, r *bufio.Reader, d time.Duration, sentinel string) string {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	var sb strings.Builder
+	done := make(chan string, 1)
+	go func() {
+		for time.Now().Before(deadline) {
+			line, err := r.ReadString('\n')
+			if line != "" {
+				sb.WriteString(line)
+				if strings.TrimSpace(line) == sentinel {
+					done <- sb.String()
+					return
+				}
+			}
+			if err != nil {
+				if err == io.EOF {
+					done <- sb.String()
+					return
+				}
+				done <- sb.String()
+				return
+			}
+		}
+		done <- sb.String()
+	}()
+	select {
+	case out := <-done:
+		return out
+	case <-time.After(d + 500*time.Millisecond):
+		t.Fatalf("timed out reading lines; partial=%q", sb.String())
+		return sb.String()
+	}
+}

--- a/internal/terminal/terminalrunner/signals_other.go
+++ b/internal/terminal/terminalrunner/signals_other.go
@@ -1,0 +1,25 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package terminalrunner
+
+import "log/slog"
+
+// startSignalForwarder is a no-op on non-Linux platforms. sbsh only runs as
+// PID 1 in Linux containers.
+func startSignalForwarder(_ *slog.Logger, _ int) func() { return func() {} }

--- a/internal/terminal/terminalrunner/terminal.go
+++ b/internal/terminal/terminalrunner/terminal.go
@@ -81,11 +81,18 @@ func (sr *Exec) prepareTerminalCommand() error {
 		config.KV(config.SBSH_TERM_PROFILE, sr.metadata.Spec.ProfileName),
 		config.KV(config.SB_ROOT_RUN_PATH, sr.metadata.Spec.RunPath),
 	)
-	// Start the process in its own process group
+	// Start the process in its own process group and session so the PID-1
+	// signal forwarder can target the child's pgroup with syscall.Kill(-pid).
+	// Setsid implies a new process group led by the child (pgid == pid), so
+	// no explicit Setpgid is needed.
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setctty: true, // make the child the controlling TTY
-		Setsid:  true, // new session
+		Setsid:  true, // new session + new pgroup led by the child
 	}
+
+	// Disable the default exec.CommandContext cancellation (which sends
+	// SIGKILL on ctx cancel). Graceful shutdown is orchestrated by Close().
+	cmd.Cancel = func() error { return nil }
 
 	// Make sure TERM is reasonable if not set (helps colors)
 	hasTERM := false
@@ -164,12 +171,12 @@ func (sr *Exec) startPty() error {
 	sr.metadata.Status.Tty = sr.pts.Name()
 	sr.metadataMu.Unlock()
 
-	go func() {
-		sr.logger.Debug("waiting on child process", "parent_pid", os.Getpid(), "child_pid", sr.cmd.Process.Pid)
-		_ = sr.cmd.Wait() // blocks until process exits
-		sr.logger.Info("child process has exited", "parent_pid", os.Getpid(), "child_pid", sr.cmd.Process.Pid)
-		sr.closeReqCh <- errors.New("the shell process has exited")
-	}()
+	if sr.initMode && sr.reaper != nil {
+		sr.reaper.RegisterChild(sr.cmd.Process.Pid)
+		sr.stopSignalForwarder = startSignalForwarder(sr.logger, sr.cmd.Process.Pid)
+	}
+
+	go sr.watchChildExit()
 
 	sr.metadataMu.RLock()
 	captureFile := sr.metadata.Spec.CaptureFile

--- a/internal/terminal/terminalrunner/terminal_runner_exec.go
+++ b/internal/terminal/terminalrunner/terminal_runner_exec.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/eminwux/sbsh/internal/initmode"
 	"github.com/eminwux/sbsh/pkg/api"
 )
 
@@ -68,10 +69,29 @@ type Exec struct {
 	closeReqCh chan error
 	closedCh   chan struct{}
 
+	// childDoneCh is closed once by the child-watching goroutine (either
+	// os/exec.Wait or the PID-1 reaper) once the tracked child has exited.
+	// Close() uses it as the "is the child dead yet" signal during graceful
+	// shutdown so it can decide when to escalate SIGTERM -> SIGKILL.
+	childDoneCh   chan struct{}
+	childDoneOnce *sync.Once
+
 	ptyPipes   *ptyPipes
 	ptyPipesMu sync.RWMutex // protects ptyPipes field (reads after initialization)
 
 	closePTY *sync.Once
+
+	// initMode is captured at construction time so tests can toggle
+	// initmode.Enable before/after NewTerminalRunnerExec without surprising
+	// the already-running goroutines.
+	initMode bool
+
+	// reaper is the PID-1 zombie reaper, non-nil only when initMode is true.
+	reaper *reaper
+
+	// stopSignalForwarder tears down the PID-1 signal forwarder. nil when
+	// initMode is false.
+	stopSignalForwarder func()
 }
 
 type ptyPipes struct {
@@ -89,6 +109,13 @@ type ioClient struct {
 
 func NewTerminalRunnerExec(ctx context.Context, logger *slog.Logger, spec *api.TerminalSpec) TerminalRunner {
 	newCtx, cancel := context.WithCancel(ctx)
+
+	inInit := initmode.IsInit()
+	var rp *reaper
+	if inInit {
+		rp = newReaper(logger)
+		rp.Start()
+	}
 
 	return &Exec{
 		id: spec.ID,
@@ -131,10 +158,37 @@ func NewTerminalRunnerExec(ctx context.Context, logger *slog.Logger, spec *api.T
 		// signaling (set in Start)
 		evCh: nil, // assigned in Start(...)
 
-		closeReqCh: make(chan error),
-		closedCh:   make(chan struct{}),
-		ptyPipes:   &ptyPipes{},
-		closePTY:   &sync.Once{},
+		closeReqCh:    make(chan error),
+		closedCh:      make(chan struct{}),
+		childDoneCh:   make(chan struct{}),
+		childDoneOnce: &sync.Once{},
+		ptyPipes:      &ptyPipes{},
+		closePTY:      &sync.Once{},
+
+		initMode: inInit,
+		reaper:   rp,
+	}
+}
+
+// markChildDone records that the child has exited. Safe to call from any
+// goroutine; subsequent calls are no-ops. Returning the bool lets the caller
+// know whether this call was the first.
+func (sr *Exec) markChildDone() bool {
+	fired := false
+	sr.childDoneOnce.Do(func() {
+		close(sr.childDoneCh)
+		fired = true
+	})
+	return fired
+}
+
+// childDone returns true if the child has exited (non-blocking).
+func (sr *Exec) childDone() bool {
+	select {
+	case <-sr.childDoneCh:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/pkg/api/terminal.go
+++ b/pkg/api/terminal.go
@@ -72,6 +72,11 @@ type TerminalSpec struct {
 
 	ProfileName string     `json:"profileName"`
 	Stages      StagesSpec `json:"stages"`
+
+	// ShutdownGrace bounds how long the terminal waits for the child to
+	// exit after SIGTERM before escalating to SIGKILL. Zero means "use the
+	// runner's default" (30s, matching Kubernetes terminationGracePeriodSeconds).
+	ShutdownGrace time.Duration `json:"shutdownGrace,omitempty"`
 }
 
 type TerminalStatus struct {


### PR DESCRIPTION
## Summary

- **Zombie reaping** (`internal/terminal/terminalrunner/reaper_linux.go`): when `initmode.IsInit()` is true (default: `os.Getpid() == 1`), a SIGCHLD-driven `Wait4(-1, WNOHANG, ...)` loop drains orphans that reparent to sbsh. No `PR_SET_CHILD_SUBREAPER`; we rely solely on actually being PID 1.
- **Reaper / `cmd.Wait` race resolved**: when the reaper is active, `watchChildExit` sources the tracked child's exit status from the reaper's `TrackedExitCh` (not `os/exec.Cmd.Wait()`, which would race to `ECHILD`). `cmd.Process.Release()` drops the handle afterward. Outside init mode the path is unchanged: plain `cmd.Wait()`.
- **Signal forwarder** (`signals_linux.go`, same init-mode gate): forwards SIGTERM/SIGINT/SIGHUP/SIGQUIT to the tracked child's process group via `syscall.Kill(-pgid, …)`. `Setsid: true` on the child already makes it the pgroup leader, so no explicit `Setpgid` is needed. SIGWINCH stays on its dedicated PTY-resize path.
- **Graceful shutdown (always on)**: `Exec.Close` now runs SIGTERM → wait up to `ShutdownGrace` → SIGKILL on the child's process group, replacing the unconditional `Process.Kill()`. `cmd.Cancel` is a no-op so ctx-cancel doesn't pre-empt the grace period.
- **`--shutdown-grace` duration flag** on `sbsh terminal` (default 30s, matching Kubernetes `terminationGracePeriodSeconds`), bound via viper and threaded through `TerminalSpec.ShutdownGrace` + `profile.DefaultShutdownGrace`.
- **Test hook**: new `internal/initmode` package with `Enable(bool)` / `Reset()` so unit tests can exercise PID-1 code paths without actually being PID 1.

Build-tag split: Linux is the real implementation; non-Linux files (`*_other.go`) are no-op stubs. sbsh only runs as PID 1 in Linux containers.

## Test plan

- [x] `make sbsh-sb` + `file ./sbsh | grep 'ELF 64-bit LSB executable'`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -timeout=60s ./internal/initmode/... ./internal/terminal/terminalrunner/... ./internal/profile/... ./cmd/sbsh/... ./cmd/sb/...` — all green
- [x] `go test -tags=integration ./cmd/sb/get/...` — ok
- [x] `./sbsh terminal --help | grep shutdown-grace` — flag appears with `default 30s`
- [x] Reaper unit tests: `TestReaper_DrainsOrphan`, `TestReaper_TrackedExitResolvesRace` (exit code 7 survives the SIGCHLD race)
- [x] Signal forwarder unit test: `TestSignalForwarder_TargetsProcessGroup` (leader + sibling subshell in same pgroup both run their HUP trap via filesystem marker)
- [x] Graceful shutdown unit tests: `TestShutdownChild_HappyPath` (SIGTERM trap exits before grace, no SIGKILL) and `TestShutdownChild_Escalation` (SIGTERM ignored, SIGKILL at grace)
- [x] Library-consumer example still builds (`docs/examples/library-consumer`)

### Known pre-existing failure

`go test ./internal/terminal/...` deadlocks on `Test_HandleEvent_EvCmdExited` with the exact same stack trace on `origin/main` (verified via `git worktree`). That deadlock is the subject of the already-open PR #139 and is unrelated to this change.

### Out of scope (per issue)

- No release-pipeline or multi-arch asset changes.
- No user-facing `--init-mode` flag.
- No generic tini replacement — sbsh still owns exactly one tracked child + PTY.
- E2E tests with `unshare -Urp` (CI does not run `./e2e`; the five unit-level acceptance scenarios from the issue are all covered).

Closes #120