### PR TITLE
fix(terminal): configurable control-socket mode and gid

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -160,6 +160,10 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SBSH_ROOT_TERM_SOCKET = DefineKV("SBSH_ROOT_TERM_SOCKET", "sbsh.root.terminal.socket")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SBSH_ROOT_TERM_SOCKET_MODE = DefineKV("SBSH_ROOT_TERM_SOCKET_MODE", "sbsh.root.terminal.socketMode")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SBSH_ROOT_TERM_SOCKET_GID = DefineKV("SBSH_ROOT_TERM_SOCKET_GID", "sbsh.root.terminal.socketGid")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SBSH_ROOT_TERM_DISABLE_SET_PROMPT = DefineKV(
 		"SBSH_ROOT_TERM_DISABLE_SET_PROMPT",
 		"sbsh.root.terminal.disableSetPrompt",
@@ -184,6 +188,10 @@ var (
 
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SBSH_TERM_SOCKET = DefineKV("SBSH_TERM_SOCKET", "sbsh.terminal.socket")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SBSH_TERM_SOCKET_MODE = DefineKV("SBSH_TERM_SOCKET_MODE", "sbsh.terminal.socketMode")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SBSH_TERM_SOCKET_GID = DefineKV("SBSH_TERM_SOCKET_GID", "sbsh.terminal.socketGid")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SBSH_TERM_ID = DefineKV("SBSH_TERM_ID", "sbsh.terminal.id")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/sbsh/sbsh.go
+++ b/cmd/sbsh/sbsh.go
@@ -26,6 +26,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -165,6 +166,8 @@ You can also use sbsh with parameters. For example:
 					LogFile:          viper.GetString(config.SBSH_ROOT_TERM_LOG_FILE.ViperKey),
 					LogLevel:         viper.GetString(config.SBSH_ROOT_TERM_LOG_LEVEL.ViperKey),
 					SocketFile:       viper.GetString(config.SBSH_ROOT_TERM_SOCKET.ViperKey),
+					SocketMode:       viper.GetString(config.SBSH_ROOT_TERM_SOCKET_MODE.ViperKey),
+					SocketGID:        readRootSocketGID(cmd),
 					DisableSetPrompt: viper.GetBool(config.SBSH_ROOT_TERM_DISABLE_SET_PROMPT.ViperKey),
 				},
 			)
@@ -349,6 +352,30 @@ func setTerminalFlags(rootCmd *cobra.Command) error {
 		return err
 	}
 
+	rootCmd.Flags().String(
+		"terminal-socket-mode",
+		"",
+		"Octal mode applied to the control socket after Listen (default 0600)",
+	)
+	if err := viper.BindPFlag(config.SBSH_ROOT_TERM_SOCKET_MODE.ViperKey, rootCmd.Flags().Lookup("terminal-socket-mode")); err != nil {
+		return err
+	}
+	if err := viper.BindEnv(config.SBSH_ROOT_TERM_SOCKET_MODE.ViperKey, config.SBSH_ROOT_TERM_SOCKET_MODE.EnvVar()); err != nil {
+		return err
+	}
+
+	rootCmd.Flags().Int(
+		"terminal-socket-gid",
+		-1,
+		"Numeric GID applied to the control socket via chown after Listen; -1 leaves group unchanged",
+	)
+	if err := viper.BindPFlag(config.SBSH_ROOT_TERM_SOCKET_GID.ViperKey, rootCmd.Flags().Lookup("terminal-socket-gid")); err != nil {
+		return err
+	}
+	if err := viper.BindEnv(config.SBSH_ROOT_TERM_SOCKET_GID.ViperKey, config.SBSH_ROOT_TERM_SOCKET_GID.EnvVar()); err != nil {
+		return err
+	}
+
 	rootCmd.Flags().Bool("terminal-disable-set-prompt", false, "Disable setting the prompt")
 	if err := viper.BindPFlag(config.SBSH_ROOT_TERM_DISABLE_SET_PROMPT.ViperKey, rootCmd.Flags().Lookup("terminal-disable-set-prompt")); err != nil {
 		return err
@@ -439,6 +466,25 @@ func runClient(
 			}
 			logger.ErrorContext(ctx, "client controller exited with error", "error", err)
 			return err
+		}
+	}
+	return nil
+}
+
+// readRootSocketGID resolves --terminal-socket-gid: explicit flag wins,
+// then SBSH_ROOT_TERM_SOCKET_GID env, otherwise nil (= leave group
+// unchanged). The pointer return distinguishes "unset" from "explicit
+// 0 = root", which is required because the runner would otherwise try
+// to chown to gid 0 and fail under non-root callers.
+func readRootSocketGID(cmd *cobra.Command) *int {
+	if cmd.Flags().Changed("terminal-socket-gid") {
+		if v, err := cmd.Flags().GetInt("terminal-socket-gid"); err == nil {
+			return &v
+		}
+	}
+	if envStr, ok := os.LookupEnv(config.SBSH_ROOT_TERM_SOCKET_GID.EnvVar()); ok && envStr != "" {
+		if v, err := strconv.Atoi(envStr); err == nil {
+			return &v
 		}
 	}
 	return nil

--- a/cmd/sbsh/terminal/terminal.go
+++ b/cmd/sbsh/terminal/terminal.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"syscall"
 
 	"github.com/eminwux/sbsh/cmd/config"
@@ -89,6 +90,26 @@ func checkFileUsage(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
+// readSocketGID resolves the socket-gid value: flag (if explicitly set) >
+// env var > nil (unset). Returning *int rather than a sentinel int keeps
+// "unset" distinguishable from "explicit 0 = root", which the runner
+// would otherwise try to chown to and reject under non-root callers.
+// viper.GetInt is unreliable here because BindPFlag only forwards a
+// *changed* pflag to viper.
+func readSocketGID(cmd *cobra.Command) *int {
+	if cmd.Flags().Changed("socket-gid") {
+		if v, err := cmd.Flags().GetInt("socket-gid"); err == nil {
+			return &v
+		}
+	}
+	if envStr, ok := os.LookupEnv(config.SBSH_TERM_SOCKET_GID.EnvVar()); ok && envStr != "" {
+		if v, err := strconv.Atoi(envStr); err == nil {
+			return &v
+		}
+	}
+	return nil
+}
+
 func buildTerminalSpecFromFlags(
 	cmd *cobra.Command,
 	logger *slog.Logger,
@@ -118,6 +139,8 @@ func buildTerminalSpecFromFlags(
 			LogFile:          viper.GetString(config.SBSH_TERM_LOG_FILE.ViperKey),
 			LogLevel:         viper.GetString(config.SBSH_TERM_LOG_LEVEL.ViperKey),
 			SocketFile:       viper.GetString(config.SBSH_TERM_SOCKET.ViperKey),
+			SocketMode:       viper.GetString(config.SBSH_TERM_SOCKET_MODE.ViperKey),
+			SocketGID:        readSocketGID(cmd),
 			DisableSetPrompt: viper.GetBool(config.SBSH_TERM_DISABLE_SET_PROMPT.ViperKey),
 			ShutdownGrace:    viper.GetDuration(config.SBSH_TERM_SHUTDOWN_GRACE.ViperKey),
 		},
@@ -413,6 +436,22 @@ func setupTerminalCmdFlags(terminalCmd *cobra.Command) {
 
 	terminalCmd.Flags().String("socket", "", "Optional socket file for the terminal")
 	_ = viper.BindPFlag(config.SBSH_TERM_SOCKET.ViperKey, terminalCmd.Flags().Lookup("socket"))
+
+	terminalCmd.Flags().String(
+		"socket-mode",
+		"",
+		"Octal mode applied to the control socket after Listen (default 0600)",
+	)
+	_ = viper.BindPFlag(config.SBSH_TERM_SOCKET_MODE.ViperKey, terminalCmd.Flags().Lookup("socket-mode"))
+	_ = viper.BindEnv(config.SBSH_TERM_SOCKET_MODE.ViperKey, config.SBSH_TERM_SOCKET_MODE.EnvVar())
+
+	terminalCmd.Flags().Int(
+		"socket-gid",
+		-1,
+		"Numeric GID applied to the control socket via chown after Listen; -1 leaves group unchanged",
+	)
+	_ = viper.BindPFlag(config.SBSH_TERM_SOCKET_GID.ViperKey, terminalCmd.Flags().Lookup("socket-gid"))
+	_ = viper.BindEnv(config.SBSH_TERM_SOCKET_GID.ViperKey, config.SBSH_TERM_SOCKET_GID.EnvVar())
 
 	terminalCmd.Flags().StringP("file", "f", "", "Optional JSON file with the terminal spec (use '-' for stdin)")
 	_ = viper.BindPFlag(config.SBSH_TERM_SPEC.ViperKey, terminalCmd.Flags().Lookup("file"))

--- a/docs/profiles/README.md
+++ b/docs/profiles/README.md
@@ -82,6 +82,9 @@ spec:
       - script: echo "Starting..."
     postAttach: # Run after attaching
       - script: echo "Attached!"
+  socket: # Control-socket permissions (optional)
+    mode: "0660" # Octal string; defaults to 0600 if omitted
+    gid: 986 # Numeric host GID; omit to leave the group unchanged
 ```
 
 ## Field Reference
@@ -189,6 +192,49 @@ Lifecycle hooks that run at specific points in the terminal lifecycle.
     - script: kubectl get pods
     - script: git status
   ```
+
+#### `socket` section (optional)
+
+Configures the filesystem permissions of the terminal's control socket — the
+Unix domain socket that `sbsh attach` (and any other client) connects to.
+Both fields are optional; omitting the block keeps the legacy owner-only
+behavior (`srw------- listener-uid:listener-gid`), which is the right default
+when no other uid needs to attach.
+
+```yaml
+spec:
+  # ...
+  socket:
+    mode: "0660" # Octal string; defaults to "0600" if omitted
+    gid: 986 # Numeric host GID; omit to leave group unchanged
+```
+
+**`mode`** (optional, default `"0600"`)
+
+- Octal string applied via `chmod` after `Listen()`
+- Quote it (`"0660"`) so YAML does not silently re-parse octal as decimal
+- The leading `0` is optional — both `"0660"` and `"660"` work
+- Mode bits outside `0o7777` are rejected at profile load
+
+**`gid`** (optional, default unset)
+
+- Numeric host GID applied via `chown(socket, -1, gid)` after `Listen()`
+- The listener's uid stays the owner; only the group is rewritten
+- Omit the field (or leave it `null`) to leave the socket's group at the
+  listener's primary group
+
+The same configuration can also be supplied at launch time and overrides the
+profile when set. The root command and the `terminal` subcommand each take
+their own flag:
+
+- `sbsh --terminal-socket-mode 0660 --terminal-socket-gid 986`
+  (or `SBSH_ROOT_TERM_SOCKET_MODE=0660` / `SBSH_ROOT_TERM_SOCKET_GID=986`)
+- `sbsh terminal --socket-mode 0660 --socket-gid 986`
+  (or `SBSH_TERM_SOCKET_MODE=0660` / `SBSH_TERM_SOCKET_GID=986`)
+
+Widening the mode and setting a host group is opt-in for callers that share a
+terminal across uids in the same group; the default (no `socket` block, no
+flag) preserves owner-only access exactly as in earlier releases.
 
 ## Example Profiles
 

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -113,6 +113,13 @@ func CreateTerminalFromProfile(profile *api.TerminalProfileDoc) (*api.TerminalSp
 		}
 		if profile.Spec.Socket.GID != nil {
 			g := *profile.Spec.Socket.GID
+			if g < 0 {
+				return nil, fmt.Errorf(
+					"invalid spec.socket.gid in profile %q: must be non-negative, got %d",
+					profile.Metadata.Name,
+					g,
+				)
+			}
 			spec.SocketGID = &g
 		}
 	}

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -21,8 +21,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/eminwux/sbsh/internal/defaults"
@@ -97,7 +99,43 @@ func CreateTerminalFromProfile(profile *api.TerminalProfileDoc) (*api.TerminalSp
 		Stages:      profile.Spec.Stages,
 	}
 
+	if profile.Spec.Socket != nil {
+		if profile.Spec.Socket.Mode != "" {
+			mode, errMode := parseSocketMode(profile.Spec.Socket.Mode)
+			if errMode != nil {
+				return nil, fmt.Errorf(
+					"invalid spec.socket.mode in profile %q: %w",
+					profile.Metadata.Name,
+					errMode,
+				)
+			}
+			spec.SocketMode = mode
+		}
+		if profile.Spec.Socket.GID != nil {
+			g := *profile.Spec.Socket.GID
+			spec.SocketGID = &g
+		}
+	}
+
 	return spec, nil
+}
+
+// chmodMask is the standard chmod surface: setuid/setgid/sticky plus the nine
+// rwx bits. parseSocketMode rejects any mode with bits outside this mask.
+const chmodMask uint64 = 0o7777
+
+// parseSocketMode parses an octal mode string like "0660" or "660" into an
+// os.FileMode and rejects modes with bits outside chmodMask. The leading "0"
+// is optional because strconv.ParseUint with base 8 accepts both forms.
+func parseSocketMode(s string) (os.FileMode, error) {
+	n, err := strconv.ParseUint(s, 8, 32)
+	if err != nil {
+		return 0, fmt.Errorf("not an octal mode: %w", err)
+	}
+	if n & ^chmodMask != 0 {
+		return 0, fmt.Errorf("mode bits outside 0o%o: 0o%o", chmodMask, n)
+	}
+	return os.FileMode(n), nil
 }
 
 func copyStringMap(in map[string]string) map[string]string {
@@ -112,18 +150,26 @@ func copyStringMap(in map[string]string) map[string]string {
 }
 
 type BuildTerminalSpecParams struct {
-	TerminalID       string
-	TerminalName     string
-	TerminalCmd      string
-	TerminalCmdArgs  []string
-	Cwd              string
-	CaptureFile      string
-	RunPath          string
-	ProfilesDir      string
-	ProfileName      string
-	LogFile          string
-	LogLevel         string
-	SocketFile       string
+	TerminalID      string
+	TerminalName    string
+	TerminalCmd     string
+	TerminalCmdArgs []string
+	Cwd             string
+	CaptureFile     string
+	RunPath         string
+	ProfilesDir     string
+	ProfileName     string
+	LogFile         string
+	LogLevel        string
+	SocketFile      string
+	// SocketMode is the raw octal flag value (e.g. "0660"). Empty means
+	// "no override; fall through to the profile or the runner default".
+	SocketMode string
+	// SocketGID is the numeric GID flag value, or nil to fall through to
+	// the profile / leave the group unchanged. A nil pointer is required
+	// because a zero int is a valid GID (root), so we can't conflate it
+	// with "unset".
+	SocketGID        *int
 	EnvVars          []string
 	DisableSetPrompt bool
 	ShutdownGrace    time.Duration
@@ -250,8 +296,31 @@ func BuildTerminalSpec(
 		return nil, errCreate
 	}
 	addInputValuesToTerminal(terminalSpec, input)
+	if errSocket := applySocketOverrides(terminalSpec, input); errSocket != nil {
+		return nil, errSocket
+	}
 
 	return terminalSpec, nil
+}
+
+// applySocketOverrides resolves the socket mode/gid precedence: explicit
+// flag/env values win over the profile's spec.socket; unset stays at
+// whatever CreateTerminalFromProfile produced (which is the profile value
+// or the zero value, the latter telling the runner to use 0o600 with no
+// chown).
+func applySocketOverrides(spec *api.TerminalSpec, input *BuildTerminalSpecParams) error {
+	if input.SocketMode != "" {
+		mode, err := parseSocketMode(input.SocketMode)
+		if err != nil {
+			return fmt.Errorf("%w: invalid socket mode %q: %w", errdefs.ErrInvalidFlag, input.SocketMode, err)
+		}
+		spec.SocketMode = mode
+	}
+	if input.SocketGID != nil {
+		g := *input.SocketGID
+		spec.SocketGID = &g
+	}
+	return nil
 }
 
 // addInputValuesToTerminal mutates terminalSpec by overriding its fields with non-empty values from input.

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"os"
 	"testing"
 
 	"github.com/eminwux/sbsh/internal/errdefs"
@@ -32,5 +33,43 @@ func TestBuildTerminalSpec_EmptyRunPath_ReturnsErrRunPathRequired(t *testing.T) 
 	_, err := BuildTerminalSpec(context.Background(), logger, &BuildTerminalSpecParams{})
 	if !errors.Is(err, errdefs.ErrRunPathRequired) {
 		t.Fatalf("expected errdefs.ErrRunPathRequired, got %v", err)
+	}
+}
+
+func TestParseSocketMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    os.FileMode
+		wantErr bool
+	}{
+		{name: "leading-zero octal", in: "0660", want: 0o660},
+		{name: "no leading zero", in: "660", want: 0o660},
+		{name: "owner-only", in: "0600", want: 0o600},
+		{name: "world-writable", in: "0666", want: 0o666},
+		{name: "setgid bit", in: "2660", want: 0o2660},
+		{name: "full mask", in: "7777", want: 0o7777},
+		{name: "zero", in: "0", want: 0},
+		{name: "out of mask", in: "10000", wantErr: true},
+		{name: "non-octal digit", in: "0680", wantErr: true},
+		{name: "non-numeric", in: "rw-", wantErr: true},
+		{name: "empty", in: "", wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseSocketMode(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseSocketMode(%q): want error, got mode 0o%o", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseSocketMode(%q): unexpected error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Fatalf("parseSocketMode(%q): want 0o%o, got 0o%o", tc.in, tc.want, got)
+			}
+		})
 	}
 }

--- a/internal/terminal/terminalrunner/sockets.go
+++ b/internal/terminal/terminalrunner/sockets.go
@@ -25,11 +25,27 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// defaultSocketMode is the legacy owner-only mode applied when the spec
+// leaves SocketMode at its zero value. Group/world access is opt-in via
+// the --socket-mode flag, SBSH_TERM_SOCKET_MODE env, or the profile's
+// spec.socket.mode field.
+const defaultSocketMode os.FileMode = 0o600
+
 func (sr *Exec) OpenSocketCtrl() error {
 	sr.metadataMu.Lock()
 	socketFile := sr.metadata.Spec.SocketFile
+	socketMode := sr.metadata.Spec.SocketMode
+	var socketGID *int
+	if g := sr.metadata.Spec.SocketGID; g != nil {
+		gv := *g
+		socketGID = &gv
+	}
 	sr.metadata.Status.SocketFile = socketFile
 	sr.metadataMu.Unlock()
+
+	if socketMode == 0 {
+		socketMode = defaultSocketMode
+	}
 
 	sr.logger.Debug("OpenSocketCtrl: preparing to listen", "socket", socketFile)
 	errMetadata := sr.updateMetadata()
@@ -60,16 +76,37 @@ func (sr *Exec) OpenSocketCtrl() error {
 	// keep references for Close()
 	sr.lnCtrl = ctrlLn
 
-	if errChmod := os.Chmod(socketFile, 0o600); errChmod != nil {
+	if errChmod := os.Chmod(socketFile, socketMode); errChmod != nil {
 		sr.logger.Error(
 			"OpenSocketCtrl: failed to chmod socket file",
 			"socket",
 			socketFile,
+			"mode",
+			fmt.Sprintf("0o%o", socketMode),
 			"error",
 			errChmod,
 		)
 		_ = ctrlLn.Close()
 		return errChmod
+	}
+
+	if socketGID != nil {
+		// Chown(-1, gid) keeps the listener's uid as owner and only
+		// rewrites the group, so the inode permits group-mode access
+		// without changing the controlling identity.
+		if errChown := os.Chown(socketFile, -1, *socketGID); errChown != nil {
+			sr.logger.Error(
+				"OpenSocketCtrl: failed to chown socket file",
+				"socket",
+				socketFile,
+				"gid",
+				*socketGID,
+				"error",
+				errChown,
+			)
+			_ = ctrlLn.Close()
+			return errChown
+		}
 	}
 
 	// update metadata with socket file path

--- a/pkg/api/profile.go
+++ b/pkg/api/profile.go
@@ -58,10 +58,20 @@ type TerminalProfileMetadata struct {
 }
 
 type TerminalProfileSpec struct {
-	RunTarget     RunTarget     `json:"runTarget"     yaml:"runTarget"`
-	RestartPolicy RestartPolicy `json:"restartPolicy" yaml:"restartPolicy"`
-	Shell         ShellSpec     `json:"shell"         yaml:"shell"`
-	Stages        StagesSpec    `json:"stages"        yaml:"stages"`
+	RunTarget     RunTarget     `json:"runTarget"        yaml:"runTarget"`
+	RestartPolicy RestartPolicy `json:"restartPolicy"    yaml:"restartPolicy"`
+	Shell         ShellSpec     `json:"shell"            yaml:"shell"`
+	Stages        StagesSpec    `json:"stages"           yaml:"stages"`
+	Socket        *SocketSpec   `json:"socket,omitempty" yaml:"socket,omitempty"`
+}
+
+// SocketSpec configures the control socket's filesystem permissions. Both
+// fields are optional; omitting the block keeps the legacy 0600 owner-only
+// behavior. Mode is an octal string ("0660") to avoid YAML's int/octal
+// ambiguity; Gid is a numeric host GID (nil leaves the group unchanged).
+type SocketSpec struct {
+	Mode string `json:"mode,omitempty" yaml:"mode,omitempty"`
+	GID  *int   `json:"gid,omitempty"  yaml:"gid,omitempty"`
 }
 
 // ShellSpec describes the base interactive process that owns the terminal lifetime.

--- a/pkg/api/terminal.go
+++ b/pkg/api/terminal.go
@@ -16,7 +16,10 @@
 
 package api
 
-import "time"
+import (
+	"os"
+	"time"
+)
 
 type TerminalController interface {
 	Run(spec *TerminalSpec) error
@@ -69,6 +72,14 @@ type TerminalSpec struct {
 	LogFile     string `json:"logFile"`
 	LogLevel    string `json:"logLevel"`
 	SocketFile  string `json:"socketIO"`
+
+	// SocketMode is the chmod applied to the control socket after Listen.
+	// Zero means "use the runner default" (0600), preserving owner-only
+	// behavior for callers that never set the field.
+	SocketMode os.FileMode `json:"socketMode,omitempty"`
+	// SocketGID is the numeric GID applied via chown(socket, -1, gid)
+	// after Listen. nil leaves the group unchanged.
+	SocketGID *int `json:"socketGid,omitempty"`
 
 	ProfileName string     `json:"profileName"`
 	Stages      StagesSpec `json:"stages"`

--- a/pkg/builder/terminal.go
+++ b/pkg/builder/terminal.go
@@ -45,6 +45,8 @@ type terminalConfig struct {
 	logFile          string
 	logLevel         string
 	socketFile       string
+	socketMode       string
+	socketGID        *int
 	profileName      string
 	profilesDir      string
 	disableSetPrompt bool
@@ -141,6 +143,26 @@ func WithSocketFile(path string) TerminalOption {
 	return func(c *terminalConfig) { c.socketFile = path }
 }
 
+// WithSocketMode sets the chmod mode applied to the control
+// socket after Listen, as an octal string ("0660", "660"). Empty
+// means "no override; fall through to the profile or the runner
+// default (0o600)".
+func WithSocketMode(mode string) TerminalOption {
+	return func(c *terminalConfig) { c.socketMode = mode }
+}
+
+// WithSocketGID sets the numeric GID applied via chown to the
+// control socket after Listen. Calling this option means
+// "explicitly set"; the zero value is a valid GID (root) and is
+// preserved. Omitting the option leaves the group unchanged (or
+// falls through to the profile).
+func WithSocketGID(gid int) TerminalOption {
+	return func(c *terminalConfig) {
+		g := gid
+		c.socketGID = &g
+	}
+}
+
 // WithDisableSetPrompt disables sbsh's automatic PS1 injection
 // when true. The default (false) preserves the shell-prompt
 // rewriting behavior.
@@ -188,6 +210,8 @@ func BuildTerminalSpec(
 		LogFile:          cfg.logFile,
 		LogLevel:         cfg.logLevel,
 		SocketFile:       cfg.socketFile,
+		SocketMode:       cfg.socketMode,
+		SocketGID:        cfg.socketGID,
 		EnvVars:          cfg.envVars,
 		DisableSetPrompt: cfg.disableSetPrompt,
 	})


### PR DESCRIPTION
## Summary
- Resolves the kukeon group-attach blocker where the control socket was hard-coded to `0600` and unreachable across uid boundaries.
- Three configuration layers (CLI flags, env vars, profile YAML) for socket mode/gid, all funneled through `BuildTerminalSpecParams` and applied after `Listen` in `OpenSocketCtrl` (chmod always, chown only when gid is set).
- Default behavior preserved: with no flag, no env, no `socket` block, the socket still gets `0600` and the group is left untouched.
- `BuildTerminalSpecParams.SocketGID` is `*int` (not `int`) so that "unset" is distinguishable from "explicit gid 0 = root" — a plain `int` made the zero-value caller path silently chown to root and reject every default-profile launch under non-root.
- `viper.GetInt` is unreliable for negative-default pflags (BindPFlag forwards a *changed* pflag; an unchanged `-1` falls through to viper's int zero value), so the gid is read directly from cobra with an env-var fallback in `readSocketGID` / `readRootSocketGID`.
- The flag pair is exposed at both the root (`sbsh --terminal-socket-mode/--terminal-socket-gid`) and the `terminal` subcommand (`sbsh terminal --socket-mode/--socket-gid`), each backed by its own env var.

## Test plan
- [x] `make sbsh-sb` and `file ./sbsh` confirms an ELF executable
- [x] `go vet ./...`
- [x] `make test` (full CI suite, including `./e2e`) — green
- [x] `TestSbsh_Default` re-run 5×, all green (initial implementation produced 5/5 socket-not-found failures before the `*int` sentinel + viper-bypass fix)
- [x] `./sbsh --help` and `./sbsh terminal --help` show the new flags with `(default -1)` for gid

Closes #188