### PR TITLE
docs(cli/sbsh): align --name example with hyphenated my-terminal

### DIFF
--- a/cmd/sbsh/terminal/terminal.go
+++ b/cmd/sbsh/terminal/terminal.go
@@ -311,7 +311,7 @@ way docker run, kubectl exec, runc exec, ctr run, sudo, env, and nsenter all
 take their argv.
 
 Examples:
-  sbsh terminal --name myterminal -- /bin/zsh
+  sbsh terminal --name my-terminal -- /bin/zsh
   sbsh terminal --profile devprofile
   sbsh terminal --profile devprofile --name customname -- /usr/bin/fish
   sbsh terminal -- /bin/sleep 3600


### PR DESCRIPTION
## Summary
- The cobra `Long:` block in `cmd/sbsh/terminal/terminal.go` showed `--name myterminal` while the lifted "execve semantics" paragraph in `docs/site/cli/sbsh.md` (and ~30 other doc occurrences) use `--name my-terminal`. A reader cross-referencing the two would notice the drift.
- Picked the hyphenated form (`my-terminal`) since it is dominant across the repo's docs and matches the `Name uniqueness` example in `sbsh.md` that follows the lifted block.

## Test plan
- [x] \`make sbsh-sb\` (canonical build)
- [x] \`file ./sbsh\` confirms ELF executable
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test -timeout=5m \$(go list ./... | grep -v '/e2e\$')\` — all packages pass
- [x] \`go test -tags=integration ./cmd/sb/get/...\` — pass
- [x] Built \`docs/examples/library-consumer\` (build + vet)
- [x] Smoke: \`./sbsh terminal --help\` renders the updated example line

Closes #171