### PR TITLE
test: fix TestSignalForwarder_TargetsProcessGroup sibling-trap race

### DIFF
--- a/internal/terminal/terminalrunner/signals_linux_test.go
+++ b/internal/terminal/terminalrunner/signals_linux_test.go
@@ -41,23 +41,49 @@ func TestSignalForwarder_TargetsProcessGroup(t *testing.T) {
 	dir := t.TempDir()
 	leaderMarker := filepath.Join(dir, "leader")
 	siblingMarker := filepath.Join(dir, "sibling")
+	siblingReadyMarker := filepath.Join(dir, "sibling_ready")
 
-	// Subshell uses "sleep & wait" so the shell does not tail-call-exec
-	// sleep (dash optimizes "exec sleep" when sleep is the last command,
-	// which would leave no shell alive to run the SIGHUP trap).
-	// Markers are written to disk so the test does not depend on stdout
-	// flush ordering of the subshell vs. the leader.
+	// Three constraints must hold to deliver a deterministic HUP-via-trap
+	// signal under both the leader AND the subshell:
+	//
+	//  1. The subshell's HUP trap must be installed before the test sends
+	//     SIGHUP. `(...) &` only guarantees the subshell has been forked, not
+	//     that it has executed its first statement. The leader therefore polls
+	//     "$SIBLING_READY", which the subshell touches *after* installing the
+	//     trap, before printing "ready".
+	//  2. The subshell must stay alive until its trap actually runs. A bare
+	//     `sleep 10 & wait` is racy: when SIGHUP reaches the sleep child first,
+	//     dash reaps it via waitpid and exits the subshell before the pending
+	//     SIGHUP for the subshell itself dispatches the trap, so $SIBLING is
+	//     never touched. A `while :; do sleep 1; done` loop keeps the shell
+	//     alive across sleep deaths until the trap's `exit 0` terminates it.
+	//  3. The leader must not print "done" until the subshell's trap has
+	//     actually finished (i.e. the subshell process is dead). `wait $child`
+	//     returns when *the leader's own* HUP trap fires, not when $child
+	//     exits. Re-waiting in a `kill -0`-gated loop pins "done" to subshell
+	//     death, ensuring the marker check in the Go side never races with an
+	//     in-flight `touch "$SIBLING"`.
+	//
+	// Markers are written to disk so the test does not depend on stdout flush
+	// ordering of the subshell vs. the leader.
 	script := `
 trap 'touch "$LEADER"' HUP
-(trap 'touch "$SIBLING"; exit 0' HUP; sleep 10 & wait) &
+(trap 'touch "$SIBLING"; exit 0' HUP; touch "$SIBLING_READY"; while :; do sleep 1; done) &
 child=$!
+while [ ! -f "$SIBLING_READY" ]; do sleep 0.01; done
 echo ready
-wait $child
+while kill -0 $child 2>/dev/null; do
+	wait $child 2>/dev/null
+done
 echo done
 exit 0
 `
 	leader := exec.Command("/bin/sh", "-c", script)
-	leader.Env = append(os.Environ(), "LEADER="+leaderMarker, "SIBLING="+siblingMarker)
+	leader.Env = append(os.Environ(),
+		"LEADER="+leaderMarker,
+		"SIBLING="+siblingMarker,
+		"SIBLING_READY="+siblingReadyMarker,
+	)
 	leader.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	stdout, err := leader.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
## Summary

`TestSignalForwarder_TargetsProcessGroup` flakes (~20% on `origin/main`) because the shell script the test fans signals through has *three* races, not the one called out in #165. This patch closes all three:

1. **Subshell trap-install race (the one identified in #165).** `(trap '…' HUP; sleep 10 & wait) &` only guarantees the subshell has been forked, not that it has executed its `trap`. SIGHUP arriving before the trap is installed takes the default action (terminate) and the marker is never touched. The subshell now `touch "$SIBLING_READY"` *after* installing its trap; the leader spins on that marker before printing `ready`, so `syscall.Kill(SIGHUP)` only ever lands once the trap is in place.
2. **Subshell `wait` premature-exit race.** With `sleep 10 & wait`, when SIGHUP reaches the `sleep` child first, dash reaps it via `waitpid` and exits the subshell *before* the pending SIGHUP for the subshell itself dispatches the trap, so `$SIBLING` is never touched. Replaced with `while :; do sleep 1; done` so the subshell stays alive across sleep deaths and the trap's `exit 0` is the only termination path.
3. **Leader `wait` early-return race.** `wait $child` in dash returns when the *leader's own* HUP trap fires — not when `$child` exits. The leader was therefore printing `done` while the subshell's `touch "$SIBLING"` was still in flight; the Go-side marker check then raced an in-flight write. Wrapped in a `while kill -0 $child …; do wait $child; done` loop so `done` is pinned to subshell death.

The third race is what surfaced when patching only #1 and #2 — the failure rate actually went *up* with the loop subshell because it widened the trap-completion window, and the early-`done` race dominated. Confirmed by an isolated diagnostic harness (run 200×) showing `trap_fired=true sibling=false` ≈30% of the time despite the trap entering and writing its first marker.

## Test plan

- [x] `go test -timeout=300s -count=500 -run '^TestSignalForwarder_TargetsProcessGroup\$' ./internal/terminal/terminalrunner/...` — 0 failures over 500 runs (was ~20% on `origin/main`)
- [x] `go test ./internal/terminal/terminalrunner/...` — green
- [x] `go test -timeout=5m -skip Test_HandleEvent_EvCmdExited \$(go list ./... | grep -v '/e2e\$')` — green (skip per known #138 deadlock; addressed by #148)
- [x] `go test -tags=integration ./cmd/sb/get/...` — green
- [x] `cd docs/examples/library-consumer && go build ./... && go vet ./...` — green
- [x] `make sbsh-sb` — `./sbsh` and `./sb` both ELF executables
- [x] `go vet ./...` — clean

Closes #165