### PR TITLE
build: make sbsh-sb hardlink step idempotent on rerun

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ sbsh-sb:
 	-o sbsh \
 	-ldflags="-s -w -X $(MODULE)/cmd/config.Version=$(SBSH_VERSION)" \
 	./cmd/
-	ln sbsh sb
+	ln -f sbsh sb
 
 sbsh:
 	go build -o sbsh ./cmd/sbsh


### PR DESCRIPTION
## Summary
- `Makefile:33` (the canonical `sbsh-sb` target) used a bare `ln sbsh sb`, so rerunning the target without `make clean` failed with `ln: failed to create hard link 'sb': File exists`. `go build -o sbsh` happily overwrites the existing `sbsh`, but the very next step refuses to replace `sb` and the build aborts mid-target.
- Two-character fix: `ln` → `ln -f`. `-f` is supported by both GNU coreutils `ln` and BSD `ln`, so the `linux darwin freebsd` release matrix is unaffected. The other common workaround (`rm -f sb && ln sbsh sb`) achieves the same effect with more noise; took the simpler form per the issue's preferred suggestion.
- CI is unaffected (always runs in fresh checkouts). The win is for local contributors editing a Go file and rerunning `make sbsh-sb` without first running `make clean` (which is overkill — it also wipes `\$HOME/.sbsh/run/*`).

## Test plan
- [x] `rm -f sbsh sb && make sbsh-sb` — succeeds; produces `sbsh` + `sb` hardlink (verified shared BuildID via `file`)
- [x] `make sbsh-sb` (rerun in same tree) — now succeeds; was the failure mode in the issue
- [x] `file ./sbsh ./sb` — both \"ELF 64-bit LSB executable\"
- [x] `go build ./...` / `go vet ./...` — clean
- [x] `go test -count=1 -timeout=300s -skip Test_HandleEvent_EvCmdExited \$(go list ./... | grep -v '/e2e\$')` — full unit suite green (skip is the known #138 deadlock currently in flight via PR for #138)
- [x] `go test -count=1 -tags=integration -timeout=120s ./cmd/sb/get/...` — green
- [x] `E2E_BIN_DIR=\$(pwd) go test -count=1 -timeout=600s ./e2e` — green (2.7s)
- [x] `cd docs/examples/library-consumer && go build ./... && go vet ./...` — clean

Closes #177