### PR TITLE
fix(terminal): fail fast on --terminal-name collision with active terminal

### DIFF
--- a/cmd/sbsh/sbsh.go
+++ b/cmd/sbsh/sbsh.go
@@ -174,6 +174,16 @@ You can also use sbsh with parameters. For example:
 				return buildErr
 			}
 
+			if errAvail := discovery.VerifyTerminalNameAvailable(
+				cmd.Context(),
+				logger,
+				terminalSpec.RunPath,
+				terminalSpec.Name,
+			); errAvail != nil {
+				logger.Error("Terminal name collision", "error", errAvail)
+				return errAvail
+			}
+
 			logger.Debug("Built terminal spec", "terminalSpec", fmt.Sprintf("%+v", terminalSpec))
 
 			// Define a new ClientDoc
@@ -303,7 +313,7 @@ func setTerminalFlags(rootCmd *cobra.Command) error {
 		return err
 	}
 
-	rootCmd.Flags().String("terminal-name", "", "Optional name for the terminal")
+	rootCmd.Flags().String("terminal-name", "", "Optional name for the terminal (must be unique across active terminals)")
 	if err := viper.BindPFlag(config.SBSH_ROOT_TERM_NAME.ViperKey, rootCmd.Flags().Lookup("terminal-name")); err != nil {
 		return err
 	}

--- a/cmd/sbsh/terminal/terminal.go
+++ b/cmd/sbsh/terminal/terminal.go
@@ -296,6 +296,11 @@ Examples:
 If no terminal name is provided, a random name will be generated.
 If no command is provided, /bin/bash will be used by default.
 If no log filename is provided, a default path under the run directory will be used.
+
+Terminal names must be unique across active (non-Exited) terminals in the
+same run path; the launch fails fast when the requested name (passed via
+--name, --file, or stdin spec) is already in use. Names from terminals
+that have exited can be reused.
 `,
 		Args:         cobra.ArbitraryArgs,
 		SilenceUsage: true,
@@ -344,6 +349,15 @@ If no log filename is provided, a default path under the run directory will be u
 				return errdefs.ErrTerminalSpecNotFound
 			}
 
+			if errAvail := discovery.VerifyTerminalNameAvailable(
+				cmd.Context(),
+				logger,
+				terminalSpec.RunPath,
+				terminalSpec.Name,
+			); errAvail != nil {
+				return errAvail
+			}
+
 			logger.Debug("Built terminal spec", "terminalSpec", fmt.Sprintf("%+v", terminalSpec))
 
 			if logger.Enabled(context.Background(), slog.LevelDebug) {
@@ -381,7 +395,7 @@ func setupTerminalCmdFlags(terminalCmd *cobra.Command) {
 	terminalCmd.Flags().String("id", "", "Optional terminal ID (random if omitted)")
 	_ = viper.BindPFlag(config.SBSH_TERM_ID.ViperKey, terminalCmd.Flags().Lookup("id"))
 
-	terminalCmd.Flags().String("name", "", "Optional name for the terminal (random if omitted)")
+	terminalCmd.Flags().String("name", "", "Optional name for the terminal (random if omitted; must be unique across active terminals)")
 	_ = viper.BindPFlag(config.SBSH_TERM_NAME.ViperKey, terminalCmd.Flags().Lookup("name"))
 
 	terminalCmd.Flags().String("log-file", "", "Optional filename for the terminal log")

--- a/docs/site/cli/sbsh.md
+++ b/docs/site/cli/sbsh.md
@@ -64,7 +64,7 @@ These flags apply to all `sbsh` commands:
 ### Terminal Flags
 
 - `--terminal-id <id>`: Optional terminal ID (random if omitted)
-- `--terminal-name <name>`: Optional name for the terminal
+- `--terminal-name <name>`: Optional name for the terminal (must be unique across active terminals — see [Name uniqueness](#name-uniqueness))
 - `-p, --terminal-profile <name>`: Profile for the terminal
 - `--terminal-command <cmd>`: Command to run (default: `/bin/bash`)
 - `--terminal-socket <file>`: Optional socket file for the terminal
@@ -123,6 +123,29 @@ sbsh terminal --name my-terminal
 sbsh terminal --name my-terminal -- /bin/zsh
 sbsh terminal -p devprofile -- /bin/sleep 3600
 ```
+
+#### Name uniqueness
+
+Terminal names must be unique across active (non-Exited) terminals sharing
+the same run path. A launch that would collide with an existing active
+terminal fails fast with a clear error rather than silently spawning a
+shadow:
+
+```bash
+$ sbsh terminal --name my-terminal &
+$ sbsh terminal --name my-terminal
+Error: terminal name already in use by an active terminal: "my-terminal" (id 7c4f3a02)
+```
+
+The check applies regardless of how the name reached the spec — flag
+(`--name`, `--terminal-name`), stdin (`sbsh terminal -`), or `--file`
+spec. Names from terminals that have exited (or whose owner process is
+gone, reconciled to `Exited` on scan) can be reused immediately; you do
+not need to `sb get terminals --prune` first. Two simultaneous launches
+with the same name can both pass the check and briefly coexist;
+downstream tools (`sb attach`/`detach`/`stop` `<name>`) resolve the
+collision by returning the first match, so the racing loser remains
+addressable by ID.
 
 ### `sbsh version`
 

--- a/internal/discovery/terminals.go
+++ b/internal/discovery/terminals.go
@@ -28,6 +28,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/eminwux/sbsh/internal/errdefs"
 	"github.com/eminwux/sbsh/pkg/api"
 	pkgdiscovery "github.com/eminwux/sbsh/pkg/discovery"
 	"go.yaml.in/yaml/v3"
@@ -272,6 +273,44 @@ func FindTerminalByName(
 	name string,
 ) (*api.TerminalDoc, error) {
 	return pkgdiscovery.FindTerminalByName(ctx, logger, runPath, name)
+}
+
+// VerifyTerminalNameAvailable returns errdefs.ErrTerminalNameInUse if an
+// active (non-Exited) terminal under runPath already carries name. Stale
+// metadata whose owner process is gone is reconciled to Exited and does not
+// block reuse, so an exited terminal's name can be recycled. An empty name
+// or runPath is treated as unconditionally available — callers fall back to
+// random-name generation in that case and the caller-side spec build owns
+// the unique-id guarantee.
+//
+// Best-effort: a concurrent sbsh launching the same name can pass this check
+// in lockstep with us. Sequential launches (the common case) get fail-fast;
+// downstream tools (sb attach/detach/stop) resolve duplicate names by first
+// match, so the racing loser remains addressable by ID.
+func VerifyTerminalNameAvailable(
+	ctx context.Context,
+	logger *slog.Logger,
+	runPath string,
+	name string,
+) error {
+	if name == "" || runPath == "" {
+		return nil
+	}
+	terminals, err := ScanTerminals(ctx, logger, runPath)
+	if err != nil {
+		return err
+	}
+	ReconcileTerminals(ctx, logger, runPath, terminals)
+	for _, t := range terminals {
+		if t.Status.State == api.Exited {
+			continue
+		}
+		if pkgdiscovery.TerminalName(t) != name {
+			continue
+		}
+		return fmt.Errorf("%w: %q (id %s)", errdefs.ErrTerminalNameInUse, name, pkgdiscovery.TerminalID(t))
+	}
+	return nil
 }
 
 func PrintTerminalSpec(s *api.TerminalSpec, logger *slog.Logger) error {

--- a/internal/discovery/terminals_test.go
+++ b/internal/discovery/terminals_test.go
@@ -1,0 +1,148 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package discovery_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/internal/discovery"
+	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+func writeTerminalDoc(t *testing.T, runPath, id, name string, state api.TerminalStatusMode, pid int) {
+	t.Helper()
+	dir := filepath.Join(runPath, defaults.TerminalsRunPath, id)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	doc := api.TerminalDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindTerminal,
+		Metadata:   api.TerminalMetadata{Name: name},
+		Spec: api.TerminalSpec{
+			ID:      api.ID(id),
+			Name:    name,
+			RunPath: runPath,
+		},
+		Status: api.TerminalStatus{
+			State:           state,
+			Pid:             pid,
+			TerminalRunPath: dir,
+		},
+	}
+	b, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), b, 0o644); err != nil {
+		t.Fatalf("write metadata.json: %v", err)
+	}
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestVerifyTerminalNameAvailable(t *testing.T) {
+	ctx := context.Background()
+	logger := discardLogger()
+	livePid := os.Getpid()
+	// PID 0 is reserved on Unix; isProcessAlive treats it as "unknown / alive",
+	// so a defunct PID like a very high number signals a dead process.
+	const deadPid = 0x7fffffff
+
+	t.Run("empty name is always available", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeTerminalDoc(t, runPath, "id-1", "alpha", api.Ready, livePid)
+		if err := discovery.VerifyTerminalNameAvailable(ctx, logger, runPath, ""); err != nil {
+			t.Fatalf("expected nil for empty name, got: %v", err)
+		}
+	})
+
+	t.Run("empty runPath is always available", func(t *testing.T) {
+		if err := discovery.VerifyTerminalNameAvailable(ctx, logger, "", "alpha"); err != nil {
+			t.Fatalf("expected nil for empty runPath, got: %v", err)
+		}
+	})
+
+	t.Run("no terminals", func(t *testing.T) {
+		runPath := t.TempDir()
+		if err := discovery.VerifyTerminalNameAvailable(ctx, logger, runPath, "alpha"); err != nil {
+			t.Fatalf("expected nil, got: %v", err)
+		}
+	})
+
+	t.Run("active terminal blocks reuse", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeTerminalDoc(t, runPath, "id-1", "alpha", api.Ready, livePid)
+		err := discovery.VerifyTerminalNameAvailable(ctx, logger, runPath, "alpha")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !errors.Is(err, errdefs.ErrTerminalNameInUse) {
+			t.Fatalf("expected ErrTerminalNameInUse, got: %v", err)
+		}
+	})
+
+	t.Run("active terminal does not block a different name", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeTerminalDoc(t, runPath, "id-1", "alpha", api.Ready, livePid)
+		if err := discovery.VerifyTerminalNameAvailable(ctx, logger, runPath, "beta"); err != nil {
+			t.Fatalf("expected nil for non-colliding name, got: %v", err)
+		}
+	})
+
+	t.Run("exited terminal allows reuse", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeTerminalDoc(t, runPath, "id-1", "alpha", api.Exited, livePid)
+		if err := discovery.VerifyTerminalNameAvailable(ctx, logger, runPath, "alpha"); err != nil {
+			t.Fatalf("expected nil for exited terminal, got: %v", err)
+		}
+	})
+
+	t.Run("stale active terminal is reconciled to exited and allows reuse", func(t *testing.T) {
+		runPath := t.TempDir()
+		// State says Ready, but the PID is gone — Reconcile should flip it to
+		// Exited under the hood, so the name becomes available.
+		writeTerminalDoc(t, runPath, "id-1", "alpha", api.Ready, deadPid)
+		if err := discovery.VerifyTerminalNameAvailable(ctx, logger, runPath, "alpha"); err != nil {
+			t.Fatalf("expected nil after stale-state reconciliation, got: %v", err)
+		}
+	})
+
+	t.Run("collision picks the active match when an exited terminal shares the name", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeTerminalDoc(t, runPath, "id-old", "alpha", api.Exited, livePid)
+		writeTerminalDoc(t, runPath, "id-new", "alpha", api.Ready, livePid)
+		err := discovery.VerifyTerminalNameAvailable(ctx, logger, runPath, "alpha")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !errors.Is(err, errdefs.ErrTerminalNameInUse) {
+			t.Fatalf("expected ErrTerminalNameInUse, got: %v", err)
+		}
+	})
+}

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -46,6 +46,7 @@ var (
 	ErrAttachNoTerminalSpec     = errors.New("no terminal ID or Name provided for attach")
 	ErrTerminalNotFoundByID     = errors.New("could not find terminal by ID")
 	ErrTerminalNotFoundByName   = errors.New("could not find terminal by Name")
+	ErrTerminalNameInUse        = errors.New("terminal name already in use by an active terminal")
 	ErrTerminalMetadataNotFound = errors.New("no terminal metadata found to attach")
 	ErrNoTerminalSpec           = errors.New("no terminal spec found")
 	ErrConfig                   = errors.New("config error")


### PR DESCRIPTION
## Summary

Spec and document what happens when \`sbsh terminal --name <name>\` (and \`sbsh --terminal-name <name>\`) is invoked with a name already in use by an active terminal: **fail fast** with a clear error rather than silently spawn a shadow. Names from terminals that have exited (or whose owner process is gone, reconciled to \`Exited\` on scan) can be reused.

The check applies symmetrically to all three name-source paths called out in the issue and its comment thread:
- \`--name\` / \`--terminal-name\` flag
- \`sbsh terminal -\` reading the spec from stdin
- \`--file\` JSON spec

Why fail-fast over a numeric suffix: every other tool in the cohort the project takes its CLI cues from (\`docker run --name\`, \`kubectl\` resource names, \`tmux new-session -s\`) rejects the collision. A silent suffix corrupts what the user asked for, breaks scripted re-fetches by name, and leaves \`sb attach <name>\` ambiguous; \`FindTerminalByName\` resolves to first match today, so a shadow terminal would only be addressable by ID.

### Implementation

- New \`errdefs.ErrTerminalNameInUse\`.
- New \`internal/discovery.VerifyTerminalNameAvailable(ctx, logger, runPath, name)\` that scans \`runPath/terminals/*\`, runs the existing \`ReconcileTerminals\` (so PID-gone terminals stuck on a non-Exited state don't block reuse), and returns \`ErrTerminalNameInUse\` on the first active match. Empty name or empty runPath short-circuits to nil — random-name generation in \`BuildTerminalSpec\` runs *before* this check, so by the time we look the spec always has a name.
- Both CLI entry points (\`cmd/sbsh/terminal\` subcommand and the \`sbsh\` root which embeds a terminal in a client) call \`VerifyTerminalNameAvailable\` after the spec is built and before any controller is started. The check uses \`spec.RunPath\` so the JSON-spec / stdin-spec paths get the same treatment as the flag path.
- \`--name\` and \`--terminal-name\` flag descriptions, the \`sbsh terminal\` Long block, and \`docs/site/cli/sbsh.md\` all call out the uniqueness rule. The docs page gets a new "Name uniqueness" subsection that includes the error wording, the exited-name-reuse rule, and the documented best-effort caveat for the racing-launches edge case.

The check is best-effort: two simultaneous launches with the same name can both pass it. Documented explicitly — downstream tools (\`sb attach\` / \`detach\` / \`stop\` \`<name>\`) resolve the duplicate by first match, so the racing loser remains addressable by ID. A truly atomic guarantee would need either a name-keyed directory or a runPath-wide lock, both of which are larger architectural changes outside this issue's scope.

### Test plan

- [x] \`make sbsh-sb\` — \`./sbsh\` and \`./sb\` both ELF executables (verified via \`file\`)
- [x] \`go build ./...\` / \`go vet ./...\` — clean
- [x] \`go test -count=1 -timeout=60s ./internal/discovery/...\` — new \`TestVerifyTerminalNameAvailable\` passes (8 subtests covering empty inputs, no-terminals, active collision, non-colliding name, exited reuse, stale-PID reconciliation, and exited+active mix)
- [x] \`go test -count=1 -timeout=300s -skip Test_HandleEvent_EvCmdExited \$(go list ./... | grep -v '/e2e\$')\` — full unit suite green (skip is the known #138 deadlock currently in flight via PRs #148/#139; matches what CI sees today)
- [x] \`go test -count=1 -tags=integration -timeout=120s ./cmd/sb/get/...\` — green
- [x] \`E2E_BIN_DIR=\$(pwd) go test -count=1 -timeout=600s ./e2e\` — green (2.95s)
- [x] \`cd docs/examples/library-consumer && go build ./... && go vet ./...\` — clean

Closes #114