### PR TITLE
feat: add pkg/attach in-process attach façade for embedders

### DIFF
--- a/cmd/sb/attach/attach.go
+++ b/cmd/sb/attach/attach.go
@@ -23,18 +23,15 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"syscall"
 	"time"
 
 	"github.com/eminwux/sbsh/cmd/config"
 	"github.com/eminwux/sbsh/cmd/sb/get"
 	"github.com/eminwux/sbsh/cmd/types"
-	"github.com/eminwux/sbsh/internal/client"
 	"github.com/eminwux/sbsh/internal/defaults"
 	"github.com/eminwux/sbsh/internal/errdefs"
-	"github.com/eminwux/sbsh/internal/naming"
-	"github.com/eminwux/sbsh/pkg/api"
+	"github.com/eminwux/sbsh/pkg/attach"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -186,168 +183,88 @@ func run(
 		return errdefs.ErrLoggerNotFound
 	}
 
-	// Top-level context also reacts to SIGINT/SIGTERM (nice UX)
+	// Top-level context also reacts to SIGINT/SIGTERM (nice UX). pkg/attach
+	// deliberately does not trap signals itself; the CLI owns that policy.
 	ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	clientID := naming.RandomID()
-	socketFileFlag := viper.GetString(config.SB_ATTACH_SOCKET.ViperKey)
-	runPath := viper.GetString(config.SB_ROOT_RUN_PATH.ViperKey)
-
-	var terminalNamePositional string
-	if len(args) > 0 {
-		terminalNamePositional = args[0]
+	socketPath, err := resolveTerminalSocket(cmd, logger, args)
+	if err != nil {
+		return err
 	}
-
-	terminalNameFlag := viper.GetString(config.SB_ATTACH_NAME.ViperKey)
-	terminalIDFlag := viper.GetString(config.SB_ATTACH_ID.ViperKey)
-
-	terminalName := terminalNamePositional
-	if terminalNamePositional == "" {
-		terminalName = terminalNameFlag
-	}
-
-	// Create a new Controller
-	logger.DebugContext(ctx, "creating client controller for attach", "run_path", runPath)
-	supCtrl := client.NewClientController(ctx, logger)
-
-	if socketFileFlag == "" {
-		socketFileFlag = filepath.Join(runPath, defaults.ClientsRunPath, clientID, "socket")
-	}
-
-	if err := os.MkdirAll(filepath.Dir(socketFileFlag), 0o700); err != nil {
-		logger.ErrorContext(ctx, "failed to create client dir", "dir", filepath.Dir(socketFileFlag), "error", err)
-		return fmt.Errorf("%w: %w", errdefs.ErrCreateClientDir, err)
-	}
-
-	supDoc := buildClientDoc(ctx, clientID, runPath, socketFileFlag, logger)
 
 	disableDetach := viper.GetBool(config.SB_ATTACH_DISABLE_DETACH_KEYSTROKE.ViperKey)
-	supDoc.Spec.DetachKeystroke = !disableDetach
 
-	if terminalIDFlag != "" {
-		supDoc.Spec.TerminalSpec.ID = api.ID(terminalIDFlag)
+	logger.DebugContext(ctx, "delegating to pkg/attach.Run", "socket", socketPath, "disable_detach", disableDetach)
+
+	runErr := attach.Run(ctx, attach.Options{
+		SocketPath:             socketPath,
+		Stdin:                  os.Stdin,
+		Stdout:                 os.Stdout,
+		Stderr:                 os.Stderr,
+		DisableDetachKeystroke: disableDetach,
+		Logger:                 logger,
+	})
+	if runErr == nil || errors.Is(runErr, context.Canceled) || errors.Is(runErr, errdefs.ErrContextDone) {
+		return nil
 	}
-	if terminalName != "" {
-		supDoc.Spec.TerminalSpec.Name = terminalName
+	if errors.Is(runErr, errdefs.ErrAttach) {
+		logger.DebugContext(ctx, "attach error", "error", runErr)
+		fmt.Fprintf(os.Stderr, "Could not attach: %v\n", runErr)
+		cancel()
+		//nolint:gocritic // os.Exit is fine here
+		os.Exit(1)
 	}
-
-	var socket string
-	if socketFileFlag != "" {
-		socket = socketFileFlag
-	} else {
-		var terminalID string
-		switch {
-		case terminalIDFlag != "":
-			terminalID = terminalIDFlag
-		case terminalName != "":
-			var errR error
-			terminalID, errR = get.ResolveTerminalNameToID(cmd.Context(), logger, runPath, terminalName)
-			if errR != nil {
-				logger.ErrorContext(
-					cmd.Context(),
-					"cannot resolve terminal name to ID",
-					"terminal_name",
-					terminalName,
-					"error",
-					errR,
-				)
-				return fmt.Errorf("%w: %w", errdefs.ErrResolveTerminalName, errR)
-			}
-		default:
-			logger.DebugContext(
-				cmd.Context(),
-				"no terminal identification method provided, cannot attach",
-			)
-			return errdefs.ErrNoTerminalIdentification
-		}
-
-		socket = fmt.Sprintf("%s/%s/%s/socket", runPath, defaults.TerminalsRunPath, terminalID)
-	}
-
-	supDoc.Spec.TerminalSpec.SocketFile = socket
-
-	logger.DebugContext(ctx, "Built client doc", "clientDoc", fmt.Sprintf("%+v", supDoc))
-
-	logger.DebugContext(ctx, "starting client controller goroutine for attach")
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- supCtrl.Run(supDoc)
-		close(errCh)
-		logger.DebugContext(ctx, "controller goroutine exited (attach)")
-	}()
-
-	logger.DebugContext(ctx, "waiting for client controller to signal ready (attach)")
-	if err := supCtrl.WaitReady(); err != nil {
-		logger.DebugContext(ctx, "controller not ready (attach)", "error", err)
-		return fmt.Errorf("%w: %w", errdefs.ErrWaitOnReady, err)
-	}
-
-	logger.DebugContext(ctx, "controller ready, entering attach event loop")
-	select {
-	case <-ctx.Done():
-		logger.DebugContext(ctx, "context canceled, waiting for controller to exit (attach)")
-		waitErr := supCtrl.WaitClose()
-		if waitErr != nil {
-			logger.DebugContext(ctx, "error waiting for controller to close after context canceled", "error", waitErr)
-			return fmt.Errorf("%w: %w", errdefs.ErrWaitOnClose, waitErr)
-		}
-		logger.DebugContext(ctx, "context canceled, controller exited (attach)")
-		return errdefs.ErrContextDone
-
-	case ctrlErr := <-errCh:
-		logger.DebugContext(ctx, "controller stopped (attach)", "error", ctrlErr)
-		if ctrlErr != nil && !errors.Is(ctrlErr, context.Canceled) {
-			waitErr := supCtrl.WaitClose()
-			if waitErr != nil {
-				logger.DebugContext(ctx, "error waiting for controller to close after error", "error", waitErr)
-				return fmt.Errorf("%w: %w", errdefs.ErrWaitOnClose, waitErr)
-			}
-			logger.DebugContext(ctx, "controller exited after error (attach)")
-			if errors.Is(ctrlErr, errdefs.ErrAttach) {
-				logger.DebugContext(ctx, "attach error", "error", ctrlErr)
-				fmt.Fprintf(os.Stderr, "Could not attach: %v\n", ctrlErr)
-				cancel()
-				//nolint:gocritic // os.Exit is fine here
-				os.Exit(1)
-			}
-			// return nothing to avoid polluting the terminal with errors
-			return nil
-		}
-	}
+	// Other errors are intentionally swallowed to avoid polluting the
+	// terminal — preserves prior `sb attach` UX.
+	logger.DebugContext(ctx, "attach loop exited with error", "error", runErr)
 	return nil
 }
 
-func buildClientDoc(
-	ctx context.Context,
-	clientID string,
-	runPath string,
-	socketFileInput string,
-	logger *slog.Logger,
-) *api.ClientDoc {
-	clientName := naming.RandomName()
-	doc := &api.ClientDoc{
-		APIVersion: api.APIVersionV1Beta1,
-		Kind:       api.KindClient,
-		Metadata: api.ClientMetadata{
-			Name:        clientName,
-			Labels:      make(map[string]string),
-			Annotations: make(map[string]string),
-		},
-		Spec: api.ClientSpec{
-			ID:           api.ID(clientID),
-			RunPath:      runPath,
-			SockerCtrl:   socketFileInput,
-			TerminalSpec: &api.TerminalSpec{},
-			ClientMode:   api.AttachToTerminal,
-		},
+// resolveTerminalSocket maps the user's positional/--id/--name/--socket
+// arguments into the absolute path of the target terminal's control
+// socket. Centralised here so pkg/attach stays free of CLI / discovery
+// concerns.
+func resolveTerminalSocket(cmd *cobra.Command, logger *slog.Logger, args []string) (string, error) {
+	socketFileFlag := viper.GetString(config.SB_ATTACH_SOCKET.ViperKey)
+	if socketFileFlag != "" {
+		return socketFileFlag, nil
 	}
-	logger.DebugContext(ctx, "attach doc created",
-		"kind", doc.Kind,
-		"id", doc.Spec.ID,
-		"name", doc.Metadata.Name,
-		"run_path", doc.Spec.RunPath,
-	)
 
-	return doc
+	runPath := viper.GetString(config.SB_ROOT_RUN_PATH.ViperKey)
+	terminalIDFlag := viper.GetString(config.SB_ATTACH_ID.ViperKey)
+	terminalNameFlag := viper.GetString(config.SB_ATTACH_NAME.ViperKey)
+
+	terminalName := terminalNameFlag
+	if len(args) > 0 {
+		terminalName = args[0]
+	}
+
+	var terminalID string
+	switch {
+	case terminalIDFlag != "":
+		terminalID = terminalIDFlag
+	case terminalName != "":
+		var errR error
+		terminalID, errR = get.ResolveTerminalNameToID(cmd.Context(), logger, runPath, terminalName)
+		if errR != nil {
+			logger.ErrorContext(
+				cmd.Context(),
+				"cannot resolve terminal name to ID",
+				"terminal_name",
+				terminalName,
+				"error",
+				errR,
+			)
+			return "", fmt.Errorf("%w: %w", errdefs.ErrResolveTerminalName, errR)
+		}
+	default:
+		logger.DebugContext(
+			cmd.Context(),
+			"no terminal identification method provided, cannot attach",
+		)
+		return "", errdefs.ErrNoTerminalIdentification
+	}
+
+	return fmt.Sprintf("%s/%s/%s/socket", runPath, defaults.TerminalsRunPath, terminalID), nil
 }

--- a/internal/client/clientrunner/client_runner_exec.go
+++ b/internal/client/clientrunner/client_runner_exec.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"log/slog"
 	"net"
+	"os"
 	"sync"
 
 	"github.com/eminwux/sbsh/internal/client/terminalstore"
@@ -39,6 +40,14 @@ type Exec struct {
 
 	uiMode        UIMode
 	lastTermState *term.State
+
+	// stdin/stdout/stderr are the user-facing terminal handles. They
+	// default to os.Stdin/Stdout/Stderr but can be overridden by
+	// embedders via NewClientRunnerExecWithIO so the attach loop drives
+	// caller-supplied file handles instead of the process's own tty.
+	stdin  *os.File
+	stdout *os.File
+	stderr *os.File
 
 	events   chan<- Event
 	terminal *api.AttachedTerminal
@@ -64,6 +73,19 @@ func NewClientRunnerExec(
 	doc *api.ClientDoc,
 	evCh chan<- Event,
 ) ClientRunner {
+	return NewClientRunnerExecWithIO(ctx, logger, doc, evCh, nil, nil, nil)
+}
+
+// NewClientRunnerExecWithIO is like NewClientRunnerExec but lets the
+// caller plug in custom stdin/stdout/stderr handles instead of the
+// process's own. A nil handle falls back to the corresponding os.Std*.
+func NewClientRunnerExecWithIO(
+	ctx context.Context,
+	logger *slog.Logger,
+	doc *api.ClientDoc,
+	evCh chan<- Event,
+	stdin, stdout, stderr *os.File,
+) ClientRunner {
 	newCtx, cancel := context.WithCancel(ctx)
 
 	// Ensure the doc has the correct structure
@@ -77,9 +99,23 @@ func NewClientRunnerExec(
 		doc.Metadata.Annotations = make(map[string]string)
 	}
 
+	if stdin == nil {
+		stdin = os.Stdin
+	}
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+
 	return &Exec{
 		id:       doc.Spec.ID,
 		metadata: *doc,
+
+		stdin:  stdin,
+		stdout: stdout,
+		stderr: stderr,
 
 		events:    evCh,
 		ctx:       newCtx,

--- a/internal/client/clientrunner/io.go
+++ b/internal/client/clientrunner/io.go
@@ -95,7 +95,7 @@ func (sr *Exec) startConnectionManager() error {
 
 	// WRITER: stdin -> socket
 	readyWriter := make(chan struct{})
-	go dc.RunCopier(os.Stdin, sr.ioConn, readyWriter, func() {
+	go dc.RunCopier(sr.stdin, sr.ioConn, readyWriter, func() {
 		if uc != nil {
 			sr.logger.DebugContext(sr.ctx, "stdin->socket: closing write side of UnixConn")
 			_ = uc.CloseWrite()
@@ -105,7 +105,7 @@ func (sr *Exec) startConnectionManager() error {
 	// Only show help message if detach keystroke is enabled
 	if detachKeystrokeEnabled {
 		// _, errHelp := os.Stdout.WriteString("To detach, press ^] twice.\r\n")
-		_, errHelp := os.Stdout.WriteString("\x1b[96mTo detach, press ^] twice\x1b[0m\r\n")
+		_, errHelp := sr.stdout.WriteString("\x1b[96mTo detach, press ^] twice\x1b[0m\r\n")
 		if errHelp != nil {
 			sr.logger.WarnContext(sr.ctx, "attachIOSocket: failed to write detach help message", "error", errHelp)
 		}
@@ -113,7 +113,7 @@ func (sr *Exec) startConnectionManager() error {
 
 	// READER: socket  -> stdout
 	readyReader := make(chan struct{})
-	go dc.RunCopier(sr.ioConn, os.Stdout, readyReader, func() {
+	go dc.RunCopier(sr.ioConn, sr.stdout, readyReader, func() {
 		if uc != nil {
 			sr.logger.DebugContext(sr.ctx, "socket->stdout: closing read side of UnixConn")
 			_ = uc.CloseRead()
@@ -166,8 +166,8 @@ func (sr *Exec) attach() error {
 }
 
 func (sr *Exec) forwardResize() error {
-	// Send initial size once (use the client's TTY: os.Stdin)
-	if rows, cols, errSize := pty.Getsize(os.Stdin); errSize == nil {
+	// Send initial size once (use the client's TTY: sr.stdin)
+	if rows, cols, errSize := pty.Getsize(sr.stdin); errSize == nil {
 		const resizeTimeout = 100 * time.Millisecond
 		ctx, cancel := context.WithTimeout(sr.ctx, resizeTimeout)
 		defer cancel()
@@ -193,7 +193,7 @@ func (sr *Exec) forwardResize() error {
 				return
 			case <-ch:
 				// Query current terminal size again on every WINCH
-				rows, cols, err := pty.Getsize(os.Stdin)
+				rows, cols, err := pty.Getsize(sr.stdin)
 				if err != nil {
 					sr.logger.WarnContext(sr.ctx, "forwardResize: Getsize failed", "error", err)
 					continue

--- a/internal/client/clientrunner/lifecycle.go
+++ b/internal/client/clientrunner/lifecycle.go
@@ -62,8 +62,8 @@ func (sr *Exec) StartTerminalCmd(terminal *api.AttachedTerminal) error {
 	//nolint:gosec,noctx // User has to specify the command and its args; we explicitly don't want to use context here to avoid killing the process on parent exit
 	cmd := exec.Command(terminal.Command, terminal.CommandArgs...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true} // detach from your pg/ctty
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = sr.stdout
+	cmd.Stderr = sr.stderr
 
 	b, err := json.Marshal(terminal.Spec)
 	if err != nil {
@@ -216,7 +216,7 @@ func (sr *Exec) Detach() error {
 	}
 
 	sr.logger.Info("Client detached", "client_id", sr.id)
-	if _, err := os.Stdout.WriteString("\x1b[93m\r\nDetached\x1b[0m\r\n"); err != nil {
+	if _, err := sr.stdout.WriteString("\x1b[93m\r\nDetached\x1b[0m\r\n"); err != nil {
 		sr.logger.Warn("Failed to write detach message to stdout", "error", err)
 		return err
 	}

--- a/internal/client/clientrunner/terminal.go
+++ b/internal/client/clientrunner/terminal.go
@@ -27,12 +27,12 @@ import (
 // toBashUIMode: set terminal to RAW, update flags.
 func (sr *Exec) toBashUIMode() error {
 	sr.logger.Debug("toBashUIMode: switching to raw mode")
-	lastTermState, err := toRawMode(sr.logger)
+	lastTermState, err := toRawMode(sr.logger, sr.stdin)
 	if err != nil {
 		sr.logger.Error("toBashUIMode: failed to set raw mode", "error", err)
 		return err
 	}
-	// defer func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }()
+	// defer func() { _ = term.Restore(int(sr.stdin.Fd()), oldState) }()
 
 	sr.uiMode = UIBash
 	sr.lastTermState = lastTermState
@@ -44,7 +44,7 @@ func (sr *Exec) toBashUIMode() error {
 func (sr *Exec) toExitShell() error {
 	sr.logger.Debug("toExitShell: switching to cooked mode")
 	if sr.lastTermState != nil {
-		err := term.Restore(int(os.Stdin.Fd()), sr.lastTermState)
+		err := term.Restore(int(sr.stdin.Fd()), sr.lastTermState)
 		if err != nil {
 			sr.logger.Error("toExitShell: failed to restore terminal state", "error", err)
 			return err
@@ -88,8 +88,8 @@ func (sr *Exec) writeTerminal(input string) error {
 	return nil
 }
 
-func toRawMode(logger *slog.Logger) (*term.State, error) {
-	state, err := term.MakeRaw(int(os.Stdin.Fd()))
+func toRawMode(logger *slog.Logger, stdin *os.File) (*term.State, error) {
+	state, err := term.MakeRaw(int(stdin.Fd()))
 	if err != nil {
 		logger.Error("toRawMode: failed to set raw mode", "error", err)
 		return nil, err

--- a/internal/client/controller.go
+++ b/internal/client/controller.go
@@ -61,6 +61,20 @@ type Controller struct {
 
 // NewClientController wires the manager and the shared event channel from terminals.
 func NewClientController(ctx context.Context, logger *slog.Logger) api.ClientController {
+	return NewClientControllerWithIO(ctx, logger, nil, nil, nil)
+}
+
+// NewClientControllerWithIO is like NewClientController but lets the
+// caller plug custom stdin/stdout/stderr handles into the underlying
+// client runner. A nil handle falls back to the corresponding os.Std*.
+// Embedders that drive an attach session in-process (see pkg/attach)
+// use this constructor to redirect the PTY copy loop away from the
+// process's own tty.
+func NewClientControllerWithIO(
+	ctx context.Context,
+	logger *slog.Logger,
+	stdin, stdout, stderr *os.File,
+) api.ClientController {
 	logger.InfoContext(ctx, "New client controller is being created")
 	newCtx, cancel := context.WithCancelCause(ctx)
 
@@ -75,8 +89,10 @@ func NewClientController(ctx context.Context, logger *slog.Logger) api.ClientCon
 		rpcDoneCh:   make(chan error),
 		closeReqCh:  make(chan error, 1),
 		//nolint:mnd // event channel buffer size
-		eventsCh:         make(chan clientrunner.Event, 32),
-		NewClientRunner:  clientrunner.NewClientRunnerExec,
+		eventsCh: make(chan clientrunner.Event, 32),
+		NewClientRunner: func(ctx context.Context, logger *slog.Logger, doc *api.ClientDoc, evCh chan<- clientrunner.Event) clientrunner.ClientRunner {
+			return clientrunner.NewClientRunnerExecWithIO(ctx, logger, doc, evCh, stdin, stdout, stderr)
+		},
 		NewTerminalStore: terminalstore.NewTerminalStoreExec,
 	}
 	return c
@@ -169,8 +185,9 @@ func (s *Controller) Run(doc *api.ClientDoc) error {
 			return fmt.Errorf("%w: %w", errdefs.ErrStartCmd, errStart)
 		}
 	case api.AttachToTerminal:
-		if doc.Spec.TerminalSpec == nil || (doc.Spec.TerminalSpec.ID == "" && doc.Spec.TerminalSpec.Name == "") {
-			s.logger.Error("no terminal ID or Name provided for attach")
+		if doc.Spec.TerminalSpec == nil ||
+			(doc.Spec.TerminalSpec.ID == "" && doc.Spec.TerminalSpec.Name == "" && doc.Spec.TerminalSpec.SocketFile == "") {
+			s.logger.Error("no terminal ID, Name, or SocketFile provided for attach")
 			errAttachSpec := errdefs.ErrAttachNoTerminalSpec
 			if errC := s.Close(errAttachSpec); errC != nil {
 				s.logger.Error("error during Close after attach spec failure", "error", errC)
@@ -272,6 +289,19 @@ func (s *Controller) Run(doc *api.ClientDoc) error {
 }
 
 func (s *Controller) createAttachTerminal(doc *api.ClientDoc) (*api.AttachedTerminal, error) {
+	// SocketFile takes precedence: callers (notably pkg/attach
+	// embedders) that already know the absolute control-socket path
+	// can skip metadata discovery entirely.
+	if doc.Spec.TerminalSpec.SocketFile != "" {
+		s.logger.Debug("attach by socket path", "socket", doc.Spec.TerminalSpec.SocketFile)
+		spec := *doc.Spec.TerminalSpec
+		terminal := terminalstore.NewSupervisedTerminal(&spec)
+		if err := s.ss.Add(terminal); err != nil {
+			return nil, fmt.Errorf("%w: %w", errdefs.ErrTerminalStore, err)
+		}
+		return terminal, nil
+	}
+
 	var metadata *api.TerminalDoc
 	if doc.Spec.TerminalSpec.ID != "" {
 		s.logger.Debug(

--- a/pkg/attach/attach.go
+++ b/pkg/attach/attach.go
@@ -1,0 +1,170 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package attach
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/eminwux/sbsh/internal/client"
+	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/internal/naming"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// Options configures a single Run invocation.
+type Options struct {
+	// SocketPath is the absolute path to the target terminal's control
+	// socket (the same path "sb attach --socket" accepts). Required.
+	SocketPath string
+
+	// Stdin is the user-facing input handle. It must be a TTY-backed
+	// *os.File: the attach loop puts it in raw mode and reads the
+	// initial / SIGWINCH-triggered window size from it. Defaults to
+	// os.Stdin if nil.
+	Stdin *os.File
+
+	// Stdout is where the remote terminal output is written. Defaults
+	// to os.Stdout if nil.
+	Stdout *os.File
+
+	// Stderr receives any out-of-band diagnostics emitted by the
+	// embedded client (currently nothing under the happy path; reserved
+	// for future use). Defaults to os.Stderr if nil.
+	Stderr *os.File
+
+	// DisableDetachKeystroke turns off the in-band ^]^] detach
+	// shortcut. When false (default), the loop scans Stdin for the
+	// escape sequence and triggers a clean detach when it fires.
+	DisableDetachKeystroke bool
+
+	// Logger is a structured logger for diagnostics. Defaults to a
+	// discard logger when nil so embedders aren't forced to wire one
+	// in.
+	Logger *slog.Logger
+}
+
+// Run connects to opts.SocketPath, runs the interactive attach loop
+// against the supplied stdio handles, and returns when the session
+// ends. The loop terminates cleanly on:
+//   - context cancellation (returns ctx.Err wrapped in
+//     errdefs.ErrContextDone),
+//   - the remote terminal closing the connection,
+//   - the embedded client's detach keystroke firing (when enabled),
+//   - any unrecoverable error from the underlying controller (returned
+//     directly so callers can errors.Is against errdefs.* sentinels).
+//
+// Run is safe to call multiple times sequentially from the same
+// process; concurrent calls each get their own private control socket
+// under os.TempDir().
+func Run(ctx context.Context, opts Options) error {
+	if opts.SocketPath == "" {
+		return errors.New("pkg/attach: Options.SocketPath is required")
+	}
+
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+
+	stdin := opts.Stdin
+	if stdin == nil {
+		stdin = os.Stdin
+	}
+	stdout := opts.Stdout
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+	stderr := opts.Stderr
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+
+	// Each attach gets its own ephemeral run dir for the embedded
+	// client's RPC ctrl socket. The socket file itself is removed by
+	// the runner on shutdown; we mop up the surrounding tmp dir.
+	runDir, err := os.MkdirTemp("", "sbsh-attach-*")
+	if err != nil {
+		return fmt.Errorf("pkg/attach: create temp run dir: %w", err)
+	}
+	defer func() {
+		if rmErr := os.RemoveAll(runDir); rmErr != nil {
+			logger.WarnContext(ctx, "pkg/attach: failed to remove temp run dir", "dir", runDir, "error", rmErr)
+		}
+	}()
+
+	clientID := naming.RandomID()
+	clientCtrlSocket := filepath.Join(runDir, "client.sock")
+
+	doc := &api.ClientDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindClient,
+		Metadata: api.ClientMetadata{
+			Name:        naming.RandomName(),
+			Labels:      make(map[string]string),
+			Annotations: make(map[string]string),
+		},
+		Spec: api.ClientSpec{
+			ID:              api.ID(clientID),
+			RunPath:         runDir,
+			SockerCtrl:      clientCtrlSocket,
+			ClientMode:      api.AttachToTerminal,
+			DetachKeystroke: !opts.DisableDetachKeystroke,
+			TerminalSpec: &api.TerminalSpec{
+				SocketFile: opts.SocketPath,
+			},
+		},
+	}
+
+	ctrl := client.NewClientControllerWithIO(ctx, logger, stdin, stdout, stderr)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- ctrl.Run(doc)
+		close(errCh)
+	}()
+
+	if waitErr := ctrl.WaitReady(); waitErr != nil {
+		// Drain ctrl.Run so the goroutine can exit; ignore its error
+		// (already surfaced via WaitReady or closing).
+		<-errCh
+		return fmt.Errorf("%w: %w", errdefs.ErrWaitOnReady, waitErr)
+	}
+
+	select {
+	case <-ctx.Done():
+		if waitErr := ctrl.WaitClose(); waitErr != nil {
+			return fmt.Errorf("%w: %w", errdefs.ErrWaitOnClose, waitErr)
+		}
+		<-errCh
+		return fmt.Errorf("%w: %w", errdefs.ErrContextDone, ctx.Err())
+
+	case ctrlErr := <-errCh:
+		if ctrlErr == nil || errors.Is(ctrlErr, context.Canceled) {
+			return nil
+		}
+		// Drain WaitClose to release internal resources; surface the
+		// run error to the caller untouched.
+		_ = ctrl.WaitClose()
+		return ctrlErr
+	}
+}

--- a/pkg/attach/attach_test.go
+++ b/pkg/attach/attach_test.go
@@ -1,0 +1,232 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package attach_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/pkg/api"
+	"github.com/eminwux/sbsh/pkg/attach"
+)
+
+// fakeTerminalController is a minimal in-process stand-in for the real
+// internal/terminal.Controller's RPC surface. It implements just enough
+// of the JSON-RPC contract for pkg/attach.Run to dial the control
+// socket, ping it, observe the terminal as Ready, then attempt Attach
+// (where we deliberately return an error so Run exits without ever
+// needing a real PTY).
+type fakeTerminalController struct {
+	pingCalls   atomic.Int32
+	stateCalls  atomic.Int32
+	attachCalls atomic.Int32
+	state       api.TerminalStatusMode
+	attachErr   error
+}
+
+func (f *fakeTerminalController) Ping(in *api.PingMessage, out *api.PingMessage) error {
+	f.pingCalls.Add(1)
+	if in != nil && in.Message == "PING" {
+		*out = api.PingMessage{Message: "PONG"}
+		return nil
+	}
+	*out = api.PingMessage{}
+	return errors.New("fake: unexpected ping")
+}
+
+func (f *fakeTerminalController) State(_ *api.Empty, out *api.TerminalStatusMode) error {
+	f.stateCalls.Add(1)
+	*out = f.state
+	return nil
+}
+
+func (f *fakeTerminalController) Attach(_ *api.ID, _ *api.Empty) error {
+	f.attachCalls.Add(1)
+	return f.attachErr
+}
+
+// startFakeTerminalServer spins up a JSON-RPC server on a fresh Unix
+// socket inside dir, registers fake under api.TerminalService, and
+// returns the absolute socket path. The server is torn down when the
+// test ends.
+func startFakeTerminalServer(t *testing.T, dir string, fake *fakeTerminalController) string {
+	t.Helper()
+	sockPath := filepath.Join(dir, "terminal.sock")
+
+	srv := rpc.NewServer()
+	if err := srv.RegisterName(api.TerminalService, fake); err != nil {
+		t.Fatalf("RegisterName: %v", err)
+	}
+
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("net.Listen unix %s: %v", sockPath, err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			conn, errAccept := ln.Accept()
+			if errAccept != nil {
+				return
+			}
+			go srv.ServeCodec(jsonrpc.NewServerCodec(conn))
+		}
+	}()
+
+	t.Cleanup(func() {
+		_ = ln.Close()
+		wg.Wait()
+	})
+
+	return sockPath
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func TestRun_RequiresSocketPath(t *testing.T) {
+	t.Parallel()
+	err := attach.Run(context.Background(), attach.Options{Logger: discardLogger()})
+	if err == nil {
+		t.Fatal("expected error when SocketPath is empty, got nil")
+	}
+}
+
+func TestRun_DialFailsOnMissingSocket(t *testing.T) {
+	t.Parallel()
+	missing := filepath.Join(t.TempDir(), "no-such.sock")
+
+	// Stdin needs to be a *os.File, but the loop never reaches raw
+	// mode because Ping fails first. A pipe satisfies the type.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = r.Close()
+		_ = w.Close()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	runErr := attach.Run(ctx, attach.Options{
+		SocketPath: missing,
+		Stdin:      r,
+		Stdout:     w,
+		Stderr:     w,
+		Logger:     discardLogger(),
+	})
+	if runErr == nil {
+		t.Fatal("expected error dialing missing socket, got nil")
+	}
+}
+
+// TestRun_AttachFailureReturnsError exercises the happy connect path
+// (Ping + State) against a fake control socket and verifies pkg/attach
+// surfaces the Attach failure as an error wrapped with errdefs.ErrAttach.
+// This is the canonical "façade against a fake control socket" coverage
+// asked for in the issue.
+func TestRun_AttachFailureReturnsError(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	fake := &fakeTerminalController{
+		state:     api.Ready,
+		attachErr: errors.New("fake: attach refused"),
+	}
+	sock := startFakeTerminalServer(t, tempDir, fake)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = r.Close()
+		_ = w.Close()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	runErr := attach.Run(ctx, attach.Options{
+		SocketPath:             sock,
+		Stdin:                  r,
+		Stdout:                 w,
+		Stderr:                 w,
+		DisableDetachKeystroke: true,
+		Logger:                 discardLogger(),
+	})
+	if runErr == nil {
+		t.Fatal("expected attach failure, got nil")
+	}
+	if !errors.Is(runErr, errdefs.ErrAttach) {
+		t.Fatalf("expected error wrapping errdefs.ErrAttach, got: %v", runErr)
+	}
+	if got := fake.pingCalls.Load(); got == 0 {
+		t.Errorf("expected at least one Ping call, got %d", got)
+	}
+	if got := fake.stateCalls.Load(); got == 0 {
+		t.Errorf("expected at least one State call, got %d", got)
+	}
+	if got := fake.attachCalls.Load(); got == 0 {
+		t.Errorf("expected at least one Attach call, got %d", got)
+	}
+}
+
+// TestRun_NilLoggerDoesNotPanic verifies the Options.Logger == nil
+// branch falls back to a discard logger rather than dereferencing nil.
+func TestRun_NilLoggerDoesNotPanic(t *testing.T) {
+	t.Parallel()
+	missing := filepath.Join(t.TempDir(), "no-such.sock")
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = r.Close()
+		_ = w.Close()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Logger intentionally left nil.
+	_ = attach.Run(ctx, attach.Options{
+		SocketPath: missing,
+		Stdin:      r,
+		Stdout:     w,
+		Stderr:     w,
+	})
+	// No panic == pass.
+}
+

--- a/pkg/attach/doc.go
+++ b/pkg/attach/doc.go
@@ -1,0 +1,44 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package attach exposes an in-process façade for sbsh's interactive
+// "sb attach" loop, so external Go programs can drive an attach session
+// against a running terminal control socket without spawning the sb
+// binary as a subprocess.
+//
+// The single public entrypoint is Run(ctx, Options). It connects to the
+// terminal control socket given by Options.SocketPath, runs the
+// bidirectional PTY copy loop (caller-supplied stdin/stdout/stderr),
+// installs the SIGWINCH-driven resize forwarder, honours the detach
+// keystroke (^] twice, opt-out via DisableDetachKeystroke), and returns
+// when the session ends — either because the remote side closed, the
+// user detached, or the caller cancelled ctx.
+//
+// Options.Stdin must be a TTY-backed *os.File (the loop puts it in raw
+// mode and reads window size from it via TIOCGWINSZ). Stdout/Stderr can
+// be any *os.File; embedders typically pass os.Stdout / os.Stderr.
+//
+// The package allocates a private Unix-domain control socket for the
+// embedded client under os.TempDir() for the lifetime of the call and
+// removes it on return. SIGINT/SIGTERM are intentionally NOT trapped
+// here — the caller is in charge of cancelling ctx in response to
+// whichever signals make sense for their program. cmd/sb/attach wires
+// signal.NotifyContext on top of pkg/attach so the CLI keeps its
+// existing Ctrl-C / SIGTERM behaviour.
+//
+// Stability: pre-v1. Field names and defaults may change between minor
+// releases until the umbrella issue (#118) closes.
+package attach


### PR DESCRIPTION
## Summary
- External Go programs (notably kukeon's `kuke attach`) need to drive an interactive sbsh attach session in-process without spawning the `sb` binary as a subprocess. Today the attach loop lives in `internal/client.ClientController`, which is not importable.
- Add `pkg/attach.Run(ctx, Options) error` as the lone public entrypoint for embedders. Internals (`ClientController`, `ClientDoc` construction, naming, run-dir housekeeping) stay private behind the package.
- Wire `cmd/sb/attach` to call `pkg/attach.Run` so there is one code path for the interactive attach loop. The CLI keeps ownership of `signal.NotifyContext(SIGINT/SIGTERM)`; pkg/attach itself deliberately does not trap signals (godoc'd) so embedders pick their own policy.
- Plumb caller-supplied stdin/stdout/stderr `*os.File` handles through `internal/client.NewClientControllerWithIO` → `clientrunner.NewClientRunnerExecWithIO` → `Exec.{stdin,stdout,stderr}`. The `os.Std*` references in `io.go`, `lifecycle.go`, `terminal.go` are replaced with the runner-scoped fields; existing callers go through the nil-defaulting overload, so behaviour is unchanged for `sb`.
- Add a SocketFile-only short-circuit in `Controller.createAttachTerminal`: embedders that already know the absolute control-socket path skip the metadata-discovery dance.

## Acceptance criteria
- [x] `pkg/attach.Run(ctx, Options) error` exists and is the only export an external embedder needs.
- [x] Feature parity with `sb attach`: detach keystroke (toggleable via `Options.DisableDetachKeystroke`), SIGWINCH-driven resize (installed by `forwardResize` against `Options.Stdin`), SIGINT/SIGTERM handled by the caller's ctx (CLI wires `signal.NotifyContext`), clean exit on context cancel (returns `errdefs.ErrContextDone`).
- [x] `cmd/sb/attach` calls `pkg/attach.Run` (no duplicate loop; `buildClientDoc` and the inline controller wiring are gone).
- [x] Unit test exercises the façade against a fake control socket (`startFakeTerminalServer` runs a JSON-RPC server with a `fakeTerminalController`; no real PTY required).
- [x] Godoc on the package describes the embedder contract (`doc.go` covers Run, Options.Stdin TTY requirement, signal-policy ownership, socket lifetime, pre-v1 stability tag).

## Test plan
- [x] `make sbsh-sb` — produces ELF executables for `sbsh` and `sb`.
- [x] `file ./sbsh ./sb` — both `ELF 64-bit LSB executable`.
- [x] `go build ./...` — clean.
- [x] `go vet ./...` — clean.
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` — full unit suite green (matches CI's `Build & Test` step), including new `pkg/attach` tests.
- [x] `go test -tags=integration ./cmd/sb/get/...` — green (matches CI's integration step).
- [x] `(cd docs/examples/library-consumer && go build ./... && go vet ./...)` — green (matches CI's library-consumer build step).
- [ ] `-race` not run locally (no gcc on this host); CI covers it.

Closes #155