### PR TITLE
fix(client): synthesize terminal ID for SocketFile-only attach

### DIFF
--- a/internal/client/controller.go
+++ b/internal/client/controller.go
@@ -30,6 +30,7 @@ import (
 	"github.com/eminwux/sbsh/internal/client/terminalstore"
 	"github.com/eminwux/sbsh/internal/discovery"
 	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/internal/naming"
 	"github.com/eminwux/sbsh/pkg/api"
 )
 
@@ -314,6 +315,9 @@ func (s *Controller) createAttachTerminal(doc *api.ClientDoc) (*api.AttachedTerm
 	if doc.Spec.TerminalSpec.SocketFile != "" {
 		s.logger.Debug("attach by socket path", "socket", doc.Spec.TerminalSpec.SocketFile)
 		spec := *doc.Spec.TerminalSpec
+		if spec.ID == "" {
+			spec.ID = api.ID(naming.RandomID())
+		}
 		terminal := terminalstore.NewSupervisedTerminal(&spec)
 		if err := s.ss.Add(terminal); err != nil {
 			return nil, fmt.Errorf("%w: %w", errdefs.ErrTerminalStore, err)

--- a/internal/client/controller_test.go
+++ b/internal/client/controller_test.go
@@ -2248,3 +2248,80 @@ func Test_ClientAttach_StateTransition(t *testing.T) {
 	_ = sc.Close(errors.New("test complete"))
 	<-exitCh
 }
+
+// Test_CreateAttachTerminal_SocketFileOnly_SynthesizesID verifies that the
+// SocketFile-only short-circuit in createAttachTerminal populates a synthetic
+// ID when the caller (e.g. pkg/attach embedders) supplied only the control
+// socket path. Without the synthetic ID, terminalstore keys, event records,
+// and log fields would all carry the empty string.
+func Test_CreateAttachTerminal_SocketFileOnly_SynthesizesID(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	sc := NewClientController(context.Background(), logger).(*Controller)
+
+	var added *api.AttachedTerminal
+	sc.ss = &terminalstore.Test{
+		AddFunc: func(s *api.AttachedTerminal) error {
+			added = s
+			return nil
+		},
+	}
+
+	doc := &api.ClientDoc{
+		Spec: api.ClientSpec{
+			TerminalSpec: &api.TerminalSpec{
+				SocketFile: "/tmp/sbsh-test/socket",
+			},
+		},
+	}
+
+	terminal, err := sc.createAttachTerminal(doc)
+	if err != nil {
+		t.Fatalf("createAttachTerminal returned error: %v", err)
+	}
+	if terminal == nil {
+		t.Fatal("createAttachTerminal returned nil terminal")
+	}
+	if terminal.Spec.ID == "" {
+		t.Fatal("terminal.Spec.ID is empty; expected synthetic ID for SocketFile-only attach")
+	}
+	if added == nil {
+		t.Fatal("terminalstore.Add was not called")
+	}
+	if added.Spec.ID != terminal.Spec.ID {
+		t.Fatalf("stored terminal ID %q != returned terminal ID %q", added.Spec.ID, terminal.Spec.ID)
+	}
+	// Caller's TerminalSpec must not be mutated — the synthetic ID lives on
+	// the local copy passed to terminalstore.
+	if doc.Spec.TerminalSpec.ID != "" {
+		t.Fatalf("doc.Spec.TerminalSpec.ID was mutated to %q; embedder's spec must stay untouched", doc.Spec.TerminalSpec.ID)
+	}
+}
+
+// Test_CreateAttachTerminal_SocketFileOnly_PreservesProvidedID confirms a
+// caller-supplied ID flows through the SocketFile-only short-circuit
+// unchanged — the synthetic ID only fires when Spec.ID is empty.
+func Test_CreateAttachTerminal_SocketFileOnly_PreservesProvidedID(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	sc := NewClientController(context.Background(), logger).(*Controller)
+
+	sc.ss = &terminalstore.Test{
+		AddFunc: func(_ *api.AttachedTerminal) error { return nil },
+	}
+
+	doc := &api.ClientDoc{
+		Spec: api.ClientSpec{
+			TerminalSpec: &api.TerminalSpec{
+				ID:         api.ID("caller-provided"),
+				SocketFile: "/tmp/sbsh-test/socket",
+			},
+		},
+	}
+
+	terminal, err := sc.createAttachTerminal(doc)
+	if err != nil {
+		t.Fatalf("createAttachTerminal returned error: %v", err)
+	}
+	if terminal.Spec.ID != api.ID("caller-provided") {
+		t.Fatalf("terminal.Spec.ID = %q; want %q", terminal.Spec.ID, "caller-provided")
+	}
+}


### PR DESCRIPTION
## Summary
- `internal/client.Controller.createAttachTerminal` now fills in a synthetic `naming.RandomID()` when the SocketFile-only short-circuit runs without a caller-provided `Spec.ID`. Embedders that hand `pkg/attach` only the absolute control-socket path no longer end up with an empty-string ID flowing into the `terminalstore` map key, `m.current`, event records (`internal/client/clientrunner/io.go`), and log fields.
- The synthetic ID lives on a local copy of the spec — the embedder's `doc.Spec.TerminalSpec` is not mutated. A caller-supplied ID still takes precedence (only the `spec.ID == ""` branch synthesizes).
- No functional bug today (each `pkg/attach.Run` gets its own Controller and adds exactly one terminal, so empty keys don't collide), but logs/events stay coherent across embedded sessions.

## Test plan
- [x] `go test -timeout=60s -run 'Test_CreateAttachTerminal' -v ./internal/client/...` — both new tests pass (synthesizes when empty; preserves when provided)
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` — full unit suite green
- [x] `go test -tags=integration ./cmd/sb/get/...` — green
- [x] `make sbsh-sb` — `./sbsh` and `./sb` ELF executables (verified via `file`)
- [x] `go build ./...` / `go vet ./...` — clean
- [x] `docs/examples/library-consumer`: `go build ./... && go vet ./...` — clean

Closes #157