### PR TITLE
docs: refresh sbsh terminal synopsis after argv-after-dash pivot

### DIFF
--- a/docs/site/cli/sbsh.md
+++ b/docs/site/cli/sbsh.md
@@ -6,7 +6,7 @@ The `sbsh` command launches a client attached to a terminal. It's designed for i
 
 ```bash
 sbsh [flags]
-sbsh terminal [flags]
+sbsh terminal [flags] [-- command [args...]]
 ```
 
 ## Commands
@@ -111,10 +111,17 @@ sbsh -d -p my-profile
 
 ### `sbsh terminal`
 
-Launch a terminal without an attached client:
+Launch a terminal without an attached client. The workload command and its
+arguments are passed positionally after a `--` separator and executed via
+`execve` semantics (no shell re-tokenization), the way `docker run`,
+`kubectl exec`, `runc exec`, `ctr run`, `sudo`, `env`, and `nsenter` all take
+their argv. With no positional argv, the profile default (`/bin/bash`) applies.
 
 ```bash
+sbsh terminal [flags] [-- command [args...]]
 sbsh terminal --name my-terminal
+sbsh terminal --name my-terminal -- /bin/zsh
+sbsh terminal -p devprofile -- /bin/sleep 3600
 ```
 
 ### `sbsh version`


### PR DESCRIPTION
## Summary
- `docs/site/cli/sbsh.md` synopsis (line 9) and the Subcommands `sbsh terminal` block (lines 110-115) still showed the pre-#147 `sbsh terminal [flags]` shape; the cobra `Use:` line is now `terminal [flags] [-- command [args...]]` (`cmd/sbsh/terminal/terminal.go:278`).
- Refreshed both blocks to match the live `Use:` line and added two examples that exercise the post-`--` argv form (`-- /bin/zsh`, `-- /bin/sleep 3600`), plus a one-paragraph note explaining the `execve`-semantics rationale lifted from the cobra `Long:` text.
- Scope kept tight to the two locations called out in #151 — `commands.md` uses a comparison-table summary rather than a synopsis line and was out of scope.

## Test plan
- [x] `make sbsh-sb` — both `./sbsh` and `./sb` are ELF executables
- [x] `go build ./...`, `go vet ./...` — clean
- [x] `go test -timeout=5m -skip Test_HandleEvent_EvCmdExited $(go list ./... | grep -v '/e2e$')` — green (skip per known #108/#138 deadlock; that test is fixed by the open PR for #138)
- [x] `go test -tags=integration ./cmd/sb/get/...` — green
- [x] `cd docs/examples/library-consumer && go build ./... && go vet ./...` — green
- [ ] No code change; `mkdocs build` not run locally (no mkdocs-material installed on this host). The docs site CI deploys on push to `main`.

Closes #151