### PR TITLE
feat(attach): add ErrDetached/ErrPeerClosed sentinels for clean-vs-hangup branching

### DIFF
--- a/internal/client/controller.go
+++ b/internal/client/controller.go
@@ -54,6 +54,14 @@ type Controller struct {
 	closedCh     chan struct{}
 	shuttingDown atomic.Bool
 
+	// detachRequested is set whenever Detach() runs (keystroke event or
+	// external RPC). The dual-copier teardown that follows surfaces as
+	// EvError "read/write routines exited" — indistinguishable from a
+	// peer hangup at that layer. handleEvent reads this flag to decide
+	// whether to tag the close reason as ErrClientDetached or
+	// ErrPeerClosed so pkg/attach can surface the right public sentinel.
+	detachRequested atomic.Bool
+
 	eventsCh chan clientrunner.Event
 
 	rpcReadyCh chan error
@@ -400,7 +408,7 @@ func (s *Controller) handleEvent(ev clientrunner.Event) {
 
 	case clientrunner.EvError:
 		s.logger.ErrorContext(s.ctx, "terminal EvError", "id", ev.ID, "err", ev.Err)
-		s.onClosed(ev.ID, ev.Err)
+		s.onClosed(ev.ID, s.classifySessionEnd(ev.Err))
 	case clientrunner.EvDetach:
 		s.logger.InfoContext(s.ctx, "terminal EvDetach", "id", ev.ID)
 		err := s.Detach()
@@ -450,11 +458,31 @@ func (s *Controller) WaitClose() error {
 }
 
 func (s *Controller) Detach() error {
+	// Mark before issuing the RPC: the terminal's Detach response triggers
+	// an asynchronous IO conn close, and the resulting EvError must be
+	// classified as a clean detach even when the runner returns an error
+	// from the RPC itself.
+	s.detachRequested.Store(true)
 	// Request detach from terminal
 	if err := s.sr.Detach(); err != nil {
 		return fmt.Errorf("%w: %w", errdefs.ErrDetachTerminal, err)
 	}
 	return nil
+}
+
+// classifySessionEnd wraps the dual-copier teardown error with the
+// matching internal sentinel so pkg/attach.Run can surface a public
+// detach-vs-hangup distinction. A nil cause still carries the sentinel
+// so embedders can errors.Is even when the runner emitted no detail.
+func (s *Controller) classifySessionEnd(cause error) error {
+	sentinel := errdefs.ErrPeerClosed
+	if s.detachRequested.Load() {
+		sentinel = errdefs.ErrClientDetached
+	}
+	if cause == nil {
+		return sentinel
+	}
+	return fmt.Errorf("%w: %w", sentinel, cause)
 }
 
 func (s *Controller) Ping(in *api.PingMessage) (*api.PingMessage, error) {

--- a/internal/client/controller_test.go
+++ b/internal/client/controller_test.go
@@ -1603,6 +1603,205 @@ func Test_EventDetachFailure(t *testing.T) {
 	<-exitCh
 }
 
+// Test_EventError_PeerClosed asserts that a bare EvError (no preceding
+// EvDetach) tags the close reason with errdefs.ErrPeerClosed so
+// pkg/attach.Run can surface attach.ErrPeerClosed at the public
+// boundary.
+func Test_EventError_PeerClosed(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	sc := NewClientController(context.Background(), logger).(*Controller)
+
+	closeReason := make(chan error, 1)
+	sc.NewClientRunner = func(ctx context.Context, logger *slog.Logger, _ *api.ClientDoc, _ chan<- clientrunner.Event) clientrunner.ClientRunner {
+		return &clientrunner.Test{
+			Ctx:    ctx,
+			Logger: logger,
+			OpenSocketCtrlFunc: func() error {
+				return nil
+			},
+			StartServerFunc: func(_ context.Context, _ *clientrpc.ClientControllerRPC, readyCh chan error, _ chan error) {
+				select {
+				case readyCh <- nil:
+				default:
+				}
+			},
+			AttachFunc:         func(_ *api.AttachedTerminal) error { return nil },
+			IDFunc:             func() api.ID { return "test-terminal" },
+			CloseFunc:          func(reason error) error { closeReason <- reason; return nil },
+			ResizeFunc:         func(_ api.ResizeArgs) {},
+			CreateMetadataFunc: func() error { return nil },
+			StartTerminalCmdFunc: func(_ *api.AttachedTerminal) error {
+				return nil
+			},
+		}
+	}
+
+	sc.NewTerminalStore = func() terminalstore.TerminalStore {
+		return &terminalstore.Test{
+			AddFunc:        func(_ *api.AttachedTerminal) error { return nil },
+			GetFunc:        func(_ api.ID) (*api.AttachedTerminal, bool) { return nil, false },
+			ListLiveFunc:   func() []api.ID { return []api.ID{} },
+			RemoveFunc:     func(_ api.ID) {},
+			CurrentFunc:    func() api.ID { return "sess-1" },
+			SetCurrentFunc: func(_ api.ID) error { return nil },
+		}
+	}
+
+	clientID := naming.RandomID()
+	doc := &api.ClientDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindClient,
+		Metadata: api.ClientMetadata{
+			Name:        "default",
+			Labels:      make(map[string]string),
+			Annotations: make(map[string]string),
+		},
+		Spec: api.ClientSpec{
+			ID:           api.ID(clientID),
+			LogFile:      "/tmp/sbsh-logs/s0",
+			RunPath:      viper.GetString("global.runPath"),
+			TerminalSpec: &api.TerminalSpec{ID: "test-terminal"},
+		},
+	}
+
+	exitCh := make(chan error)
+	go func() {
+		exitCh <- sc.Run(doc)
+	}()
+	<-sc.ctrlReadyCh
+
+	sc.eventsCh <- clientrunner.Event{
+		ID:   "test-terminal",
+		Type: clientrunner.EvError,
+		Err:  errors.New("read/write routines exited"),
+		When: time.Now(),
+	}
+
+	select {
+	case reason := <-closeReason:
+		if !errors.Is(reason, errdefs.ErrPeerClosed) {
+			t.Fatalf("expected close reason to wrap errdefs.ErrPeerClosed, got: %v", reason)
+		}
+		if errors.Is(reason, errdefs.ErrClientDetached) {
+			t.Fatalf("expected close reason NOT to match errdefs.ErrClientDetached, got: %v", reason)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("CloseFunc was not called after EvError")
+	}
+
+	runErr := <-exitCh
+	if !errors.Is(runErr, errdefs.ErrPeerClosed) {
+		t.Fatalf("expected Run to return error wrapping errdefs.ErrPeerClosed, got: %v", runErr)
+	}
+}
+
+// Test_EventDetachThenError_ClientDetached asserts that an EvDetach
+// followed by EvError (the real-world flow: keystroke triggers Detach
+// RPC, terminal closes the IO conn, dual-copier reports it as a teardown)
+// tags the close reason with errdefs.ErrClientDetached so the public
+// boundary can route operators back into a re-attach loop instead of
+// killing the cell.
+func Test_EventDetachThenError_ClientDetached(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	sc := NewClientController(context.Background(), logger).(*Controller)
+
+	detachCalled := make(chan struct{}, 1)
+	closeReason := make(chan error, 1)
+	sc.NewClientRunner = func(ctx context.Context, logger *slog.Logger, _ *api.ClientDoc, _ chan<- clientrunner.Event) clientrunner.ClientRunner {
+		return &clientrunner.Test{
+			Ctx:    ctx,
+			Logger: logger,
+			OpenSocketCtrlFunc: func() error {
+				return nil
+			},
+			StartServerFunc: func(_ context.Context, _ *clientrpc.ClientControllerRPC, readyCh chan error, _ chan error) {
+				select {
+				case readyCh <- nil:
+				default:
+				}
+			},
+			AttachFunc:         func(_ *api.AttachedTerminal) error { return nil },
+			IDFunc:             func() api.ID { return "test-terminal" },
+			CloseFunc:          func(reason error) error { closeReason <- reason; return nil },
+			ResizeFunc:         func(_ api.ResizeArgs) {},
+			CreateMetadataFunc: func() error { return nil },
+			StartTerminalCmdFunc: func(_ *api.AttachedTerminal) error {
+				return nil
+			},
+			DetachFunc: func() error { detachCalled <- struct{}{}; return nil },
+		}
+	}
+
+	sc.NewTerminalStore = func() terminalstore.TerminalStore {
+		return &terminalstore.Test{
+			AddFunc:        func(_ *api.AttachedTerminal) error { return nil },
+			GetFunc:        func(_ api.ID) (*api.AttachedTerminal, bool) { return nil, false },
+			ListLiveFunc:   func() []api.ID { return []api.ID{} },
+			RemoveFunc:     func(_ api.ID) {},
+			CurrentFunc:    func() api.ID { return "sess-1" },
+			SetCurrentFunc: func(_ api.ID) error { return nil },
+		}
+	}
+
+	clientID := naming.RandomID()
+	doc := &api.ClientDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindClient,
+		Metadata: api.ClientMetadata{
+			Name:        "default",
+			Labels:      make(map[string]string),
+			Annotations: make(map[string]string),
+		},
+		Spec: api.ClientSpec{
+			ID:           api.ID(clientID),
+			LogFile:      "/tmp/sbsh-logs/s0",
+			RunPath:      viper.GetString("global.runPath"),
+			TerminalSpec: &api.TerminalSpec{ID: "test-terminal"},
+		},
+	}
+
+	exitCh := make(chan error)
+	go func() {
+		exitCh <- sc.Run(doc)
+	}()
+	<-sc.ctrlReadyCh
+
+	sc.eventsCh <- clientrunner.Event{
+		ID:   "test-terminal",
+		Type: clientrunner.EvDetach,
+		When: time.Now(),
+	}
+	select {
+	case <-detachCalled:
+	case <-time.After(1 * time.Second):
+		t.Fatal("DetachFunc was not called after EvDetach")
+	}
+
+	sc.eventsCh <- clientrunner.Event{
+		ID:   "test-terminal",
+		Type: clientrunner.EvError,
+		Err:  errors.New("read/write routines exited"),
+		When: time.Now(),
+	}
+
+	select {
+	case reason := <-closeReason:
+		if !errors.Is(reason, errdefs.ErrClientDetached) {
+			t.Fatalf("expected close reason to wrap errdefs.ErrClientDetached, got: %v", reason)
+		}
+		if errors.Is(reason, errdefs.ErrPeerClosed) {
+			t.Fatalf("expected close reason NOT to match errdefs.ErrPeerClosed, got: %v", reason)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("CloseFunc was not called after EvError following EvDetach")
+	}
+
+	runErr := <-exitCh
+	if !errors.Is(runErr, errdefs.ErrClientDetached) {
+		t.Fatalf("expected Run to return error wrapping errdefs.ErrClientDetached, got: %v", runErr)
+	}
+}
+
 func Test_EventUnknown(_ *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	sc := NewClientController(context.Background(), logger).(*Controller)

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -85,4 +85,16 @@ var (
 	ErrTerminalStdinClosed    = errors.New("terminal stdin is closed")
 	ErrSubscriberLagged       = errors.New("subscriber fell behind and was disconnected")
 	ErrInvalidProfiles        = errors.New("one or more profiles failed validation")
+	// ErrClientDetached marks a session-end caused by the operator's
+	// in-band detach keystroke (or by an external Detach RPC). The
+	// remote terminal stays alive — re-attach is possible. Internal
+	// callers chain this on the close reason; pkg/attach.Run remaps it
+	// to attach.ErrDetached at the public boundary.
+	ErrClientDetached = errors.New("client detached")
+	// ErrPeerClosed marks a session-end caused by the remote terminal
+	// dropping the IO connection — workload exited, peer crashed, or
+	// the session otherwise ended on the far side. Internal callers
+	// chain this on the close reason; pkg/attach.Run remaps it to
+	// attach.ErrPeerClosed at the public boundary.
+	ErrPeerClosed = errors.New("peer closed connection")
 )

--- a/pkg/attach/attach.go
+++ b/pkg/attach/attach.go
@@ -162,9 +162,27 @@ func Run(ctx context.Context, opts Options) error {
 		if ctrlErr == nil || errors.Is(ctrlErr, context.Canceled) {
 			return nil
 		}
-		// Drain WaitClose to release internal resources; surface the
-		// run error to the caller untouched.
+		// Drain WaitClose to release internal resources, then map the
+		// controller-level session-end sentinel to the matching public
+		// sentinel so embedders can branch with errors.Is. Setup and
+		// infrastructure failures (no errdefs session-end sentinel
+		// chained) keep their identity.
 		_ = ctrl.WaitClose()
-		return ctrlErr
+		return classifySessionEnd(ctrlErr)
+	}
+}
+
+// classifySessionEnd maps a controller-level error from Run to the
+// matching public sentinel. errdefs.ErrClientDetached → ErrDetached;
+// errdefs.ErrPeerClosed → ErrPeerClosed; anything else is returned
+// unchanged so existing errdefs.* matches keep working.
+func classifySessionEnd(err error) error {
+	switch {
+	case errors.Is(err, errdefs.ErrClientDetached):
+		return fmt.Errorf("%w: %w", ErrDetached, err)
+	case errors.Is(err, errdefs.ErrPeerClosed):
+		return fmt.Errorf("%w: %w", ErrPeerClosed, err)
+	default:
+		return err
 	}
 }

--- a/pkg/attach/attach_test.go
+++ b/pkg/attach/attach_test.go
@@ -19,12 +19,14 @@ package attach_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/rpc"
 	"net/rpc/jsonrpc"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -205,6 +207,82 @@ func TestRun_AttachFailureReturnsError(t *testing.T) {
 	}
 }
 
+// TestClassifySessionEnd_NilPassthrough confirms the helper is safe to
+// call with nil input — the same shape Run uses on the happy path.
+func TestClassifySessionEnd_NilPassthrough(t *testing.T) {
+	t.Parallel()
+	if got := attach.ClassifySessionEnd(nil); got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}
+
+// TestClassifySessionEnd_ClientDetached confirms a controller error
+// chained with errdefs.ErrClientDetached surfaces as attach.ErrDetached
+// while preserving the inner sentinel and the substrings kukeon's
+// pre-migration string match relies on.
+func TestClassifySessionEnd_ClientDetached(t *testing.T) {
+	t.Parallel()
+	in := fmt.Errorf("%w: %w", errdefs.ErrCloseReq,
+		fmt.Errorf("%w: %w", errdefs.ErrClientDetached, errors.New("read/write routines exited")))
+	got := attach.ClassifySessionEnd(in)
+	if !errors.Is(got, attach.ErrDetached) {
+		t.Fatalf("expected attach.ErrDetached match, got: %v", got)
+	}
+	if errors.Is(got, attach.ErrPeerClosed) {
+		t.Fatalf("did not expect attach.ErrPeerClosed match, got: %v", got)
+	}
+	if !errors.Is(got, errdefs.ErrClientDetached) {
+		t.Fatalf("expected chain to preserve errdefs.ErrClientDetached, got: %v", got)
+	}
+	for _, sub := range []string{"close requested", "read/write routines exited"} {
+		if !strings.Contains(got.Error(), sub) {
+			t.Fatalf("expected error text to contain %q, got %q", sub, got.Error())
+		}
+	}
+}
+
+// TestClassifySessionEnd_PeerClosed confirms a controller error chained
+// with errdefs.ErrPeerClosed surfaces as attach.ErrPeerClosed while
+// preserving the inner sentinel and the legacy substrings.
+func TestClassifySessionEnd_PeerClosed(t *testing.T) {
+	t.Parallel()
+	in := fmt.Errorf("%w: %w", errdefs.ErrCloseReq,
+		fmt.Errorf("%w: %w", errdefs.ErrPeerClosed, errors.New("read/write routines exited")))
+	got := attach.ClassifySessionEnd(in)
+	if !errors.Is(got, attach.ErrPeerClosed) {
+		t.Fatalf("expected attach.ErrPeerClosed match, got: %v", got)
+	}
+	if errors.Is(got, attach.ErrDetached) {
+		t.Fatalf("did not expect attach.ErrDetached match, got: %v", got)
+	}
+	if !errors.Is(got, errdefs.ErrPeerClosed) {
+		t.Fatalf("expected chain to preserve errdefs.ErrPeerClosed, got: %v", got)
+	}
+	for _, sub := range []string{"close requested", "read/write routines exited"} {
+		if !strings.Contains(got.Error(), sub) {
+			t.Fatalf("expected error text to contain %q, got %q", sub, got.Error())
+		}
+	}
+}
+
+// TestClassifySessionEnd_SetupErrorPassesThrough confirms setup-time
+// failures (no session-end sentinel chained) keep their original
+// identity so existing errdefs.ErrAttach matchers still fire.
+func TestClassifySessionEnd_SetupErrorPassesThrough(t *testing.T) {
+	t.Parallel()
+	in := fmt.Errorf("%w: %w", errdefs.ErrAttach, errors.New("fake: attach refused"))
+	got := attach.ClassifySessionEnd(in)
+	if errors.Is(got, attach.ErrDetached) || errors.Is(got, attach.ErrPeerClosed) {
+		t.Fatalf("did not expect public session-end sentinel, got: %v", got)
+	}
+	if !errors.Is(got, errdefs.ErrAttach) {
+		t.Fatalf("expected chain to preserve errdefs.ErrAttach, got: %v", got)
+	}
+	if !errors.Is(got, in) {
+		t.Fatalf("expected pass-through of input, got: %v", got)
+	}
+}
+
 // TestRun_NilLoggerDoesNotPanic verifies the Options.Logger == nil
 // branch falls back to a discard logger rather than dereferencing nil.
 func TestRun_NilLoggerDoesNotPanic(t *testing.T) {
@@ -232,4 +310,3 @@ func TestRun_NilLoggerDoesNotPanic(t *testing.T) {
 	})
 	// No panic == pass.
 }
-

--- a/pkg/attach/errors.go
+++ b/pkg/attach/errors.go
@@ -23,3 +23,18 @@ import "errors"
 // sentinel to distinguish a missing required option from any other
 // failure surfaced by the underlying controller.
 var ErrSocketPathRequired = errors.New("pkg/attach: Options.SocketPath is required")
+
+// ErrDetached signals that Run returned because the operator issued a
+// clean detach — either by pressing the in-band ^]^] keystroke or by
+// some peer triggering a Detach RPC against the controller. The remote
+// terminal is still alive; embedders can re-attach to the same
+// SocketPath. Match with errors.Is to branch on this case (e.g. mapping
+// it to a zero exit code or leaving a managed cell running).
+var ErrDetached = errors.New("pkg/attach: client detached")
+
+// ErrPeerClosed signals that Run returned because the remote terminal
+// dropped the IO connection — workload exited, peer crashed, or the
+// session otherwise ended on the far side. Re-attaching to the same
+// SocketPath will fail. Match with errors.Is to branch on this case
+// (e.g. tearing down a managed cell or surfacing a non-zero exit).
+var ErrPeerClosed = errors.New("pkg/attach: peer closed connection")

--- a/pkg/attach/export_test.go
+++ b/pkg/attach/export_test.go
@@ -1,0 +1,25 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package attach
+
+// ClassifySessionEnd re-exports the unexported translation helper for
+// tests. The mapping it performs is part of Run's contract; the helper
+// stays unexported on the public surface so embedders match on the
+// sentinels rather than calling the translator directly.
+func ClassifySessionEnd(err error) error {
+	return classifySessionEnd(err)
+}


### PR DESCRIPTION
## Summary
- Add `attach.ErrDetached` and `attach.ErrPeerClosed` so embedders (notably kukeon) can `errors.Is` against the public sentinels instead of brittle string matching on the composed `\"close requested: read/write routines exited\"` message.
- Plumb the cause forward: a new `Controller.detachRequested` flag, set in `Detach()`, lets `handleEvent` tag the `EvError` close reason with `errdefs.ErrClientDetached` when a clean detach was requested, otherwise `errdefs.ErrPeerClosed`. `pkg/attach.Run` translates those internal sentinels to the public ones at the boundary.
- Cross-references kukeon's blocked clean-up in [eminwux/kukeon#279](https://github.com/eminwux/kukeon/issues/279). Setup-time errors (`errdefs.ErrAttach`, etc.) are intentionally **not** retagged so existing matchers keep firing.
- Backwards-compat: the wrapped chain still includes the human-readable substrings kukeon currently keys on (`close requested`, `read/write routines exited`), so the `strings.Contains` check at `cmd/kuke/attach/attach.go:161-168` keeps working until kukeon migrates to `errors.Is`.

## Test plan
- [x] `make sbsh-sb` (canonical build, `file ./sbsh` confirmed ELF executable, `sb` hardlink intact)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — full suite including `./cmd/sb...`, `./cmd/sbsh...`, `./internal/terminal...`, `./internal/client...`, integration tag, and `./e2e` all pass
- [x] New unit coverage in `pkg/attach`: `TestClassifySessionEnd_NilPassthrough`, `TestClassifySessionEnd_ClientDetached`, `TestClassifySessionEnd_PeerClosed`, `TestClassifySessionEnd_SetupErrorPassesThrough` exercise the public translation, including the legacy substring assertion for kukeon's pre-migration string match.
- [x] New controller-level coverage in `internal/client`: `Test_EventError_PeerClosed` and `Test_EventDetachThenError_ClientDetached` drive both real-world flows (lone EvError vs. EvDetach-then-EvError) through the fake runner and assert the `Run` exit error matches the right `errdefs.*` sentinel.

Closes #192