### PR TITLE
fix: atomic shutdown gate in Controller.Close prevents deadlock

### DIFF
--- a/internal/client/controller.go
+++ b/internal/client/controller.go
@@ -92,7 +92,7 @@ func NewClientControllerWithIO(
 		// that bailed on ctx.Done would pin StartServer forever on its send.
 		rpcReadyCh: make(chan error, 1),
 		rpcDoneCh:  make(chan error),
-		closeReqCh:  make(chan error, 1),
+		closeReqCh: make(chan error, 1),
 		//nolint:mnd // event channel buffer size
 		eventsCh: make(chan clientrunner.Event, 32),
 		NewClientRunner: func(ctx context.Context, logger *slog.Logger, doc *api.ClientDoc, evCh chan<- clientrunner.Event) clientrunner.ClientRunner {
@@ -259,15 +259,21 @@ func (s *Controller) Run(doc *api.ClientDoc) error {
 	s.logger.Info("controller ready, entering main event loop")
 	close(s.ctrlReadyCh)
 
-	go func() {
-		errC := <-s.closingCh
-		s.shuttingDown.Store(true)
-		s.logger.Warn("controller closing", "reason", errC)
-	}()
-
 	for {
 		select {
 		case <-s.ctx.Done():
+			// See matching comment in internal/terminal/controller.go: prefer
+			// the close-request signal when it is already queued so the exit
+			// error carries the original reason rather than "context canceled".
+			select {
+			case errClose := <-s.closeReqCh:
+				s.logger.Warn("close request received", "error", errClose)
+				if errClose == nil {
+					return nil
+				}
+				return fmt.Errorf("%w: %w", errdefs.ErrCloseReq, errClose)
+			default:
+			}
 			ctxErr := s.ctx.Err()
 			s.logger.Warn("parent context canceled, shutting down controller")
 			if errC := s.Close(ctxErr); errC != nil {
@@ -412,22 +418,26 @@ func (s *Controller) onClosed(_ api.ID, err error) {
 }
 
 func (s *Controller) Close(reason error) error {
-	if !s.shuttingDown.Load() {
-		s.logger.Info("initiating shutdown sequence", "reason", reason)
-		// Set closing reason
-		s.closingCh <- reason
-
-		// Notify terminal runner to close all terminals
-		_ = s.sr.Close(reason)
-
-		// Notify Run to exit
-		s.closeReqCh <- reason
-
-		// Mark controller as closed
-		close(s.closedCh)
-	} else {
+	// CompareAndSwap fuses the shutting-down check with the flip so that
+	// concurrent Close callers cannot both enter the body and re-send on the
+	// one-shot closeReqCh / closingCh — see the matching fix in
+	// internal/terminal/controller.go.
+	if !s.shuttingDown.CompareAndSwap(false, true) {
 		s.logger.Info("shutdown sequence already in progress, ignoring duplicate request", "reason", reason)
+		return nil
 	}
+	s.logger.Info("initiating shutdown sequence", "reason", reason)
+	// Set closing reason
+	s.closingCh <- reason
+
+	// Notify terminal runner to close all terminals
+	_ = s.sr.Close(reason)
+
+	// Notify Run to exit
+	s.closeReqCh <- reason
+
+	// Mark controller as closed
+	close(s.closedCh)
 	return nil
 }
 

--- a/internal/terminal/controller.go
+++ b/internal/terminal/controller.go
@@ -182,15 +182,19 @@ func (c *Controller) Run(spec *api.TerminalSpec) error {
 	c.logger.InfoContext(c.ctx, "controller ready")
 	close(c.ctrlReadyCh)
 
-	go func() {
-		err := <-c.closingCh
-		c.shuttingDown.Store(true)
-		c.logger.WarnContext(c.ctx, "controller closing", "reason", err)
-	}()
-
 	for {
 		select {
 		case <-c.ctx.Done():
+			// Close cancels c.ctx to unblock WaitReady, so ctx.Done can race
+			// closeReqCh after our own Close fires. When the close-request
+			// signal is already queued, prefer it: it carries the original
+			// reason instead of a generic "context canceled".
+			select {
+			case reason := <-c.closeReqCh:
+				c.logger.WarnContext(c.ctx, "close request received", "err", reason)
+				return fmt.Errorf("%w: %w", errdefs.ErrCloseReq, reason)
+			default:
+			}
 			ctxErr := c.ctx.Err()
 			c.logger.WarnContext(c.ctx, "parent context channel has been closed")
 			if errC := c.Close(ctxErr); errC != nil {
@@ -243,31 +247,40 @@ func (c *Controller) handleEvent(ev terminalrunner.Event) {
 }
 
 func (c *Controller) Close(reason error) error {
-	if !c.shuttingDown.Load() {
-		c.logger.InfoContext(c.ctx, "initiating shutdown sequence", "reason", reason)
-
-		// cancel the controller context so WaitReady unblocks
-		c.cancel(reason)
-
-		// Set closing reason
-		c.closingCh <- reason
-
-		// Notify terminal runner to close all terminals
-		c.srMu.RLock()
-		sr := c.sr
-		c.srMu.RUnlock()
-		if sr != nil {
-			_ = sr.Close(reason)
-		}
-
-		// Notify Run to exit
-		c.closeReqCh <- reason
-
-		// Mark controller as closed
-		close(c.closedCh)
-	} else {
-		c.logger.WarnContext(c.ctx, "shutdown sequence already in progress, ignoring duplicate request", "reason", reason)
+	// CompareAndSwap fuses the shutting-down check with the flip so that
+	// concurrent Close callers (e.g., handleEvent path racing the Run loop's
+	// ctx.Done branch) cannot both enter the body and re-send on the
+	// one-shot closeReqCh / closingCh, which previously deadlocked Run.
+	if !c.shuttingDown.CompareAndSwap(false, true) {
+		c.logger.WarnContext(
+			c.ctx,
+			"shutdown sequence already in progress, ignoring duplicate request",
+			"reason",
+			reason,
+		)
+		return nil
 	}
+	c.logger.InfoContext(c.ctx, "initiating shutdown sequence", "reason", reason)
+
+	// cancel the controller context so WaitReady unblocks
+	c.cancel(reason)
+
+	// Set closing reason
+	c.closingCh <- reason
+
+	// Notify terminal runner to close all terminals
+	c.srMu.RLock()
+	sr := c.sr
+	c.srMu.RUnlock()
+	if sr != nil {
+		_ = sr.Close(reason)
+	}
+
+	// Notify Run to exit
+	c.closeReqCh <- reason
+
+	// Mark controller as closed
+	close(c.closedCh)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- `Controller.Close` in `internal/terminal/controller.go` and `internal/client/controller.go` gated its body on `shuttingDown.Load()`, but the flag was flipped in a separate goroutine that read `closingCh`. Two concurrent `Close` callers (typically `handleEvent → onClosed` racing the `Run` loop's `ctx.Done` branch) could both enter the body before the watcher set the flag, blow through the cap-1 sends to `closingCh` / `closeReqCh`, and pin `Run` forever — see issue #138 for the full goroutine trace.
- Replace the `Load`-guarded entry with `shuttingDown.CompareAndSwap(false, true)` so the flag flip is fused atomically with the act it gates: only the first caller proceeds, every subsequent caller short-circuits before any channel send. The `closingCh`-reader goroutine is removed (its only job was setting the flag).
- After the gate fix, `Close` cancels `ctx` (to unblock `WaitReady`) before sending on `closeReqCh`, so `Run` can wake on either signal. To keep the canonical close-request exit path (and surface the original reason instead of a generic `"context canceled"`), the `ctx.Done` branch in `Run` now drains `closeReqCh` non-blockingly first; falls through to the existing `ErrContextDone` path when the parent really was the canceller.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -timeout=60s -run '^Test_HandleEvent_EvCmdExited$' -v ./internal/terminal/` — previously deadlocked, now passes deterministically
- [x] `go test -race -count=100 -timeout=120s -run '^Test_HandleEvent_EvCmdExited$' ./internal/terminal/` — 100/100 race-clean
- [x] `go test -race -timeout=120s ./internal/terminal/... ./internal/client/...`
- [x] `make sbsh-sb` produced ELF executables (`file ./sbsh ./sb` confirms `ELF 64-bit LSB executable`)
- [x] `make test` (unit + integration + e2e)
- [x] `make test-race`

Closes #138