### PR TITLE
docs: align --terminal-capture-file flag description between root and subcommand

### DIFF
--- a/cmd/sbsh/sbsh.go
+++ b/cmd/sbsh/sbsh.go
@@ -308,7 +308,7 @@ func setTerminalFlags(rootCmd *cobra.Command) error {
 		return err
 	}
 
-	rootCmd.Flags().String("terminal-capture-file", "", "Optional filename for the terminal capture")
+	rootCmd.Flags().String("terminal-capture-file", "", "Optional filename for the PTY transcript capture")
 	if err := viper.BindPFlag(config.SBSH_ROOT_TERM_CAPTURE_FILE.ViperKey, rootCmd.Flags().Lookup("terminal-capture-file")); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- Root `sbsh` and `sbsh terminal` registered the capture-file flag with two slightly different descriptions; the issue called for the more precise wording (`PTY transcript capture`) and asked it to be applied uniformly.
- `cmd/sbsh/terminal/terminal.go:390` and `docs/site/cli/sbsh.md:71` already use the precise wording — only the root registration in `cmd/sbsh/sbsh.go:311` was out of date. One-line update there.

## Notes for reviewer
- Local `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` reproduces the pre-existing `Test_HandleEvent_EvCmdExited` deadlock that's already tracked in #108 / #138 with PR #148 in flight. The Test workflow on `main` is currently failing on that same test (`gh run list --branch main`), so CI on this docs-only PR will likely surface the same red. Re-running with `-skip '^Test_HandleEvent_EvCmdExited$'` is fully green; the docs change does not touch that code path. Per CLAUDE.md's "verifying a reviewer's ask uncovers a separate bug" guidance, not bundling the fix.

## Test plan
- [x] `make sbsh-sb` — both `./sbsh` and `./sb` are ELF executables
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test -timeout=5m -skip '^Test_HandleEvent_EvCmdExited$' $(go list ./... | grep -v '/e2e$')` — green
- [x] `go test -tags=integration ./cmd/sb/get/...` — green
- [x] `docs/examples/library-consumer`: `go build ./... && go vet ./...` — green
- [x] `./sbsh --help | grep terminal-capture-file` shows `Optional filename for the PTY transcript capture` (matches `./sbsh terminal --help` already)

Closes #154