### PR TITLE
fix(attach): accept --id/--name without positional arg

### DIFF
--- a/cmd/sb/attach/attach.go
+++ b/cmd/sb/attach/attach.go
@@ -64,25 +64,8 @@ to quickly create a Cobra application.`,
 				return errdefs.ErrLoggerNotFound
 			}
 
-			switch {
-			case len(args) == 0:
-				return errdefs.ErrNoTerminalIdentifier
-			case len(args) == 1:
-				// If user passed -n when listing, reject it
-				if cmd.Flags().Changed("id") {
-					return fmt.Errorf(
-						"%w: the --id flag is not valid when using positional terminal name",
-						errdefs.ErrInvalidFlag,
-					)
-				}
-				if cmd.Flags().Changed("name") {
-					return fmt.Errorf(
-						"%w: the --name flag is not valid when using positional terminal name",
-						errdefs.ErrInvalidFlag,
-					)
-				}
-			case len(args) > 1:
-				return errdefs.ErrTooManyArguments
+			if err := validateAttachArgs(cmd, args); err != nil {
+				return err
 			}
 
 			logger.DebugContext(cmd.Context(), "attach command invoked",
@@ -106,6 +89,36 @@ to quickly create a Cobra application.`,
 
 	setupAttachCmdFlags(attachCmd)
 	return attachCmd
+}
+
+// validateAttachArgs enforces the positional/flag contract for
+// `sb attach`: zero or one positional terminal identifier, optionally
+// replaced by --id or --name; the flags are mutually exclusive with a
+// positional arg but are themselves a valid way to identify the target
+// (so library callers like pkg/spawn can use --id alone).
+func validateAttachArgs(cmd *cobra.Command, args []string) error {
+	switch {
+	case len(args) == 0:
+		if !cmd.Flags().Changed("id") && !cmd.Flags().Changed("name") {
+			return errdefs.ErrNoTerminalIdentifier
+		}
+	case len(args) == 1:
+		if cmd.Flags().Changed("id") {
+			return fmt.Errorf(
+				"%w: the --id flag is not valid when using positional terminal name",
+				errdefs.ErrInvalidFlag,
+			)
+		}
+		if cmd.Flags().Changed("name") {
+			return fmt.Errorf(
+				"%w: the --name flag is not valid when using positional terminal name",
+				errdefs.ErrInvalidFlag,
+			)
+		}
+	case len(args) > 1:
+		return errdefs.ErrTooManyArguments
+	}
+	return nil
 }
 
 func setupAttachCmdFlags(attachCmd *cobra.Command) {

--- a/cmd/sb/attach/attach_test.go
+++ b/cmd/sb/attach/attach_test.go
@@ -98,6 +98,26 @@ func Test_ErrInvalidFlag_Name(t *testing.T) {
 	}
 }
 
+func Test_ValidateAttachArgs_IDFlagOnly(t *testing.T) {
+	cmd := NewAttachCmd()
+	if err := cmd.Flags().Set("id", "some-id"); err != nil {
+		t.Fatalf("failed to set --id: %v", err)
+	}
+	if err := validateAttachArgs(cmd, []string{}); err != nil {
+		t.Fatalf("expected nil error when --id is set with no positional arg; got: %v", err)
+	}
+}
+
+func Test_ValidateAttachArgs_NameFlagOnly(t *testing.T) {
+	cmd := NewAttachCmd()
+	if err := cmd.Flags().Set("name", "some-name"); err != nil {
+		t.Fatalf("failed to set --name: %v", err)
+	}
+	if err := validateAttachArgs(cmd, []string{}); err != nil {
+		t.Fatalf("expected nil error when --name is set with no positional arg; got: %v", err)
+	}
+}
+
 func Test_ErrTooManyArguments(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	cmd := NewAttachCmd()


### PR DESCRIPTION
## Summary
- `sb attach --id <id>` (with no positional) returned `ErrNoTerminalIdentifier` and exited 1, making `pkg/spawn.NewClient` unusable with an ID-only `TerminalSpec` — `buildClientAttachArgs` emits `--id` without a positional and the CLI rejected it.
- Relax the args-zero branch to pass validation when either `--id` or `--name` is set; the existing flag-only handling in `run()` already supports this path.
- Extract the inline arg/flag validation into `validateAttachArgs` so the contract is testable in isolation.
- Add unit tests covering the flag-only success paths for both `--id` and `--name`.

## Test plan
- [x] `go test ./cmd/sb/attach/...`
- [x] `go test ./pkg/spawn/...`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make sbsh-sb` + `file ./sbsh` (ELF confirmed)
- [x] `make test` — only pre-existing failures surface (`Test_HandleEvent_EvCmdExited` fixed in unmerged PR #139; `TestSignalForwarder_TargetsProcessGroup` is known-flaky per the shell-signal tests guidance and passes on retry)

Closes #142