### PR TITLE
fix(controller): atomic Close guard fixes #138 deadlock

### DIFF
--- a/internal/client/controller.go
+++ b/internal/client/controller.go
@@ -222,13 +222,19 @@ func (s *Controller) Run(doc *api.ClientDoc) error {
 	s.logger.Info("controller ready, entering main event loop")
 	close(s.ctrlReadyCh)
 
-	go func() {
-		errC := <-s.closingCh
-		s.shuttingDown.Store(true)
-		s.logger.Warn("controller closing", "reason", errC)
-	}()
-
 	for {
+		// On the internal close path (handleEvent → onClosed → Close → return),
+		// prefer ErrCloseReq over ErrContextDone.
+		select {
+		case errClose := <-s.closeReqCh:
+			s.logger.Warn("close request received", "error", errClose)
+			if errClose == nil {
+				return nil
+			}
+			return fmt.Errorf("%w: %w", errdefs.ErrCloseReq, errClose)
+		default:
+		}
+
 		select {
 		case <-s.ctx.Done():
 			var errDone error
@@ -359,22 +365,25 @@ func (s *Controller) onClosed(_ api.ID, err error) {
 }
 
 func (s *Controller) Close(reason error) error {
-	if !s.shuttingDown.Load() {
-		s.logger.Info("initiating shutdown sequence", "reason", reason)
-		// Set closing reason
-		s.closingCh <- reason
-
-		// Notify terminal runner to close all terminals
-		_ = s.sr.Close(reason)
-
-		// Notify Run to exit
-		s.closeReqCh <- reason
-
-		// Mark controller as closed
-		close(s.closedCh)
-	} else {
+	// CAS ensures a single shutdown entrant; see #138.
+	if !s.shuttingDown.CompareAndSwap(false, true) {
 		s.logger.Info("shutdown sequence already in progress, ignoring duplicate request", "reason", reason)
+		return nil
 	}
+
+	s.logger.Info("initiating shutdown sequence", "reason", reason)
+
+	// Set closing reason
+	s.closingCh <- reason
+
+	// Notify terminal runner to close all terminals
+	_ = s.sr.Close(reason)
+
+	// Notify Run to exit
+	s.closeReqCh <- reason
+
+	// Mark controller as closed
+	close(s.closedCh)
 	return nil
 }
 

--- a/internal/terminal/controller.go
+++ b/internal/terminal/controller.go
@@ -182,13 +182,16 @@ func (c *Controller) Run(spec *api.TerminalSpec) error {
 	c.logger.InfoContext(c.ctx, "controller ready")
 	close(c.ctrlReadyCh)
 
-	go func() {
-		err := <-c.closingCh
-		c.shuttingDown.Store(true)
-		c.logger.WarnContext(c.ctx, "controller closing", "reason", err)
-	}()
-
 	for {
+		// On the internal close path (handleEvent → onClosed → Close → return),
+		// prefer ErrCloseReq over ErrContextDone since Close also cancelled ctx.
+		select {
+		case err := <-c.closeReqCh:
+			c.logger.WarnContext(c.ctx, "close request received", "err", err)
+			return fmt.Errorf("%w: %w", errdefs.ErrCloseReq, err)
+		default:
+		}
+
 		select {
 		case <-c.ctx.Done():
 			var err error
@@ -243,31 +246,33 @@ func (c *Controller) handleEvent(ev terminalrunner.Event) {
 }
 
 func (c *Controller) Close(reason error) error {
-	if !c.shuttingDown.Load() {
-		c.logger.InfoContext(c.ctx, "initiating shutdown sequence", "reason", reason)
-
-		// cancel the controller context so WaitReady unblocks
-		c.cancel(reason)
-
-		// Set closing reason
-		c.closingCh <- reason
-
-		// Notify terminal runner to close all terminals
-		c.srMu.RLock()
-		sr := c.sr
-		c.srMu.RUnlock()
-		if sr != nil {
-			_ = sr.Close(reason)
-		}
-
-		// Notify Run to exit
-		c.closeReqCh <- reason
-
-		// Mark controller as closed
-		close(c.closedCh)
-	} else {
+	// CAS ensures a single shutdown entrant; see #138.
+	if !c.shuttingDown.CompareAndSwap(false, true) {
 		c.logger.WarnContext(c.ctx, "shutdown sequence already in progress, ignoring duplicate request", "reason", reason)
+		return nil
 	}
+
+	c.logger.InfoContext(c.ctx, "initiating shutdown sequence", "reason", reason)
+
+	// cancel the controller context so WaitReady unblocks
+	c.cancel(reason)
+
+	// Set closing reason
+	c.closingCh <- reason
+
+	// Notify terminal runner to close all terminals
+	c.srMu.RLock()
+	sr := c.sr
+	c.srMu.RUnlock()
+	if sr != nil {
+		_ = sr.Close(reason)
+	}
+
+	// Notify Run to exit
+	c.closeReqCh <- reason
+
+	// Mark controller as closed
+	close(c.closedCh)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- `internal/terminal` and `internal/client` `Controller.Close` guarded re-entry with `shuttingDown.Load()` while a separate goroutine flipped the flag asynchronously off `closingCh`. When `EvCmdExited` triggered `onClosed → Close`, `Close` cancelled ctx and filled the one-shot `closeReqCh` (cap 1); `Run` then woke on `<-c.ctx.Done()` and called `Close` again before the watcher had been scheduled. The second invocation found `shuttingDown=false` and blocked forever sending on `closeReqCh`.
- Replace the Load-then-act guard with a `CompareAndSwap` at the top of `Close`. The guard is now atomic with the body it protects, so any re-entry returns immediately. The watcher goroutine is removed (`WaitClose` still observes `closingCh` for callers).
- Add a non-blocking `closeReqCh` pre-check at the top of `Run`'s loop so the **internal** close path (`handleEvent → onClosed → Close → return`) deterministically returns `ErrCloseReq` instead of racing with the ctx cancellation that `Close` itself just performed. External callers of `Close` still hit the `ctx.Done`/`closeReqCh` race because `cancel(reason)` runs before the `closeReqCh` send — the deadlock is fixed in either case; only the internal-path error is made deterministic.
- Mirrored fix in `internal/client/controller.go` (same shape, called out in #138 as worth auditing). Note that the client `Close` doesn't cancel ctx, so the priority pre-check there is purely defensive — same hygienic shape.

This is a fresh PR for #138 because I'm not the owner of the branch backing #139.

## Test plan
- [x] `go test -timeout=60s -run '^Test_HandleEvent_EvCmdExited$' -count=300 ./internal/terminal/` — passes 300/300 (was deadlocking deterministically; full goroutine trace in #138)
- [x] `go test -timeout=180s ./internal/terminal/ ./internal/client/...` — green
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` — full unit suite green (matches CI's `Build & Test` step)
- [x] `make sbsh-sb` — `./sbsh` and `./sb` both ELF executables
- [x] `go vet ./...` — clean
- [ ] `-race` not run locally (no gcc on this host); CI covers this

Closes #138