### PR TITLE
fix(controller): wrap ctx.Err() in ErrContextDone return so message isn't %!w(<nil>)

### DIFF
--- a/internal/client/controller.go
+++ b/internal/client/controller.go
@@ -161,14 +161,15 @@ func (s *Controller) Run(doc *api.ClientDoc) error {
 			return fmt.Errorf("%w: %w", errdefs.ErrStartRPCServer, errRPC)
 		}
 	case <-s.ctx.Done():
-		var errDone error
+		ctxErr := s.ctx.Err()
+		errReturn := fmt.Errorf("%w: %w", errdefs.ErrContextDone, ctxErr)
 		s.logger.Warn("parent context canceled while waiting for RPC server start")
-		if errC := s.Close(s.ctx.Err()); errC != nil {
+		if errC := s.Close(ctxErr); errC != nil {
 			s.logger.Error("error during Close after context done", "error", errC)
-			errDone = fmt.Errorf("%w: %w", errdefs.ErrOnClose, errC)
+			errReturn = fmt.Errorf("%w: %w: %w", errdefs.ErrContextDone, ctxErr, errC)
 		}
 		close(s.ctrlReadyCh)
-		return fmt.Errorf("%w: %w", errdefs.ErrContextDone, errDone)
+		return errReturn
 	}
 
 	var terminal *api.AttachedTerminal
@@ -266,13 +267,13 @@ func (s *Controller) Run(doc *api.ClientDoc) error {
 	for {
 		select {
 		case <-s.ctx.Done():
-			var errDone error
+			ctxErr := s.ctx.Err()
 			s.logger.Warn("parent context canceled, shutting down controller")
-			if errC := s.Close(s.ctx.Err()); errC != nil {
+			if errC := s.Close(ctxErr); errC != nil {
 				s.logger.Error("error during Close after context done", "error", errC)
-				errDone = fmt.Errorf("%w: %w", errdefs.ErrOnClose, errC)
+				return fmt.Errorf("%w: %w: %w", errdefs.ErrContextDone, ctxErr, errC)
 			}
-			return fmt.Errorf("%w: %w", errdefs.ErrContextDone, errDone)
+			return fmt.Errorf("%w: %w", errdefs.ErrContextDone, ctxErr)
 
 		case ev := <-s.eventsCh:
 			s.logger.Debug(

--- a/internal/terminal/controller.go
+++ b/internal/terminal/controller.go
@@ -191,13 +191,13 @@ func (c *Controller) Run(spec *api.TerminalSpec) error {
 	for {
 		select {
 		case <-c.ctx.Done():
-			var err error
+			ctxErr := c.ctx.Err()
 			c.logger.WarnContext(c.ctx, "parent context channel has been closed")
-			if errC := c.Close(c.ctx.Err()); errC != nil {
+			if errC := c.Close(ctxErr); errC != nil {
 				c.logger.ErrorContext(c.ctx, "error during Close after context done", "err", errC)
-				err = fmt.Errorf("%w: %w", errdefs.ErrOnClose, errC)
+				return fmt.Errorf("%w: %w: %w", errdefs.ErrContextDone, ctxErr, errC)
 			}
-			return fmt.Errorf("%w: %w", errdefs.ErrContextDone, err)
+			return fmt.Errorf("%w: %w", errdefs.ErrContextDone, ctxErr)
 
 		case ev := <-c.eventsCh:
 			c.logger.DebugContext(c.ctx,


### PR DESCRIPTION
## Summary

- The three `case <-ctx.Done()` branches in `internal/client/controller.go` and `internal/terminal/controller.go` wrapped a `var err error` (nil when `Close` succeeded) into the returned error, so the message rendered as `"context has been cancelled: %!w(<nil>)"`. `errors.Is(err, errdefs.ErrContextDone)` still matched, so the bug was cosmetic but tests using `Errorf` formatting saw the malformed string (visible in `Test_HandleEvent_EvCmdExited`'s failure output during occasional flakes).
- Wrap `ctx.Err()` (always non-nil here, distinguishes `context.Canceled` from `context.DeadlineExceeded`) instead of the never-set local. When `Close` returns an error, fold it in as a third wrapped error so the cause stays in the chain. The intermediate `errdefs.ErrOnClose` sentinel is dropped from this path — no test or production caller does `errors.Is(..., ErrOnClose)`, so this is a deliberate simplification rather than a behavior break.
- Issue called out two sites; the same pattern exists at `internal/client/controller.go:171` (the RPC-readiness select arm) — fixed there too with the equivalent shape that preserves the original `close(s.ctrlReadyCh)` ordering.

## Test plan

- [x] `make sbsh-sb` (ELF binary verified)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -timeout=5m -skip Test_HandleEvent_EvCmdExited $(go list ./... | grep -v '/e2e$')` — all green
- [x] `go test -tags=integration ./cmd/sb/get/...` — green
- [x] `cd docs/examples/library-consumer && go build ./... && go vet ./...` — green
- [x] `Test_HandleEvent_EvCmdExited` skipped: pre-existing flaky deadlock tracked by #138 / #108 with open fixes #139 and #148. Reproduced on `origin/main` (~40% deadlock over 5 runs) — unrelated to this PR's scope.

Closes #162