### PR TITLE
feat(terminal): replace --command with positional argv after --

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -191,8 +191,6 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SBSH_TERM_PROFILE = DefineKV("SBSH_TERM_PROFILE", "sbsh.terminal.profile")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
-	SBSH_TERM_COMMAND = DefineKV("SBSH_TERM_COMMAND", "sbsh.terminal.command")
-	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SBSH_TERM_CAPTURE_FILE = DefineKV("SBSH_TERM_CAPTURE_FILE", "sbsh.terminal.captureFile")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SBSH_TERM_LOG_FILE = DefineKV("SBSH_TERM_LOG_FILE", "sbsh.terminal.logFile")

--- a/cmd/sbsh/terminal/terminal.go
+++ b/cmd/sbsh/terminal/terminal.go
@@ -54,9 +54,22 @@ func checkFlag(cmd *cobra.Command, flag string, err string) error {
 	return nil
 }
 
+// splitWorkload partitions positional args around a "--" separator. dash is
+// the index of the first arg after "--" (i.e. cobra.Command.ArgsLenAtDash);
+// pass -1 when no "--" was given. Pre-dash args keep their existing meaning
+// (e.g. "-" for stdin); post-dash args are the workload's argv (argv[0] is
+// the binary, the rest are its args), preserved verbatim with no shell
+// re-tokenization.
+func splitWorkload(args []string, dash int) (preDash, workload []string) {
+	if dash < 0 {
+		return args, nil
+	}
+	return args[:dash], args[dash:]
+}
+
 func checkStdInUsage(cmd *cobra.Command, _ []string) error {
 	errorMessage := "positional argument '-'"
-	flagsToCheck := []string{"id", "name", "command", "profile", "log-file", "log-level", "socket", "file"}
+	flagsToCheck := []string{"id", "name", "profile", "log-file", "log-level", "socket", "file"}
 	for _, flag := range flagsToCheck {
 		if err := checkFlag(cmd, flag, errorMessage); err != nil {
 			return err
@@ -67,7 +80,7 @@ func checkStdInUsage(cmd *cobra.Command, _ []string) error {
 
 func checkFileUsage(cmd *cobra.Command, _ []string) error {
 	errorMessage := "the --file flag"
-	flagsToCheck := []string{"id", "name", "command", "profile", "log-file", "log-level", "socket"}
+	flagsToCheck := []string{"id", "name", "profile", "log-file", "log-level", "socket"}
 	for _, flag := range flagsToCheck {
 		if err := checkFlag(cmd, flag, errorMessage); err != nil {
 			return err
@@ -76,14 +89,28 @@ func checkFileUsage(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func buildTerminalSpecFromFlags(cmd *cobra.Command, logger *slog.Logger) (*api.TerminalSpec, error) {
+func buildTerminalSpecFromFlags(
+	cmd *cobra.Command,
+	logger *slog.Logger,
+	workload []string,
+) (*api.TerminalSpec, error) {
+	var (
+		terminalCmd     string
+		terminalCmdArgs []string
+	)
+	if len(workload) > 0 {
+		terminalCmd = workload[0]
+		terminalCmdArgs = workload[1:]
+	}
+
 	spec, buildErr := profile.BuildTerminalSpec(
 		cmd.Context(),
 		logger,
 		&profile.BuildTerminalSpecParams{
 			TerminalID:       viper.GetString(config.SBSH_TERM_ID.ViperKey),
 			TerminalName:     viper.GetString(config.SBSH_TERM_NAME.ViperKey),
-			TerminalCmd:      viper.GetString(config.SBSH_TERM_COMMAND.ViperKey),
+			TerminalCmd:      terminalCmd,
+			TerminalCmdArgs:  terminalCmdArgs,
 			CaptureFile:      viper.GetString(config.SBSH_TERM_CAPTURE_FILE.ViperKey),
 			RunPath:          viper.GetString(config.SB_ROOT_RUN_PATH.ViperKey),
 			ProfilesDir:      viper.GetString(config.SBSH_ROOT_PROFILES_DIR.ViperKey),
@@ -185,7 +212,7 @@ func setLoggingVarsFromFlags() {
 	}
 }
 
-func processSpec(cmd *cobra.Command, spec **api.TerminalSpec) error {
+func processSpec(cmd *cobra.Command, spec **api.TerminalSpec, workload []string) error {
 	// Check if spec is already provided
 	if *spec != nil {
 		// Spec provided via stdin
@@ -221,7 +248,7 @@ func processSpec(cmd *cobra.Command, spec **api.TerminalSpec) error {
 	}
 
 	// Build spec from flags
-	specBuilt, err := buildTerminalSpecFromFlags(cmd, logger)
+	specBuilt, err := buildTerminalSpecFromFlags(cmd, logger, workload)
 	if err != nil {
 		return fmt.Errorf("%w: %w", errdefs.ErrBuildTerminalSpec, err)
 	}
@@ -240,22 +267,29 @@ func processSpec(cmd *cobra.Command, spec **api.TerminalSpec) error {
 func NewTerminalCmd() *cobra.Command {
 	// terminalCmd represents the terminal command.
 	terminalCmd := &cobra.Command{
-		Use:     Command,
+		Use:     Command + " [flags] [-- command [args...]]",
 		Aliases: []string{CommandAlias},
 		Short:   "Run a new sbsh terminal",
 		Long: `Run a new sbsh terminal.
 The terminal can be customized via command-line options or by specifying a profile.
 If no profile is specified, a default profile is used with the provided command or /bin/bash.
 
+The workload command and its arguments are passed positionally after a "--"
+separator and executed via execve semantics (no shell re-tokenization), the
+way docker run, kubectl exec, runc exec, ctr run, sudo, env, and nsenter all
+take their argv.
+
 Examples:
-  sbsh terminal --name myterminal --command "/bin/zsh"
+  sbsh terminal --name myterminal -- /bin/zsh
   sbsh terminal --profile devprofile
-  sbsh terminal --profile devprofile --name customname --command "/usr/bin/fish"
+  sbsh terminal --profile devprofile --name customname -- /usr/bin/fish
+  sbsh terminal -- /bin/sleep 3600
 
 If no terminal name is provided, a random name will be generated.
 If no command is provided, /bin/bash will be used by default.
 If no log filename is provided, a default path under the run directory will be used.
 `,
+		Args:         cobra.ArbitraryArgs,
 		SilenceUsage: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			var runPath string
@@ -265,17 +299,19 @@ If no log filename is provided, a default path under the run directory will be u
 			_ = config.SB_ROOT_RUN_PATH.BindEnv()
 			config.SB_ROOT_RUN_PATH.SetDefault(runPath)
 
+			preDashArgs, workload := splitWorkload(args, cmd.ArgsLenAtDash())
+
 			// Check if first argument indicates stdin usage
 			var spec *api.TerminalSpec
 
 			// Process stdin input if '-' is provided
-			spec, errProcess := processInput(cmd, args)
+			spec, errProcess := processInput(cmd, preDashArgs)
 			if errProcess != nil && !errors.Is(errProcess, errdefs.ErrNoSpecDefined) {
 				return errProcess
 			}
 
 			// Process spec (from stdin or flags)
-			errProcessSpec := processSpec(cmd, &spec)
+			errProcessSpec := processSpec(cmd, &spec, workload)
 			if errProcessSpec != nil {
 				return errProcessSpec
 			}
@@ -336,9 +372,6 @@ If no log filename is provided, a default path under the run directory will be u
 func setupTerminalCmdFlags(terminalCmd *cobra.Command) {
 	terminalCmd.Flags().String("id", "", "Optional terminal ID (random if omitted)")
 	_ = viper.BindPFlag(config.SBSH_TERM_ID.ViperKey, terminalCmd.Flags().Lookup("id"))
-
-	terminalCmd.Flags().String("command", "", "Optional command (default: /bin/bash)")
-	_ = viper.BindPFlag(config.SBSH_TERM_COMMAND.ViperKey, terminalCmd.Flags().Lookup("command"))
 
 	terminalCmd.Flags().String("name", "", "Optional name for the terminal (random if omitted)")
 	_ = viper.BindPFlag(config.SBSH_TERM_NAME.ViperKey, terminalCmd.Flags().Lookup("name"))

--- a/cmd/sbsh/terminal/terminal_test.go
+++ b/cmd/sbsh/terminal/terminal_test.go
@@ -21,10 +21,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"log"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -309,6 +312,144 @@ func Test_ErrLoggerNotFound_RunE(t *testing.T) {
 	}
 	if !errors.Is(err, errdefs.ErrLoggerNotFound) {
 		t.Fatalf("expected '%v'; got: '%v'", errdefs.ErrLoggerNotFound, err)
+	}
+}
+
+func Test_splitWorkload(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		dash         int
+		wantPreDash  []string
+		wantWorkload []string
+	}{
+		{
+			name:         "no dash separator",
+			args:         []string{"-"},
+			dash:         -1,
+			wantPreDash:  []string{"-"},
+			wantWorkload: nil,
+		},
+		{
+			name:         "no positional args at all",
+			args:         []string{},
+			dash:         -1,
+			wantPreDash:  []string{},
+			wantWorkload: nil,
+		},
+		{
+			name:         "workload with no pre-dash args",
+			args:         []string{"/bin/bash"},
+			dash:         0,
+			wantPreDash:  []string{},
+			wantWorkload: []string{"/bin/bash"},
+		},
+		{
+			name:         "workload with whitespace and quoting in args",
+			args:         []string{"printf", "%s\n", "a b", "c'd"},
+			dash:         0,
+			wantPreDash:  []string{},
+			wantWorkload: []string{"printf", "%s\n", "a b", "c'd"},
+		},
+		{
+			name:         "workload with multiple pre-dash args",
+			args:         []string{"-", "extra", "/bin/echo", "hi"},
+			dash:         2,
+			wantPreDash:  []string{"-", "extra"},
+			wantWorkload: []string{"/bin/echo", "hi"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotPreDash, gotWorkload := splitWorkload(tc.args, tc.dash)
+			if !reflect.DeepEqual(gotPreDash, tc.wantPreDash) {
+				t.Fatalf("preDash: expected %#v; got %#v", tc.wantPreDash, gotPreDash)
+			}
+			if !reflect.DeepEqual(gotWorkload, tc.wantWorkload) {
+				t.Fatalf("workload: expected %#v; got %#v", tc.wantWorkload, gotWorkload)
+			}
+		})
+	}
+}
+
+func Test_TerminalCmd_RejectsCommandFlag(t *testing.T) {
+	cmd := NewTerminalCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"--command", "/bin/bash"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error: --command flag should be removed and rejected by cobra")
+	}
+	if !strings.Contains(err.Error(), "unknown flag") {
+		t.Fatalf("expected unknown flag error; got: %v", err)
+	}
+}
+
+func Test_TerminalCmd_PositionalArgvAfterDash(t *testing.T) {
+	// Verify that cobra parses positional argv after `--` and exposes it
+	// verbatim (no shell re-tokenization) via ArgsLenAtDash + args[dash:].
+	cmd := NewTerminalCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	want := []string{"printf", "%s\n", "a b"}
+
+	var (
+		gotWorkload []string
+		captured    bool
+	)
+	cmd.PreRunE = func(c *cobra.Command, args []string) error {
+		_, gotWorkload = splitWorkload(args, c.ArgsLenAtDash())
+		captured = true
+		return errors.New("stop after capture")
+	}
+	cmd.RunE = func(_ *cobra.Command, _ []string) error { return nil }
+
+	cmdArgs := append([]string{"--"}, want...)
+	cmd.SetArgs(cmdArgs)
+	_ = cmd.Execute()
+
+	if !captured {
+		t.Fatal("PreRunE was not invoked")
+	}
+	if !reflect.DeepEqual(gotWorkload, want) {
+		t.Fatalf("workload: expected %#v; got %#v", want, gotWorkload)
+	}
+}
+
+func Test_TerminalCmd_DefaultFallback_NoWorkload(t *testing.T) {
+	// When no positional argv is given after `--`, ArgsLenAtDash returns -1
+	// and the workload is empty so the profile default (/bin/bash) applies.
+	cmd := NewTerminalCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	var (
+		gotDash     int
+		gotWorkload []string
+		captured    bool
+	)
+	cmd.PreRunE = func(c *cobra.Command, args []string) error {
+		gotDash = c.ArgsLenAtDash()
+		_, gotWorkload = splitWorkload(args, gotDash)
+		captured = true
+		return errors.New("stop after capture")
+	}
+	cmd.RunE = func(_ *cobra.Command, _ []string) error { return nil }
+
+	cmd.SetArgs([]string{})
+	_ = cmd.Execute()
+
+	if !captured {
+		t.Fatal("PreRunE was not invoked")
+	}
+	if gotDash != -1 {
+		t.Fatalf("ArgsLenAtDash: expected -1 (no `--`); got %d", gotDash)
+	}
+	if len(gotWorkload) != 0 {
+		t.Fatalf("workload: expected empty; got %#v", gotWorkload)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `sbsh terminal` now takes the workload as positional argv after a `--` separator (`sbsh terminal --socket ... -- /bin/sleep 3600`), matching how `docker run`, `kubectl exec`, `runc exec`, `ctr run`, `nsenter`, `sudo`, and `env` all wrap their child argv. The workload runs via `execve` semantics with no shell re-tokenization, which preserves args containing whitespace, quotes, or shell metacharacters.
- The `--command` flag is removed (no deprecation window — cobra now rejects it as `unknown flag`). The `SBSH_TERM_COMMAND` viper key was the only consumer of that flag and is dropped along with it.
- Default fallback is unchanged: with no positional argv, the profile default (`/bin/bash`) still applies.
- Help text and `Use` line updated to `terminal [flags] [-- command [args...]]` with examples that reflect the new shape.

## Test plan
- [x] `make sbsh-sb` produces ELF binaries (`sbsh` and the `sb` hardlink).
- [x] `go vet ./...` and `go build ./...` clean.
- [x] `make test` (unit + integration + e2e) green, including new `Test_splitWorkload`, `Test_TerminalCmd_RejectsCommandFlag`, `Test_TerminalCmd_PositionalArgvAfterDash`, `Test_TerminalCmd_DefaultFallback_NoWorkload`.
- [x] Manual smoke: `./sbsh terminal --command /bin/bash` → `Error: unknown flag: --command`. `./sbsh terminal --help` shows `Usage: sbsh terminal [flags] [-- command [args...]]` and the new examples.

Closes #146