### PR TITLE
fix(client): wait on rpcReadyCh with ctx.Done so Run can't pin on RPC startup

### DIFF
--- a/internal/client/controller.go
+++ b/internal/client/controller.go
@@ -85,8 +85,12 @@ func NewClientControllerWithIO(
 		closedCh:    make(chan struct{}),
 		closingCh:   make(chan error, 1),
 		ctrlReadyCh: make(chan struct{}),
-		rpcReadyCh:  make(chan error),
-		rpcDoneCh:   make(chan error),
+		// rpcReadyCh is buffered (cap 1) so StartServer can deposit its
+		// one-shot ready signal without blocking on a receiver. Run watches
+		// both this channel and ctx.Done below; without the buffer, a Run
+		// that bailed on ctx.Done would pin StartServer forever on its send.
+		rpcReadyCh: make(chan error, 1),
+		rpcDoneCh:  make(chan error),
 		closeReqCh:  make(chan error, 1),
 		//nolint:mnd // event channel buffer size
 		eventsCh: make(chan clientrunner.Event, 32),
@@ -142,15 +146,29 @@ func (s *Controller) Run(doc *api.ClientDoc) error {
 	rpc := &clientrpc.ClientControllerRPC{Core: s}
 
 	go s.sr.StartServer(s.ctx, rpc, s.rpcReadyCh, s.rpcDoneCh)
-	// Wait for startup result
-	if errRPC := <-s.rpcReadyCh; errRPC != nil {
-		if errC := s.Close(errRPC); errC != nil {
-			s.logger.Error("error during Close after RPC server start failure", "error", errC)
-			errRPC = fmt.Errorf("%w: %w: %w", errRPC, errdefs.ErrOnClose, errC)
+	// Wait for startup result. Watch ctx.Done so a StartServer that never
+	// signals readiness — whether because it crashed before its send or
+	// because its caller cancelled before scheduling — can't pin Run forever.
+	select {
+	case errRPC := <-s.rpcReadyCh:
+		if errRPC != nil {
+			if errC := s.Close(errRPC); errC != nil {
+				s.logger.Error("error during Close after RPC server start failure", "error", errC)
+				errRPC = fmt.Errorf("%w: %w: %w", errRPC, errdefs.ErrOnClose, errC)
+			}
+			close(s.ctrlReadyCh)
+			s.logger.Error("failed to start client RPC server", "error", errRPC)
+			return fmt.Errorf("%w: %w", errdefs.ErrStartRPCServer, errRPC)
+		}
+	case <-s.ctx.Done():
+		var errDone error
+		s.logger.Warn("parent context canceled while waiting for RPC server start")
+		if errC := s.Close(s.ctx.Err()); errC != nil {
+			s.logger.Error("error during Close after context done", "error", errC)
+			errDone = fmt.Errorf("%w: %w", errdefs.ErrOnClose, errC)
 		}
 		close(s.ctrlReadyCh)
-		s.logger.Error("failed to start client RPC server", "error", errRPC)
-		return fmt.Errorf("%w: %w", errdefs.ErrStartRPCServer, errRPC)
+		return fmt.Errorf("%w: %w", errdefs.ErrContextDone, errDone)
 	}
 
 	var terminal *api.AttachedTerminal

--- a/internal/client/controller_test.go
+++ b/internal/client/controller_test.go
@@ -375,6 +375,71 @@ func Test_ErrContextDone(t *testing.T) {
 	}
 }
 
+// Regression for #149: if StartServer never signals on rpcReadyCh — e.g.
+// a hang or crash before its send — Run must still unblock when its parent
+// context is canceled, instead of pinning forever on the receive.
+func Test_ErrContextDone_RPCNeverReady(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	sc := NewClientController(ctx, logger).(*Controller)
+	sc.NewClientRunner = func(ctx context.Context, logger *slog.Logger, _ *api.ClientDoc, _ chan<- clientrunner.Event) clientrunner.ClientRunner {
+		return &clientrunner.Test{
+			Ctx:    ctx,
+			Logger: logger,
+			OpenSocketCtrlFunc: func() error {
+				return nil
+			},
+			StartServerFunc: func(ctx context.Context, _ *clientrpc.ClientControllerRPC, _ chan error, _ chan error) {
+				// Never signal readiness — sit on ctx until cancel.
+				<-ctx.Done()
+			},
+			CloseFunc: func(_ error) error {
+				return nil
+			},
+			CreateMetadataFunc: func() error {
+				return nil
+			},
+		}
+	}
+	sc.NewTerminalStore = func() terminalstore.TerminalStore {
+		return &terminalstore.Test{}
+	}
+
+	clientID := naming.RandomID()
+	doc := &api.ClientDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindClient,
+		Metadata: api.ClientMetadata{
+			Name:        "default",
+			Labels:      make(map[string]string),
+			Annotations: make(map[string]string),
+		},
+		Spec: api.ClientSpec{
+			ID:           api.ID(clientID),
+			LogFile:      "/tmp/sbsh-logs/s0",
+			RunPath:      viper.GetString("global.runPath"),
+			TerminalSpec: &api.TerminalSpec{ID: "test-terminal"},
+		},
+	}
+
+	exitCh := make(chan error, 1)
+	go func() {
+		exitCh <- sc.Run(doc)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-exitCh:
+		if !errors.Is(err, errdefs.ErrContextDone) {
+			t.Fatalf("expected '%v'; got: '%v'", errdefs.ErrContextDone, err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancel; rpcReadyCh wait is missing ctx.Done case")
+	}
+}
+
 func Test_ErrRPCServerExited(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	sc := NewClientController(context.Background(), logger).(*Controller)


### PR DESCRIPTION
## Summary
- `client.Controller.Run` waited on `<-s.rpcReadyCh` outside any select, so a `StartServer` that crashed before its send — or a test mock that hit its non-blocking-send `default` branch — would pin Run forever, even after the parent context cancelled. Wrap the receive in a select that also watches `s.ctx.Done()` so context cancellation always unblocks startup.
- Buffer `rpcReadyCh` (cap 1). Two reasons: (a) the production `StartServer.readyCh <- nil` send no longer blocks forever if Run took the new ctx.Done branch (no goroutine leak); (b) the existing tests' `select { case readyCh <- nil: default: }` mock can't drop the signal anymore — the buffered slot is always available. This eliminates the race surface called out in #149.
- Add `Test_ErrContextDone_RPCNeverReady` regression: a `StartServerFunc` that never signals readiness must still let `Run` return with `ErrContextDone` when the parent context is cancelled. Without the new select arm, this hangs until the test's 2s deadline trips.

## Test plan
- [x] `go test -timeout=120s -count=200 -run '^Test_ErrContextDone(_RPCNeverReady)?$|^Test_ErrRPCServerExited$|^Test_ErrCloseReq$' ./internal/client/` — 200/200 green
- [x] `go test -timeout=180s ./internal/client/...` — full client suite green
- [x] `go test -timeout=5m -skip 'Test_HandleEvent_EvCmdExited' $(go list ./... | grep -v '/e2e$')` — full unit suite green
- [x] `go test -tags=integration ./cmd/sb/get/...` — green
- [x] `make sbsh-sb` — `./sbsh` is `ELF 64-bit LSB executable`
- [x] `go vet ./...` — clean
- [x] `cd docs/examples/library-consumer && go build ./... && go vet ./...` — green

`Test_HandleEvent_EvCmdExited` (`internal/terminal`) is the pre-existing #138 deadlock — verified to fail 5/5 on `origin/main` (`468aabb`) in an isolated worktree, unrelated to this PR's diff. Open PRs #148 and #139 fix it.

Closes #149