### PR TITLE
fix(attach): export ErrSocketPathRequired so Run's validation error is errors.Is-matchable

### DIFF
--- a/pkg/attach/attach.go
+++ b/pkg/attach/attach.go
@@ -78,7 +78,7 @@ type Options struct {
 // under os.TempDir().
 func Run(ctx context.Context, opts Options) error {
 	if opts.SocketPath == "" {
-		return errors.New("pkg/attach: Options.SocketPath is required")
+		return ErrSocketPathRequired
 	}
 
 	logger := opts.Logger

--- a/pkg/attach/attach_test.go
+++ b/pkg/attach/attach_test.go
@@ -119,6 +119,9 @@ func TestRun_RequiresSocketPath(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when SocketPath is empty, got nil")
 	}
+	if !errors.Is(err, attach.ErrSocketPathRequired) {
+		t.Fatalf("expected error matching attach.ErrSocketPathRequired, got: %v", err)
+	}
 }
 
 func TestRun_DialFailsOnMissingSocket(t *testing.T) {

--- a/pkg/attach/errors.go
+++ b/pkg/attach/errors.go
@@ -1,0 +1,25 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package attach
+
+import "errors"
+
+// ErrSocketPathRequired is returned from Run when Options.SocketPath is
+// empty. Embedders branching on error type can errors.Is against this
+// sentinel to distinguish a missing required option from any other
+// failure surfaced by the underlying controller.
+var ErrSocketPathRequired = errors.New("pkg/attach: Options.SocketPath is required")


### PR DESCRIPTION
## Summary
- `pkg/attach/doc.go` advertises that embedders can `errors.Is` returned errors against `errdefs.*` sentinels for unrecoverable failures, but the `Options.SocketPath == ""` validation in `pkg/attach/attach.go` returned a bare `errors.New(...)` — embedders branching on error type couldn't distinguish "missing required option" from any other failure.
- New `pkg/attach/errors.go` exports `ErrSocketPathRequired`, mirroring the shape of `pkg/spawn/errors.go` (single-line message, godoc explaining the contract). `Run` now returns the sentinel directly so `errors.Is(err, attach.ErrSocketPathRequired)` matches.
- Issue floated two options; took option 1 (export a sentinel) per the issue's own preference and to match the existing `pkg/spawn` precedent.
- Bare return rather than wrapped: the validation runs before any underlying operation, so there is no inner error worth preserving — same shape `pkg/spawn` uses for its required-option sentinels.
- Existing `TestRun_RequiresSocketPath` extended with an `errors.Is(err, attach.ErrSocketPathRequired)` assertion to lock in the contract.

## Test plan
- [x] `go test -timeout=60s -run TestRun_RequiresSocketPath -v ./pkg/attach/...` — passes with the new assertion
- [x] `make sbsh-sb` — `./sbsh` and `./sb` ELF executables (verified via `file`)
- [x] `go build ./...` / `go vet ./...` — clean
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` — full unit suite green
- [x] `go test -tags=integration ./cmd/sb/get/...` — green
- [x] `docs/examples/library-consumer`: `go build ./... && go vet ./...` — clean

Closes #159