### PR TITLE
test(profile): cover CreateTerminalFromProfile socket gid validation

### DIFF
--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -22,9 +22,11 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/pkg/api"
 )
 
 func TestBuildTerminalSpec_EmptyRunPath_ReturnsErrRunPathRequired(t *testing.T) {
@@ -33,6 +35,62 @@ func TestBuildTerminalSpec_EmptyRunPath_ReturnsErrRunPathRequired(t *testing.T) 
 	_, err := BuildTerminalSpec(context.Background(), logger, &BuildTerminalSpecParams{})
 	if !errors.Is(err, errdefs.ErrRunPathRequired) {
 		t.Fatalf("expected errdefs.ErrRunPathRequired, got %v", err)
+	}
+}
+
+func profileWithSocketGID(name string, gid *int) *api.TerminalProfileDoc {
+	return &api.TerminalProfileDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindTerminalProfile,
+		Metadata:   api.TerminalProfileMetadata{Name: name},
+		Spec: api.TerminalProfileSpec{
+			RunTarget: api.RunTargetLocal,
+			Shell:     api.ShellSpec{Cmd: "/bin/bash"},
+			Socket:    &api.SocketSpec{GID: gid},
+		},
+	}
+}
+
+func TestCreateTerminalFromProfile_RejectsNegativeGID(t *testing.T) {
+	gid := -5
+	_, err := CreateTerminalFromProfile(profileWithSocketGID("tprof", &gid))
+	if err == nil {
+		t.Fatal("expected error for negative gid, got nil")
+	}
+	if !strings.Contains(err.Error(), "spec.socket.gid") {
+		t.Fatalf("error %q should mention spec.socket.gid", err.Error())
+	}
+	if !strings.Contains(err.Error(), "tprof") {
+		t.Fatalf("error %q should mention profile name", err.Error())
+	}
+}
+
+func TestCreateTerminalFromProfile_AcceptsValidGID(t *testing.T) {
+	gidZero := 0
+	gidPos := 1234
+	tests := []struct {
+		name string
+		gid  *int
+	}{
+		{name: "nil leaves group unchanged", gid: nil},
+		{name: "zero is a valid root gid", gid: &gidZero},
+		{name: "positive gid", gid: &gidPos},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spec, err := CreateTerminalFromProfile(profileWithSocketGID("tprof", tc.gid))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			gotNil := spec.SocketGID == nil
+			wantNil := tc.gid == nil
+			if gotNil != wantNil {
+				t.Fatalf("SocketGID nil=%v, want nil=%v", gotNil, wantNil)
+			}
+			if !wantNil && *spec.SocketGID != *tc.gid {
+				t.Fatalf("SocketGID = %d, want %d", *spec.SocketGID, *tc.gid)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- The negative-gid rejection in `CreateTerminalFromProfile` (added in #189 via 11aee39) had no test coverage. Lock the behavior in: `*spec.socket.gid = -5` returns an error mentioning the field and the profile name.
- Cover the happy path too (`nil`, explicit `0`, positive int) so future refactors can't silently regress the precedence rules around "unset vs explicit-zero gid".
- Code-only test file change; no production code touched (validation already lives at `internal/profile/profile.go:114-124`).

## Test plan
- [x] `pre-commit run --files internal/profile/profile_test.go` — passes (full-tree pre-commit fails on pre-existing main drift tracked by #197 / #198, not by this change)
- [x] `make sbsh-sb` — produces ELF executable, `file ./sbsh` confirms
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')`
- [x] `go test -tags=integration ./cmd/sb/get/...`
- [x] `cd docs/examples/library-consumer && go build ./... && go vet ./...`

Closes #191