### PR TITLE
docs: align processSpec comment with stdin or --file paths

### DIFF
--- a/cmd/sbsh/terminal/terminal.go
+++ b/cmd/sbsh/terminal/terminal.go
@@ -223,7 +223,7 @@ func processSpec(cmd *cobra.Command, spec **api.TerminalSpec, workload []string)
 				errdefs.ErrInvalidArgument,
 			)
 		}
-		// Spec provided via stdin
+		// Spec provided via stdin or --file
 		err := logging.SetupFileLogger(cmd, (*spec).LogFile, (*spec).LogLevel)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary
- `cmd/sbsh/terminal/terminal.go:226` commented the `*spec != nil` branch as `// Spec provided via stdin`, but the spec can also arrive via `--file` since the file-load path was added; the surrounding error message at line 222 already says `via stdin or --file`. Two-character cosmetic — flagged out of scope on #164's review.
- Updated the comment to `// Spec provided via stdin or --file` so the inline doc matches the error text and the actual code paths.

## Test plan
- [x] `make sbsh-sb` — `./sbsh` and `./sb` both ELF executables (verified via `file`)
- [x] `go build ./...` / `go vet ./...` — clean
- [x] `go test -count=1 -timeout=300s -skip Test_HandleEvent_EvCmdExited $(go list ./... | grep -v '/e2e$')` — full unit suite green (skip is the known #138 deadlock currently in flight via PR #148; matches what CI sees today)
- [x] `go test -count=1 -tags=integration -timeout=120s ./cmd/sb/get/...` — green
- [x] `E2E_BIN_DIR=$(pwd) go test -count=1 -timeout=600s ./e2e` — green (2.8s)
- [x] `cd docs/examples/library-consumer && go build ./... && go vet ./...` — clean

Closes #166