### PR TITLE
test(builder): cover WithSocketMode and WithSocketGID option threading

### DIFF
--- a/pkg/builder/terminal_test.go
+++ b/pkg/builder/terminal_test.go
@@ -330,6 +330,85 @@ spec:
 	}
 }
 
+// WithSocketMode threads the octal mode string through to spec.SocketMode.
+// Empty leaves spec.SocketMode at its zero value (runner default, 0o600).
+func TestBuildTerminalSpec_WithSocketMode(t *testing.T) {
+	runPath := t.TempDir()
+
+	// Default: no WithSocketMode → zero value, runner picks 0o600.
+	spec, err := builder.BuildTerminalSpec(context.Background(), testLogger(), runPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.SocketMode != 0 {
+		t.Fatalf("default socketMode: want 0, got 0o%o", spec.SocketMode)
+	}
+
+	// Override: "0660" parses to 0o660.
+	spec, err = builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithSocketMode("0660"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.SocketMode != 0o660 {
+		t.Fatalf("socketMode: want 0o660, got 0o%o", spec.SocketMode)
+	}
+}
+
+// WithSocketGID threads the explicit gid through to spec.SocketGID, and
+// preserves the unset/zero distinction: never calling WithSocketGID leaves
+// spec.SocketGID nil; calling WithSocketGID(0) sets *spec.SocketGID to 0.
+func TestBuildTerminalSpec_WithSocketGID(t *testing.T) {
+	runPath := t.TempDir()
+
+	// Default: no WithSocketGID → nil pointer, runner leaves group unchanged.
+	spec, err := builder.BuildTerminalSpec(context.Background(), testLogger(), runPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.SocketGID != nil {
+		t.Fatalf("default socketGID: want nil, got %d", *spec.SocketGID)
+	}
+
+	// Explicit non-zero: gets forwarded as the same value.
+	spec, err = builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithSocketGID(1234),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.SocketGID == nil {
+		t.Fatalf("socketGID: want non-nil pointer to 1234, got nil")
+	}
+	if *spec.SocketGID != 1234 {
+		t.Fatalf("socketGID: want 1234, got %d", *spec.SocketGID)
+	}
+
+	// Explicit zero: WithSocketGID(0) means "set to root", distinct from unset.
+	spec, err = builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithSocketGID(0),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.SocketGID == nil {
+		t.Fatalf("socketGID(0): want non-nil pointer to 0, got nil")
+	}
+	if *spec.SocketGID != 0 {
+		t.Fatalf("socketGID(0): want 0, got %d", *spec.SocketGID)
+	}
+}
+
 // WithCommand with empty argv (or empty argv[0]) is a no-op.
 func TestBuildTerminalSpec_WithCommandEmpty(t *testing.T) {
 	runPath := t.TempDir()


### PR DESCRIPTION
## Summary
- Issue #190 asked for `WithSocketMode` / `WithSocketGID` builder options to thread through `BuildTerminalSpec` to the resulting `*api.TerminalSpec`. The wiring itself already landed in #189's review-nits fixup commit (`pkg/builder/terminal.go:48-49,150-164,213-214`), but no PR ever closed #190 and no unit tests assert the threading.
- This PR adds two unit tests next to the existing `TestBuildTerminalSpec_*` suite:
  - `TestBuildTerminalSpec_WithSocketMode` — verifies "0660" parses to `0o660` on the spec, and that omitting the option leaves `spec.SocketMode` zero (runner picks the 0o600 default).
  - `TestBuildTerminalSpec_WithSocketGID` — verifies the unset / explicit-zero / explicit-non-zero distinction round-trips (omit ⇒ `nil`, `WithSocketGID(0)` ⇒ pointer to 0, `WithSocketGID(1234)` ⇒ pointer to 1234). The `*int` sentinel is load-bearing per #189's PR body, so guarding it with a test is worth the lines.
- Closes #190 so the stale `in-progress` label gets cleaned up.

## Test plan
- [x] `go test ./pkg/builder/...` (new tests green)
- [x] `make sbsh-sb` and `file ./sbsh` confirms ELF executable
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` (full unit-test target CI runs)
- [x] `go test -tags=integration ./cmd/sb/get/...` (integration suite CI runs)
- [x] `(cd docs/examples/library-consumer && go build ./... && go vet ./...)` (library-consumer step CI runs)
- [x] `pre-commit run --files pkg/builder/terminal_test.go` (all hooks pass on the changed file; running `--all-files` surfaces pre-existing formatting drift in unrelated files which is out of scope here)

Closes #190