### PR TITLE
fix(terminal): reject positional argv after -- when stdin/file spec supplied

### DIFF
--- a/cmd/sbsh/terminal/terminal.go
+++ b/cmd/sbsh/terminal/terminal.go
@@ -215,6 +215,14 @@ func setLoggingVarsFromFlags() {
 func processSpec(cmd *cobra.Command, spec **api.TerminalSpec, workload []string) error {
 	// Check if spec is already provided
 	if *spec != nil {
+		// A stdin/file spec already supplies the workload; positional argv
+		// after `--` would be silently dropped, so reject it loudly.
+		if len(workload) > 0 {
+			return fmt.Errorf(
+				"%w: positional argv after '--' is not valid when a terminal spec is supplied via stdin or --file",
+				errdefs.ErrInvalidArgument,
+			)
+		}
 		// Spec provided via stdin
 		err := logging.SetupFileLogger(cmd, (*spec).LogFile, (*spec).LogLevel)
 		if err != nil {

--- a/cmd/sbsh/terminal/terminal_test.go
+++ b/cmd/sbsh/terminal/terminal_test.go
@@ -491,3 +491,23 @@ func Test_ValidJSONSpec(t *testing.T) {
 		t.Fatalf("expected Name %s; got: %s", validSpec.Name, spec.Name)
 	}
 }
+
+func Test_processSpec_RejectsWorkloadWithSpec(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	spec := &api.TerminalSpec{
+		ID:      api.ID("test-id"),
+		Kind:    api.TerminalLocal,
+		Name:    "test-name",
+		Command: "/bin/bash",
+	}
+
+	err := processSpec(cmd, &spec, []string{"/bin/zsh"})
+	if err == nil {
+		t.Fatal("expected error when workload supplied alongside a stdin/file spec")
+	}
+	if !errors.Is(err, errdefs.ErrInvalidArgument) {
+		t.Fatalf("expected '%v'; got: '%v'", errdefs.ErrInvalidArgument, err)
+	}
+}


### PR DESCRIPTION
## Summary

- `cmd/sbsh/terminal/terminal.go`'s `processSpec` short-circuited on a non-nil spec from stdin/`--file` and ignored `workload`, so `sbsh terminal - -- /bin/bash` and `sbsh terminal --file foo.json -- /bin/bash` silently dropped the positional argv.
- Added a guard at the top of the `*spec != nil` branch that returns `errdefs.ErrInvalidArgument` when a workload accompanies a stdin/file spec, restoring the pre-#147 "incompatible inputs are loud" contract that `checkStdInUsage` used to enforce.
- The existing comment "Spec provided via stdin" is technically stale (spec can also come from `--file`), but updating it is out of scope for this fix.

## Test plan

- [x] `make sbsh-sb` (ELF binary verified)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./cmd/sbsh/terminal/...` — green, including new `Test_processSpec_RejectsWorkloadWithSpec`
- [x] `go test -timeout=5m -skip Test_HandleEvent_EvCmdExited \$(go list ./... | grep -v '/e2e\$')` — green (skip per known #138 deadlock)
- [x] `go test -tags=integration ./cmd/sb/get/...` — green
- [x] `cd docs/examples/library-consumer && go build ./... && go vet ./...` — green
- [x] Manual: `./sbsh terminal --file /tmp/spec.json -- /bin/zsh` and `echo '{...}' | ./sbsh terminal - -- /bin/zsh` both error with `invalid positional argument: positional argv after '--' is not valid when a terminal spec is supplied via stdin or --file`
- [ ] **Pre-existing flake unrelated to this PR:** `TestSignalForwarder_TargetsProcessGroup` in `internal/terminal/terminalrunner` flakes on \`origin/main\` (~80% over 20 runs in an isolated worktree); reproduces independently of this branch's diff. Will surface separately via \`/reflect\`.

Closes #150