### PR TITLE
test(signals_linux_test): drop redundant 2>/dev/null on inner wait

### DIFF
--- a/internal/terminal/terminalrunner/signals_linux_test.go
+++ b/internal/terminal/terminalrunner/signals_linux_test.go
@@ -73,7 +73,7 @@ child=$!
 while [ ! -f "$SIBLING_READY" ]; do sleep 0.01; done
 echo ready
 while kill -0 $child 2>/dev/null; do
-	wait $child 2>/dev/null
+	wait $child
 done
 echo done
 exit 0


### PR DESCRIPTION
## Summary
- `internal/terminal/terminalrunner/signals_linux_test.go:76` had `wait $child 2>/dev/null` inside a `while kill -0 $child 2>/dev/null; do … done` loop. The inner stderr redirect is dead weight: the only stderr `wait` would emit is "not a child of this shell", and by the time that condition holds, `kill -0` on the same pid has already failed and the loop has exited. Outer redirect on `kill -0` is the one that actually suppresses output (during normal child-still-alive polling, that's the noisy call).
- Drop the inner `2>/dev/null`. Pure style cleanup — no behavior change.

## Test plan
- [x] `go test -count=1 -run TestSignalForwarder_TargetsProcessGroup ./internal/terminal/terminalrunner/ -v` — pass
- [x] `make sbsh-sb` — `./sbsh` and `./sb` both ELF executables (verified via `file`)
- [x] `go build ./...` / `go vet ./...` — clean
- [x] `go test -count=1 -timeout=300s -skip Test_HandleEvent_EvCmdExited $(go list ./... | grep -v '/e2e$')` — full unit suite green (skip is the known #138 deadlock currently in flight via PR #148; matches what CI sees today)
- [x] `go test -count=1 -tags=integration -timeout=120s ./cmd/sb/get/...` — green
- [x] `E2E_BIN_DIR=$(pwd) go test -count=1 -timeout=600s ./e2e` — green (2.7s)
- [x] `cd docs/examples/library-consumer && go build ./... && go vet ./...` — clean

Closes #169