### PR TITLE
test: note GNU-only sleep 0.01 in signals_linux_test

### DIFF
--- a/internal/terminal/terminalrunner/signals_linux_test.go
+++ b/internal/terminal/terminalrunner/signals_linux_test.go
@@ -66,6 +66,10 @@ func TestSignalForwarder_TargetsProcessGroup(t *testing.T) {
 	//
 	// Markers are written to disk so the test does not depend on stdout flush
 	// ordering of the subshell vs. the leader.
+	// NOTE: the embedded shell script uses `sleep 0.01`, a GNU coreutils
+	// extension. Safe here because the file is gated `//go:build linux`. Do
+	// not cargo-cult this idiom into a cross-platform test — BSD/macOS
+	// `sleep` rejects fractional arguments.
 	script := `
 trap 'touch "$LEADER"' HUP
 (trap 'touch "$SIBLING"; exit 0' HUP; touch "$SIBLING_READY"; while :; do sleep 1; done) &


### PR DESCRIPTION
## Summary
- Adds a 4-line Go comment immediately above the embedded shell script in `internal/terminal/terminalrunner/signals_linux_test.go` warning that `sleep 0.01` is a GNU coreutils extension. Safe in this file because of the `//go:build linux` gate, but a future cross-platform test that copies this idiom would silently fail on BSD/macOS where `sleep` rejects fractional arguments.
- Pure documentation; no behavior change.

## Test plan
- [x] `make sbsh-sb` — `./sbsh` and `./sb` both ELF executables (verified via `file`)
- [x] `go build ./...` / `go vet ./...` — clean
- [x] `go test -count=1 -run TestSignalForwarder_TargetsProcessGroup ./internal/terminal/terminalrunner/ -v` — pass (0.02s)
- [x] `go test -count=1 -timeout=300s -skip Test_HandleEvent_EvCmdExited $(go list ./... | grep -v '/e2e$')` — full unit suite green (skip is the known #138 deadlock currently in flight via PRs #148/#139; matches what CI sees today)
- [x] `go test -count=1 -tags=integration -timeout=120s ./cmd/sb/get/...` — green
- [x] `E2E_BIN_DIR=$(pwd) go test -count=1 -timeout=600s ./e2e` — green (2.8s)
- [x] `cd docs/examples/library-consumer && go build ./... && go vet ./...` — clean

Closes #170