### PR TITLE
fix(terminalrunner): prune dead writers instead of killing the PTY

### DIFF
--- a/internal/terminal/terminalrunner/connections.go
+++ b/internal/terminal/terminalrunner/connections.go
@@ -25,6 +25,19 @@ import (
 
 func (sr *Exec) cleanupClient(client *ioClient) {
 	sr.logger.Info("client connection handler exiting", "client", client.id)
+
+	// Drop this client's pipe from the fan-out *before* closing the conn so
+	// no further PTY output targets a dying writer. Without this, an abrupt
+	// disconnect (socket EOF, attacher kill, network drop) leaves the dead
+	// pipeOutW in multiOutW; a later broken pipe used to cascade into a
+	// fatal terminal event and reap the child process.
+	sr.ptyPipesMu.RLock()
+	multiOutW := sr.ptyPipes.multiOutW
+	sr.ptyPipesMu.RUnlock()
+	if multiOutW != nil && client.pipeOutW != nil {
+		multiOutW.Remove(client.pipeOutW)
+	}
+
 	if cerr := client.conn.Close(); cerr != nil {
 		sr.logger.Warn("error closing client connection", "err", cerr, "client", client.id)
 	}

--- a/internal/terminal/terminalrunner/terminal.go
+++ b/internal/terminal/terminalrunner/terminal.go
@@ -259,7 +259,10 @@ func (sr *Exec) terminalManagerReader(multiOutW io.Writer) {
 				sr.logger.Debug("writing to multiOutW")
 				_, errWrite := multiOutW.Write(buf[:n])
 				sr.logger.Debug("writing to multiOutW done")
-				if errWrite != nil {
+				// Only escalate when every fan-out endpoint has gone away —
+				// the log file alone keeps the session usable, and a single
+				// dropped attacher must not kill the PTY.
+				if errors.Is(errWrite, ErrAllWritersFailed) {
 					sr.logger.Error("error writing raw data to client", "err", errWrite)
 					errReturn := fmt.Errorf(
 						"terminalManagerReader multiWriter write error: %w: %w",

--- a/internal/terminal/terminalrunner/terminal_multiwriter.go
+++ b/internal/terminal/terminalrunner/terminal_multiwriter.go
@@ -17,10 +17,17 @@
 package terminalrunner
 
 import (
+	"errors"
 	"io"
 	"log/slog"
 	"sync"
 )
+
+// ErrAllWritersFailed is returned by DynamicMultiWriter.Write when every writer
+// in the snapshot returned an error. Callers may use this to detect the
+// terminal-fatal case (no remaining sinks) versus the routine case of a single
+// stale fan-out endpoint that has just been pruned.
+var ErrAllWritersFailed = errors.New("all writers failed")
 
 type DynamicMultiWriter struct {
 	mu      sync.RWMutex
@@ -35,6 +42,10 @@ func NewDynamicMultiWriter(logger *slog.Logger, writers ...io.Writer) *DynamicMu
 	return &DynamicMultiWriter{writers: writers, logger: logger}
 }
 
+// Write fans p out to every registered writer. A writer that returns an error
+// is dropped from the slice and writing continues to the rest — one stale
+// client must not be able to tear down the producer. Write returns
+// ErrAllWritersFailed only when no writer accepted the payload.
 func (dmw *DynamicMultiWriter) Write(p []byte) (int, error) {
 	dmw.logger.Debug("acquiring read lock for writers")
 	dmw.mu.RLock()
@@ -42,21 +53,37 @@ func (dmw *DynamicMultiWriter) Write(p []byte) (int, error) {
 	dmw.mu.RUnlock()
 	dmw.logger.Debug("read lock released, writers snapshot taken", "writers_count", len(ws), "write_len", len(p))
 
+	var failed []io.Writer
 	for i, w := range ws {
 		dmw.logger.Debug("writing to writer", "index", i, "write_len", len(p))
 		n, err := w.Write(p)
 		if err != nil {
-			dmw.logger.Error("write to writer failed", "index", i, "error", err)
-			return 0, err
+			dmw.logger.Error("write to writer failed; dropping writer", "index", i, "error", err)
+			failed = append(failed, w)
+			continue
 		}
 		if n != len(p) {
 			dmw.logger.Warn("partial write to writer", "index", i, "expected", len(p), "actual", n)
-			// continue to next writer, but still return full len(p) if all succeed
 		} else {
 			dmw.logger.Debug("write to writer succeeded", "index", i, "bytes_written", n)
 		}
 	}
-	dmw.logger.Info("write completed for all writers", "writers_count", len(ws), "bytes", len(p))
+
+	for _, w := range failed {
+		dmw.Remove(w)
+	}
+
+	if len(ws) > 0 && len(failed) == len(ws) {
+		dmw.logger.Error("all writers failed", "writers_count", len(ws), "bytes", len(p))
+		return 0, ErrAllWritersFailed
+	}
+
+	dmw.logger.Info(
+		"write completed for all writers",
+		"writers_count", len(ws),
+		"failed", len(failed),
+		"bytes", len(p),
+	)
 	return len(p), nil
 }
 

--- a/internal/terminal/terminalrunner/terminal_multiwriter_test.go
+++ b/internal/terminal/terminalrunner/terminal_multiwriter_test.go
@@ -1,0 +1,139 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrunner
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+)
+
+type errWriter struct {
+	err error
+}
+
+func (e *errWriter) Write(_ []byte) (int, error) {
+	return 0, e.err
+}
+
+func TestDynamicMultiWriter_DropsFailingWriterAndContinues(t *testing.T) {
+	good := &bytes.Buffer{}
+	bad := &errWriter{err: errors.New("broken pipe")}
+	other := &bytes.Buffer{}
+
+	dmw := NewDynamicMultiWriter(nil, good, bad, other)
+
+	n, err := dmw.Write([]byte("hello"))
+	if err != nil {
+		t.Fatalf("Write returned error with healthy writers present: %v", err)
+	}
+	if n != len("hello") {
+		t.Fatalf("Write returned n=%d, want %d", n, len("hello"))
+	}
+
+	if got := good.String(); got != "hello" {
+		t.Errorf("good writer got %q, want %q", got, "hello")
+	}
+	if got := other.String(); got != "hello" {
+		t.Errorf("other writer got %q, want %q", got, "hello")
+	}
+
+	dmw.mu.RLock()
+	count := len(dmw.writers)
+	hasBad := false
+	for _, w := range dmw.writers {
+		if w == bad {
+			hasBad = true
+			break
+		}
+	}
+	dmw.mu.RUnlock()
+	if count != 2 {
+		t.Errorf("after write, writer count = %d, want 2 (failing writer should be dropped)", count)
+	}
+	if hasBad {
+		t.Errorf("failing writer was not dropped from the slice")
+	}
+
+	good.Reset()
+	other.Reset()
+	if _, errAgain := dmw.Write([]byte("again")); errAgain != nil {
+		t.Fatalf("second Write returned error: %v", errAgain)
+	}
+	if got := good.String(); got != "again" {
+		t.Errorf("good writer second write got %q, want %q", got, "again")
+	}
+	if got := other.String(); got != "again" {
+		t.Errorf("other writer second write got %q, want %q", got, "again")
+	}
+}
+
+func TestDynamicMultiWriter_AllFailingReturnsErr(t *testing.T) {
+	bad1 := &errWriter{err: errors.New("dead 1")}
+	bad2 := &errWriter{err: errors.New("dead 2")}
+
+	dmw := NewDynamicMultiWriter(nil, bad1, bad2)
+
+	_, err := dmw.Write([]byte("x"))
+	if !errors.Is(err, ErrAllWritersFailed) {
+		t.Fatalf("Write err = %v, want ErrAllWritersFailed", err)
+	}
+
+	dmw.mu.RLock()
+	count := len(dmw.writers)
+	dmw.mu.RUnlock()
+	if count != 0 {
+		t.Errorf("after all-failed write, writer count = %d, want 0", count)
+	}
+}
+
+func TestDynamicMultiWriter_NoWritersReturnsNil(t *testing.T) {
+	dmw := NewDynamicMultiWriter(nil)
+	n, err := dmw.Write([]byte("noop"))
+	if err != nil {
+		t.Fatalf("Write on empty multiwriter returned err: %v", err)
+	}
+	if n != len("noop") {
+		t.Fatalf("Write returned n=%d, want %d", n, len("noop"))
+	}
+}
+
+func TestDynamicMultiWriter_RemoveAfterFailureIsNoop(t *testing.T) {
+	good := &bytes.Buffer{}
+	bad := &errWriter{err: errors.New("dead")}
+	dmw := NewDynamicMultiWriter(nil, good, bad)
+
+	if _, err := dmw.Write([]byte("a")); err != nil {
+		t.Fatalf("Write returned err: %v", err)
+	}
+
+	// bad has already been auto-removed; an explicit Remove must not panic
+	// or wedge the slice. The Remove logger emits a warning but the call
+	// returns normally.
+	dmw.Remove(bad)
+
+	dmw.mu.RLock()
+	count := len(dmw.writers)
+	dmw.mu.RUnlock()
+	if count != 1 {
+		t.Errorf("writer count after redundant Remove = %d, want 1", count)
+	}
+}
+
+// Sanity: io.Writer still satisfied.
+var _ io.Writer = (*DynamicMultiWriter)(nil)


### PR DESCRIPTION
## Summary

- An ungracefully-disconnected client used to leave its `pipeOutW` in `DynamicMultiWriter`; the next broken-pipe error there cascaded into a fatal `EvError` and killed the PTY along with the user's child process.
- `cleanupClient` now removes the client's writer from `multiOutW` before closing the conn — mirroring what the explicit `Detach()` path already did.
- `DynamicMultiWriter.Write` now drops a failing writer from the slice and continues; only when **every** writer has failed does it return the new `ErrAllWritersFailed`. A single dead fan-out endpoint can no longer take down the producer.
- `terminalManagerReader` only escalates to `EvError` on `ErrAllWritersFailed` — the log file alone keeps the session usable while attachers come and go.

Closes #183.

## Test plan

- [x] `make sbsh-sb` (verified `file ./sbsh` is `ELF 64-bit LSB executable`)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/terminal/terminalrunner/...` — green, including four new `TestDynamicMultiWriter_*` cases (drop-and-continue, all-fail returns `ErrAllWritersFailed`, empty multiwriter, redundant Remove is a no-op).
- [x] `make test` — full project suite passes.
- [ ] `make test-race` — `internal/terminal` `Test_HandleEvent_EvCmdExited` deadlocks at `controller.go:264`. **Reproduces on `origin/main` with the exact CI command (`go test -timeout=5m $(go list ./... | grep -v '/e2e$')`)** — pre-existing race in `Controller.Close` (sends to `closingCh` / `closeReqCh` after `cancel()`, with the goroutine that reads `closingCh` not yet having flipped `shuttingDown`). Filing separately.

## Notes for reviewer

- New exported symbol: `ErrAllWritersFailed`. Callers outside `terminalrunner` can detect the terminal-fatal case with `errors.Is`. The only in-tree caller updated here is `terminalManagerReader`.
- Per-write success log now includes a `failed=N` field so it's obvious in the log when a writer was just pruned.
- I considered closing `client.pipeOutR/pipeOutW` in `cleanupClient` to fully release the FDs, but `Detach()` doesn't close them either, and doing so would expand scope beyond the issue's acceptance criteria. Worth a follow-up if FD leaks become measurable.