### PR TITLE
test: refresh stale comment in Test_ErrAttachNoIDOrName

### DIFF
--- a/internal/client/controller_test.go
+++ b/internal/client/controller_test.go
@@ -1121,7 +1121,7 @@ func Test_ErrAttachNoIDOrName(t *testing.T) {
 			ID:           api.ID(clientID),
 			LogFile:      "/tmp/sbsh-logs/s0",
 			RunPath:      viper.GetString("global.runPath"),
-			TerminalSpec: &api.TerminalSpec{ID: "", Name: ""}, // Both empty should trigger ErrAttachNoTerminalSpec
+			TerminalSpec: &api.TerminalSpec{ID: "", Name: ""}, // All three (ID, Name, SocketFile) empty should trigger ErrAttachNoTerminalSpec
 			ClientMode:   api.AttachToTerminal,
 		},
 	}


### PR DESCRIPTION
## Summary
- The inline comment in `Test_ErrAttachNoIDOrName` (`internal/client/controller_test.go:1124`) read "Both empty should trigger ErrAttachNoTerminalSpec", but after #156 the validation in `internal/client/controller.go:208` checks all three of `ID`, `Name`, and `SocketFile`. Refresh the comment to reflect the actual condition.
- Pure comment edit; the test still passes (none of the three are set on the literal — `SocketFile` is the zero value).

## Test plan
- [x] `make sbsh-sb` — `./sbsh` and `./sb` ELF executables (verified via `file`)
- [x] `go build ./...` / `go vet ./...` — clean
- [x] `go test -timeout=5m \$(go list ./... | grep -v '/e2e\$')` — full unit suite green
- [x] `go test -tags=integration ./cmd/sb/get/...` — green
- [x] `docs/examples/library-consumer`: `go build ./... && go vet ./...` — clean

Closes #158