### PR TITLE
refactor: remove dead closingCh from client controller

### DIFF
--- a/internal/client/controller.go
+++ b/internal/client/controller.go
@@ -50,7 +50,6 @@ type Controller struct {
 
 	ctrlReadyCh  chan struct{}
 	closeReqCh   chan error
-	closingCh    chan error
 	closedCh     chan struct{}
 	shuttingDown atomic.Bool
 
@@ -92,7 +91,6 @@ func NewClientControllerWithIO(
 		cancel:      cancel,
 		logger:      logger,
 		closedCh:    make(chan struct{}),
-		closingCh:   make(chan error, 1),
 		ctrlReadyCh: make(chan struct{}),
 		// rpcReadyCh is buffered (cap 1) so StartServer can deposit its
 		// one-shot ready signal without blocking on a receiver. Run watches
@@ -428,15 +426,13 @@ func (s *Controller) onClosed(_ api.ID, err error) {
 func (s *Controller) Close(reason error) error {
 	// CompareAndSwap fuses the shutting-down check with the flip so that
 	// concurrent Close callers cannot both enter the body and re-send on the
-	// one-shot closeReqCh / closingCh — see the matching fix in
+	// one-shot closeReqCh — see the matching fix in
 	// internal/terminal/controller.go.
 	if !s.shuttingDown.CompareAndSwap(false, true) {
 		s.logger.Info("shutdown sequence already in progress, ignoring duplicate request", "reason", reason)
 		return nil
 	}
 	s.logger.Info("initiating shutdown sequence", "reason", reason)
-	// Set closing reason
-	s.closingCh <- reason
 
 	// Notify terminal runner to close all terminals
 	_ = s.sr.Close(reason)

--- a/internal/client/controller_test.go
+++ b/internal/client/controller_test.go
@@ -2012,21 +2012,11 @@ func Test_CloseIdempotent(t *testing.T) {
 	// Initialize sr to avoid nil pointer
 	sc.sr = sc.NewClientRunner(sc.ctx, sc.logger, nil, sc.eventsCh)
 
-	// Start a goroutine to drain closingCh (simulating what Run() does)
-	go func() {
-		errC := <-sc.closingCh
-		sc.shuttingDown.Store(true)
-		sc.logger.Warn("controller closing", "reason", errC)
-	}()
-
 	// First close
 	err1 := sc.Close(errors.New("first close"))
 	if err1 != nil {
 		t.Fatalf("expected nil error from first Close; got: '%v'", err1)
 	}
-
-	// Wait a bit for shuttingDown to be set
-	time.Sleep(10 * time.Millisecond)
 
 	// Second close should be idempotent
 	err2 := sc.Close(errors.New("second close"))
@@ -2055,21 +2045,11 @@ func Test_CloseErrorHandling(t *testing.T) {
 
 	sc.sr = sc.NewClientRunner(sc.ctx, sc.logger, nil, sc.eventsCh)
 
-	// Start a goroutine to drain closingCh (simulating what Run() does)
-	go func() {
-		errC := <-sc.closingCh
-		sc.shuttingDown.Store(true)
-		sc.logger.Warn("controller closing", "reason", errC)
-	}()
-
 	// Close should still succeed even if sr.Close returns an error
 	err := sc.Close(errors.New("test close"))
 	if err != nil {
 		t.Fatalf("expected nil error from Close even when sr.Close fails; got: '%v'", err)
 	}
-
-	// Wait a bit for shuttingDown to be set by the goroutine
-	time.Sleep(10 * time.Millisecond)
 
 	// Verify shuttingDown is set
 	if !sc.shuttingDown.Load() {


### PR DESCRIPTION
## Summary
- After the watcher goroutine that read `closingCh` was removed (PR #185), the client `Controller`'s `closingCh` had no production readers — `WaitClose` reads only `closedCh`. Delete the field, the `make` in the constructor, the send in `Close`, and the matching drain goroutines in `Test_CloseIdempotent`/`Test_CloseErrorHandling`.
- Updated the `Close` comment that referenced `closingCh`. The terminal controller's own `closingCh` (`internal/terminal/controller.go`) stays — that one is still load-bearing.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make sbsh-sb` + `file ./sbsh` confirms ELF executable
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` — all packages pass, including `internal/client`
- [x] `go test -tags=integration ./cmd/sb/get/...` — pass
- [x] `docs/examples/library-consumer`: `go build ./...` + `go vet ./...` pass

Closes #186