### PR TITLE
ci: make pre-commit pass on clean main and enforce in CI

### DIFF
--- a/.github/workflows/mkdocs.yaml
+++ b/.github/workflows/mkdocs.yaml
@@ -9,7 +9,7 @@ on:
     branches:
       - main
     paths:
-      - 'docs/site/**'
+      - "docs/site/**"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,6 +26,14 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
+
       - name: Build binary
         run: make sbsh-sb
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        args: ["--unsafe", "--allow-multiple-documents"]
         exclude: ^examples/profiles/local\.yaml$
       - id: check-json
       - id: check-toml

--- a/cmd/sb/validate/profiles.go
+++ b/cmd/sb/validate/profiles.go
@@ -70,9 +70,9 @@ rejected.`,
 // YAML file, together with the (partial) parse error that aborted reading
 // that file if any.
 type fileValidation struct {
-	Path       string
-	Results    []profile.ProfileValidationResult
-	DecodeErr  error
+	Path      string
+	Results   []profile.ProfileValidationResult
+	DecodeErr error
 }
 
 func runValidateProfiles(cmd *cobra.Command, args []string, stdout, stderr io.Writer) error {
@@ -236,4 +236,3 @@ func formatLabel(r profile.ProfileValidationResult) string {
 	}
 	return fmt.Sprintf("document %d (%s)", r.DocIndex, r.ProfileName)
 }
-

--- a/docs/examples/library-consumer/README.md
+++ b/docs/examples/library-consumer/README.md
@@ -73,13 +73,13 @@ go run . -mode attach -sbsh "$(pwd)/../../../sbsh" -v
 
 Flags:
 
-| Flag | Description |
-| --- | --- |
-| `-sbsh` | **Required.** Absolute path to the `sbsh` binary. |
-| `-sb` | Absolute path to the `sb` binary. Defaults to `$(dirname <sbsh>)/sb`. Only consulted in `-mode=rpc`. |
-| `-mode` | `rpc` (default) or `attach`. See "What it does" above. |
+| Flag          | Description                                                                                               |
+| ------------- | --------------------------------------------------------------------------------------------------------- |
+| `-sbsh`       | **Required.** Absolute path to the `sbsh` binary.                                                         |
+| `-sb`         | Absolute path to the `sb` binary. Defaults to `$(dirname <sbsh>)/sb`. Only consulted in `-mode=rpc`.      |
+| `-mode`       | `rpc` (default) or `attach`. See "What it does" above.                                                    |
 | `-state-root` | Run path for sbsh state. Defaults to a fresh `$TMPDIR/sbsh-lib-example-*` directory (cleaned up on exit). |
-| `-v` | Log spawn/RPC internals at debug level. |
+| `-v`          | Log spawn/RPC internals at debug level.                                                                   |
 
 ### Headless contexts (`-mode=attach`)
 

--- a/docs/gap-analysis.md
+++ b/docs/gap-analysis.md
@@ -24,9 +24,10 @@ complexity. Items are ordered by priority.
 
 ## Gaps in detail
 
-### 1. No `sb get profile <name>` detail view  (P0) — **DONE**
+### 1. No `sb get profile <name>` detail view (P0) — **DONE**
 
 Closed by commit `e09b45e` (`feat: wide output for sb get`). At HEAD:
+
 - `sb get profile <name>` works via single-arg dispatch in
   `cmd/sb/get/profiles.go:42-50`; aliases `profile|prof|pro|p`.
 - `-o yaml|json` honored at `cmd/sb/get/profiles.go:60` and validated at
@@ -39,7 +40,7 @@ Residual polish (tracked informally): `printTerminalMetadata` duplicates
 output in the empty-format branch (`%+v` + `PrintHuman`);
 `FindProfileByName` returns a plain `fmt.Errorf` rather than a sentinel.
 
-### 2. No profile validation / lint command  (P0)
+### 2. No profile validation / lint command (P0)
 
 - **Observed:** An invalid profile (bad YAML, unknown field, invalid
   `runTarget`, malformed `prompt` escape) is only discovered when you try
@@ -53,7 +54,7 @@ output in the empty-format branch (`%+v` + `PrintHuman`);
   `runTarget: local`.
 - **Complexity:** Low–medium.
 
-### 3. No way to stop a live terminal  (P1) — **DONE**
+### 3. No way to stop a live terminal (P1) — **DONE**
 
 Implemented via a new `sb stop terminal <name>` command.
 
@@ -72,7 +73,7 @@ Implemented via a new `sb stop terminal <name>` command.
   command idempotent. Attached clients are warned then disconnected.
 - Metadata is left in place — `sb prune terminals` still owns cleanup.
 
-### 4. `sb get terminals` lacks PID and cwd  (P1)
+### 4. `sb get terminals` lacks PID and cwd (P1)
 
 - **Observed:** Columns are `NAME PROFILE TTY CREATED`. PID only appears in
   the launch output. `cwd` is not shown anywhere post-launch.
@@ -83,7 +84,7 @@ Implemented via a new `sb stop terminal <name>` command.
   already do this for `sb get`, per commit `e09b45e`).
 - **Complexity:** Low.
 
-### 5. No `sb logs` command; relying on `--terminal-capture-file`  (P1)
+### 5. No `sb logs` command; relying on `--terminal-capture-file` (P1)
 
 - **Observed:** To observe a detached terminal I had to pass
   `--terminal-capture-file /tmp/foo.log` at launch. The file contains raw ANSI
@@ -98,7 +99,7 @@ Implemented via a new `sb stop terminal <name>` command.
 - **Complexity:** Medium. Requires always-on capture (small buffer or
   on-disk ring).
 
-### 6. Profiles must live in one file  (P2) — RESOLVED
+### 6. Profiles must live in one file (P2) — RESOLVED
 
 - **Observed (historical):** `~/.sbsh/profiles.yaml` held all profiles separated
   by `---`. Editing one profile touched the shared file; concurrent edits by
@@ -110,7 +111,7 @@ Implemented via a new `sb stop terminal <name>` command.
   empty. The single-file layout is no longer read — breaking change,
   users migrate by dropping their profiles into `profiles.d/`.
 
-### 7. `onInit` semantics undocumented  (P2)
+### 7. `onInit` semantics undocumented (P2)
 
 - **Observed:** `internal/terminal/terminalrunner/lifecycle.go:259-282`
   shows `onInit` steps are typed into the PTY via `sr.Write(...)`. They are
@@ -130,14 +131,14 @@ Implemented via a new `sb stop terminal <name>` command.
   - Caveats: multi-line scripts, here-docs, and env scoping.
 - **Complexity:** Trivial (docs only).
 
-### 8. No structured output from `sb get`  (P2)
+### 8. No structured output from `sb get` (P2)
 
 - **Observed:** `sb get profiles` and `sb get terminals` emit a table only.
 - **Impact:** Agents cannot reliably parse output; must regex column widths.
 - **Fix:** Add `-o json` and `-o yaml` for both commands.
 - **Complexity:** Low.
 
-### 9. No published JSON Schema for `TerminalProfile`  (P3)
+### 9. No published JSON Schema for `TerminalProfile` (P3)
 
 - **Observed:** I had to cross-reference example profiles
   (`docs/profiles/*.yaml`) and the Go struct to confirm which fields exist
@@ -149,7 +150,7 @@ Implemented via a new `sb stop terminal <name>` command.
   and publish at `docs/schema/terminal-profile.json`.
 - **Complexity:** Medium.
 
-### 10. `--terminal-name` collision behavior  (P3)
+### 10. `--terminal-name` collision behavior (P3)
 
 - **Observed:** Behavior undocumented if a terminal with the same name
   already exists.
@@ -157,7 +158,7 @@ Implemented via a new `sb stop terminal <name>` command.
 - **Fix:** Document + either fail fast or append a suffix.
 - **Complexity:** Low.
 
-### 11. `CREATED` column sometimes shows `-`  (P3)
+### 11. `CREATED` column sometimes shows `-` (P3)
 
 - **Observed:** `sb get terminals` showed `CREATED: -` for
   `farseeing_smeagol` while others had `7m`.
@@ -167,10 +168,10 @@ Implemented via a new `sb stop terminal <name>` command.
   `api.State`.
 - **Complexity:** Low.
 
-### 12. Help text tautology  (P3)
+### 12. Help text tautology (P3)
 
 - **Observed:** `sbsh --help` prints `You can see available options and
-  commands with: sbsh help`.
+commands with: sbsh help`.
 - **Impact:** Confusing — `sbsh --help` already did that.
 - **Fix:** Replace with useful guidance (e.g. link to docs, or list
   example flows).

--- a/docs/site/guides/configuration.md
+++ b/docs/site/guides/configuration.md
@@ -22,23 +22,23 @@ kind: Configuration
 metadata:
   name: default
 spec:
-  runPath: /path/to/state-root         # optional, default $HOME/.sbsh/run
-  profilesDir: /path/to/profiles.d     # optional, default $HOME/.sbsh/profiles.d
-  logLevel: info                       # optional, default info (debug|info|warn|error)
+  runPath: /path/to/state-root # optional, default $HOME/.sbsh/run
+  profilesDir: /path/to/profiles.d # optional, default $HOME/.sbsh/profiles.d
+  logLevel: info # optional, default info (debug|info|warn|error)
 ```
 
 All fields under `spec` are optional. An empty or missing field keeps the built-in default.
 
 ### Fields
 
-| Field              | Description                                                                                           |
-| ------------------ | ----------------------------------------------------------------------------------------------------- |
-| `apiVersion`       | Must be `sbsh/v1beta1`.                                                                               |
-| `kind`             | Must be `Configuration`. Any other kind is rejected.                                                  |
-| `metadata.name`    | Free-form label for the document. Optional.                                                           |
-| `spec.runPath`     | Root directory where sbsh writes per-terminal and per-client state.                                   |
-| `spec.profilesDir` | Directory scanned recursively for `*.yaml` / `*.yml` files containing `TerminalProfile` documents.    |
-| `spec.logLevel`    | Default log level when `--log-level` and `SBSH_LOG_LEVEL` are not provided.                           |
+| Field              | Description                                                                                        |
+| ------------------ | -------------------------------------------------------------------------------------------------- |
+| `apiVersion`       | Must be `sbsh/v1beta1`.                                                                            |
+| `kind`             | Must be `Configuration`. Any other kind is rejected.                                               |
+| `metadata.name`    | Free-form label for the document. Optional.                                                        |
+| `spec.runPath`     | Root directory where sbsh writes per-terminal and per-client state.                                |
+| `spec.profilesDir` | Directory scanned recursively for `*.yaml` / `*.yml` files containing `TerminalProfile` documents. |
+| `spec.logLevel`    | Default log level when `--log-level` and `SBSH_LOG_LEVEL` are not provided.                        |
 
 ## Precedence
 

--- a/docs/site/reference/library.md
+++ b/docs/site/reference/library.md
@@ -12,15 +12,15 @@ A complete, build-tested example lives at
 
 The public library lives under [`github.com/eminwux/sbsh/pkg`](https://pkg.go.dev/github.com/eminwux/sbsh/pkg):
 
-| Package | Purpose |
-| --- | --- |
-| `pkg/api` | Declarative document types (`TerminalDoc`, `TerminalSpec`, `ClientDoc`, `TerminalProfileDoc`, …) and RPC payload types (`PingMessage`, `WriteRequest`, `SubscribeRequest`, `StopArgs`, …). Counterpart of the YAML/JSON manifests. |
-| `pkg/builder` | Construct a `TerminalSpec` or `ClientDoc` from a profile name plus inline overrides (`WithProfile`, `WithProfilesDir`, `WithCommand`, `WithEnv`, `WithClientMode`, …). No YAML round-trip. |
-| `pkg/spawn` | Launch detached `Terminal` and `Client` subprocesses (`NewTerminal`, `NewClient`). Returns `TerminalHandle` / `ClientHandle` with `PID`, `SocketPath`, `WaitReady`, `WaitClose`, `Close`. |
-| `pkg/discovery` | Enumerate live terminals/clients or look them up by ID/Name under a run path (`ScanTerminals`, `FindTerminalByID`, `FindTerminalByName`, `ScanClients`, `FindClientByName`). Load profiles from disk (`LoadProfilesFromDir`, `FindProfileByNameInDir`). |
-| `pkg/rpcclient/terminal` | JSON-RPC client for the `TerminalController` socket (`Ping`, `Resize`, `Attach`, `Detach`, `Metadata`, `State`, `Stop`, `Write`, `Subscribe`). |
-| `pkg/rpcclient/client` | JSON-RPC client for the `ClientController` socket (`Ping`, `Metadata`, `State`, `Stop`, `Detach`). |
-| `pkg/errors` | Curated error sentinels re-exported from `internal/errdefs`. Use `errors.Is` to branch on well-known failure modes without importing internal packages. |
+| Package                  | Purpose                                                                                                                                                                                                                                                 |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pkg/api`                | Declarative document types (`TerminalDoc`, `TerminalSpec`, `ClientDoc`, `TerminalProfileDoc`, …) and RPC payload types (`PingMessage`, `WriteRequest`, `SubscribeRequest`, `StopArgs`, …). Counterpart of the YAML/JSON manifests.                      |
+| `pkg/builder`            | Construct a `TerminalSpec` or `ClientDoc` from a profile name plus inline overrides (`WithProfile`, `WithProfilesDir`, `WithCommand`, `WithEnv`, `WithClientMode`, …). No YAML round-trip.                                                              |
+| `pkg/spawn`              | Launch detached `Terminal` and `Client` subprocesses (`NewTerminal`, `NewClient`). Returns `TerminalHandle` / `ClientHandle` with `PID`, `SocketPath`, `WaitReady`, `WaitClose`, `Close`.                                                               |
+| `pkg/discovery`          | Enumerate live terminals/clients or look them up by ID/Name under a run path (`ScanTerminals`, `FindTerminalByID`, `FindTerminalByName`, `ScanClients`, `FindClientByName`). Load profiles from disk (`LoadProfilesFromDir`, `FindProfileByNameInDir`). |
+| `pkg/rpcclient/terminal` | JSON-RPC client for the `TerminalController` socket (`Ping`, `Resize`, `Attach`, `Detach`, `Metadata`, `State`, `Stop`, `Write`, `Subscribe`).                                                                                                          |
+| `pkg/rpcclient/client`   | JSON-RPC client for the `ClientController` socket (`Ping`, `Metadata`, `State`, `Stop`, `Detach`).                                                                                                                                                      |
+| `pkg/errors`             | Curated error sentinels re-exported from `internal/errdefs`. Use `errors.Is` to branch on well-known failure modes without importing internal packages.                                                                                                 |
 
 Nothing under `internal/` is part of the supported surface and
 Go's visibility rules prevent external modules from importing it.

--- a/internal/client/controller_rpcs_test.go
+++ b/internal/client/controller_rpcs_test.go
@@ -164,4 +164,3 @@ func TestController_Stop_NilArgsUsesDefaultReason(t *testing.T) {
 		t.Fatalf("Close was not triggered by Stop(nil)")
 	}
 }
-

--- a/internal/terminal/terminalrunner/reaper_other.go
+++ b/internal/terminal/terminalrunner/reaper_other.go
@@ -25,8 +25,8 @@ import "log/slog"
 // PID 1.
 type reaper struct{}
 
-func newReaper(_ *slog.Logger) *reaper          { return &reaper{} }
-func (r *reaper) Start()                        {}
-func (r *reaper) Stop()                         {}
-func (r *reaper) RegisterChild(_ int)           {}
-func (r *reaper) TrackedExitCh() <-chan int     { return nil }
+func newReaper(_ *slog.Logger) *reaper      { return &reaper{} }
+func (r *reaper) Start()                    {}
+func (r *reaper) Stop()                     {}
+func (r *reaper) RegisterChild(_ int)       {}
+func (r *reaper) TrackedExitCh() <-chan int { return nil }


### PR DESCRIPTION
## Summary
- Hooks failed on `main` with no local edits — `check-yaml` rejected `mkdocs.yml`'s `!!python/name` constructor and the multi-doc `profiles.yaml` files; `end-of-file-fixer`, `go fmt`, and `prettier` rewrote eight files of pre-existing drift. Configure `check-yaml` with `--unsafe` and `--allow-multiple-documents`, accept the formatter output for the eight drifted files, and add a `pre-commit run --all-files` step to `test.yaml` so future drift fails CI before it lands.
- The fixer-applied diffs are mechanical (gofmt struct/method alignment, prettier table padding, end-of-file trims, prettier wrap of an inline-code continuation in `gap-analysis.md`); no behavioral changes.

## Test plan
- [x] `pre-commit run --all-files` — passes
- [x] `make sbsh-sb` — produces ELF executable, `file ./sbsh` confirms
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')`
- [x] `go test -tags=integration ./cmd/sb/get/...`
- [x] `cd docs/examples/library-consumer && go build ./... && go vet ./...`

Closes #197