### PR TITLE
fix: honor mode/gid for capture and log files

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -164,6 +164,14 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SBSH_ROOT_TERM_SOCKET_GID = DefineKV("SBSH_ROOT_TERM_SOCKET_GID", "sbsh.root.terminal.socketGid")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SBSH_ROOT_TERM_CAPTURE_MODE = DefineKV("SBSH_ROOT_TERM_CAPTURE_MODE", "sbsh.root.terminal.captureMode")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SBSH_ROOT_TERM_CAPTURE_GID = DefineKV("SBSH_ROOT_TERM_CAPTURE_GID", "sbsh.root.terminal.captureGid")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SBSH_ROOT_TERM_LOG_FILE_MODE = DefineKV("SBSH_ROOT_TERM_LOG_FILE_MODE", "sbsh.root.terminal.logFileMode")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SBSH_ROOT_TERM_LOG_FILE_GID = DefineKV("SBSH_ROOT_TERM_LOG_FILE_GID", "sbsh.root.terminal.logFileGid")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SBSH_ROOT_TERM_DISABLE_SET_PROMPT = DefineKV(
 		"SBSH_ROOT_TERM_DISABLE_SET_PROMPT",
 		"sbsh.root.terminal.disableSetPrompt",
@@ -192,6 +200,14 @@ var (
 	SBSH_TERM_SOCKET_MODE = DefineKV("SBSH_TERM_SOCKET_MODE", "sbsh.terminal.socketMode")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SBSH_TERM_SOCKET_GID = DefineKV("SBSH_TERM_SOCKET_GID", "sbsh.terminal.socketGid")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SBSH_TERM_CAPTURE_MODE = DefineKV("SBSH_TERM_CAPTURE_MODE", "sbsh.terminal.captureMode")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SBSH_TERM_CAPTURE_GID = DefineKV("SBSH_TERM_CAPTURE_GID", "sbsh.terminal.captureGid")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SBSH_TERM_LOG_FILE_MODE = DefineKV("SBSH_TERM_LOG_FILE_MODE", "sbsh.terminal.logFileMode")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SBSH_TERM_LOG_FILE_GID = DefineKV("SBSH_TERM_LOG_FILE_GID", "sbsh.terminal.logFileGid")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SBSH_TERM_ID = DefineKV("SBSH_TERM_ID", "sbsh.terminal.id")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/sbsh/sbsh.go
+++ b/cmd/sbsh/sbsh.go
@@ -168,6 +168,10 @@ You can also use sbsh with parameters. For example:
 					SocketFile:       viper.GetString(config.SBSH_ROOT_TERM_SOCKET.ViperKey),
 					SocketMode:       viper.GetString(config.SBSH_ROOT_TERM_SOCKET_MODE.ViperKey),
 					SocketGID:        readRootSocketGID(cmd),
+					CaptureMode:      viper.GetString(config.SBSH_ROOT_TERM_CAPTURE_MODE.ViperKey),
+					CaptureGID:       readRootCaptureGID(cmd),
+					LogFileMode:      viper.GetString(config.SBSH_ROOT_TERM_LOG_FILE_MODE.ViperKey),
+					LogFileGID:       readRootLogFileGID(cmd),
 					DisableSetPrompt: viper.GetBool(config.SBSH_ROOT_TERM_DISABLE_SET_PROMPT.ViperKey),
 				},
 			)
@@ -376,6 +380,54 @@ func setTerminalFlags(rootCmd *cobra.Command) error {
 		return err
 	}
 
+	rootCmd.Flags().String(
+		"terminal-capture-mode",
+		"",
+		"Octal mode applied to the capture file after Open (default 0600)",
+	)
+	if err := viper.BindPFlag(config.SBSH_ROOT_TERM_CAPTURE_MODE.ViperKey, rootCmd.Flags().Lookup("terminal-capture-mode")); err != nil {
+		return err
+	}
+	if err := viper.BindEnv(config.SBSH_ROOT_TERM_CAPTURE_MODE.ViperKey, config.SBSH_ROOT_TERM_CAPTURE_MODE.EnvVar()); err != nil {
+		return err
+	}
+
+	rootCmd.Flags().Int(
+		"terminal-capture-gid",
+		-1,
+		"Numeric GID applied to the capture file via chown after Open; -1 leaves group unchanged",
+	)
+	if err := viper.BindPFlag(config.SBSH_ROOT_TERM_CAPTURE_GID.ViperKey, rootCmd.Flags().Lookup("terminal-capture-gid")); err != nil {
+		return err
+	}
+	if err := viper.BindEnv(config.SBSH_ROOT_TERM_CAPTURE_GID.ViperKey, config.SBSH_ROOT_TERM_CAPTURE_GID.EnvVar()); err != nil {
+		return err
+	}
+
+	rootCmd.Flags().String(
+		"terminal-log-file-mode",
+		"",
+		"Octal mode applied to the log file after Open (default 0600)",
+	)
+	if err := viper.BindPFlag(config.SBSH_ROOT_TERM_LOG_FILE_MODE.ViperKey, rootCmd.Flags().Lookup("terminal-log-file-mode")); err != nil {
+		return err
+	}
+	if err := viper.BindEnv(config.SBSH_ROOT_TERM_LOG_FILE_MODE.ViperKey, config.SBSH_ROOT_TERM_LOG_FILE_MODE.EnvVar()); err != nil {
+		return err
+	}
+
+	rootCmd.Flags().Int(
+		"terminal-log-file-gid",
+		-1,
+		"Numeric GID applied to the log file via chown after Open; -1 leaves group unchanged",
+	)
+	if err := viper.BindPFlag(config.SBSH_ROOT_TERM_LOG_FILE_GID.ViperKey, rootCmd.Flags().Lookup("terminal-log-file-gid")); err != nil {
+		return err
+	}
+	if err := viper.BindEnv(config.SBSH_ROOT_TERM_LOG_FILE_GID.ViperKey, config.SBSH_ROOT_TERM_LOG_FILE_GID.EnvVar()); err != nil {
+		return err
+	}
+
 	rootCmd.Flags().Bool("terminal-disable-set-prompt", false, "Disable setting the prompt")
 	if err := viper.BindPFlag(config.SBSH_ROOT_TERM_DISABLE_SET_PROMPT.ViperKey, rootCmd.Flags().Lookup("terminal-disable-set-prompt")); err != nil {
 		return err
@@ -477,12 +529,26 @@ func runClient(
 // 0 = root", which is required because the runner would otherwise try
 // to chown to gid 0 and fail under non-root callers.
 func readRootSocketGID(cmd *cobra.Command) *int {
-	if cmd.Flags().Changed("terminal-socket-gid") {
-		if v, err := cmd.Flags().GetInt("terminal-socket-gid"); err == nil {
+	return readRootGIDFlag(cmd, "terminal-socket-gid", config.SBSH_ROOT_TERM_SOCKET_GID.EnvVar())
+}
+
+// readRootCaptureGID mirrors readRootSocketGID for --terminal-capture-gid.
+func readRootCaptureGID(cmd *cobra.Command) *int {
+	return readRootGIDFlag(cmd, "terminal-capture-gid", config.SBSH_ROOT_TERM_CAPTURE_GID.EnvVar())
+}
+
+// readRootLogFileGID mirrors readRootSocketGID for --terminal-log-file-gid.
+func readRootLogFileGID(cmd *cobra.Command) *int {
+	return readRootGIDFlag(cmd, "terminal-log-file-gid", config.SBSH_ROOT_TERM_LOG_FILE_GID.EnvVar())
+}
+
+func readRootGIDFlag(cmd *cobra.Command, flagName, envName string) *int {
+	if cmd.Flags().Changed(flagName) {
+		if v, err := cmd.Flags().GetInt(flagName); err == nil {
 			return &v
 		}
 	}
-	if envStr, ok := os.LookupEnv(config.SBSH_ROOT_TERM_SOCKET_GID.EnvVar()); ok && envStr != "" {
+	if envStr, ok := os.LookupEnv(envName); ok && envStr != "" {
 		if v, err := strconv.Atoi(envStr); err == nil {
 			return &v
 		}

--- a/cmd/sbsh/terminal/terminal.go
+++ b/cmd/sbsh/terminal/terminal.go
@@ -97,12 +97,28 @@ func checkFileUsage(cmd *cobra.Command, _ []string) error {
 // viper.GetInt is unreliable here because BindPFlag only forwards a
 // *changed* pflag to viper.
 func readSocketGID(cmd *cobra.Command) *int {
-	if cmd.Flags().Changed("socket-gid") {
-		if v, err := cmd.Flags().GetInt("socket-gid"); err == nil {
+	return readGIDFlag(cmd, "socket-gid", config.SBSH_TERM_SOCKET_GID.EnvVar())
+}
+
+// readCaptureGID mirrors readSocketGID for --capture-gid. The same
+// pointer-vs-sentinel discipline applies: gid 0 (root) is a valid value
+// and must remain distinguishable from "unset, leave the group alone".
+func readCaptureGID(cmd *cobra.Command) *int {
+	return readGIDFlag(cmd, "capture-gid", config.SBSH_TERM_CAPTURE_GID.EnvVar())
+}
+
+// readLogFileGID mirrors readSocketGID for --log-file-gid.
+func readLogFileGID(cmd *cobra.Command) *int {
+	return readGIDFlag(cmd, "log-file-gid", config.SBSH_TERM_LOG_FILE_GID.EnvVar())
+}
+
+func readGIDFlag(cmd *cobra.Command, flagName, envName string) *int {
+	if cmd.Flags().Changed(flagName) {
+		if v, err := cmd.Flags().GetInt(flagName); err == nil {
 			return &v
 		}
 	}
-	if envStr, ok := os.LookupEnv(config.SBSH_TERM_SOCKET_GID.EnvVar()); ok && envStr != "" {
+	if envStr, ok := os.LookupEnv(envName); ok && envStr != "" {
 		if v, err := strconv.Atoi(envStr); err == nil {
 			return &v
 		}
@@ -141,6 +157,10 @@ func buildTerminalSpecFromFlags(
 			SocketFile:       viper.GetString(config.SBSH_TERM_SOCKET.ViperKey),
 			SocketMode:       viper.GetString(config.SBSH_TERM_SOCKET_MODE.ViperKey),
 			SocketGID:        readSocketGID(cmd),
+			CaptureMode:      viper.GetString(config.SBSH_TERM_CAPTURE_MODE.ViperKey),
+			CaptureGID:       readCaptureGID(cmd),
+			LogFileMode:      viper.GetString(config.SBSH_TERM_LOG_FILE_MODE.ViperKey),
+			LogFileGID:       readLogFileGID(cmd),
 			DisableSetPrompt: viper.GetBool(config.SBSH_TERM_DISABLE_SET_PROMPT.ViperKey),
 			ShutdownGrace:    viper.GetDuration(config.SBSH_TERM_SHUTDOWN_GRACE.ViperKey),
 		},
@@ -452,6 +472,38 @@ func setupTerminalCmdFlags(terminalCmd *cobra.Command) {
 	)
 	_ = viper.BindPFlag(config.SBSH_TERM_SOCKET_GID.ViperKey, terminalCmd.Flags().Lookup("socket-gid"))
 	_ = viper.BindEnv(config.SBSH_TERM_SOCKET_GID.ViperKey, config.SBSH_TERM_SOCKET_GID.EnvVar())
+
+	terminalCmd.Flags().String(
+		"capture-mode",
+		"",
+		"Octal mode applied to the capture file after Open (default 0600)",
+	)
+	_ = viper.BindPFlag(config.SBSH_TERM_CAPTURE_MODE.ViperKey, terminalCmd.Flags().Lookup("capture-mode"))
+	_ = viper.BindEnv(config.SBSH_TERM_CAPTURE_MODE.ViperKey, config.SBSH_TERM_CAPTURE_MODE.EnvVar())
+
+	terminalCmd.Flags().Int(
+		"capture-gid",
+		-1,
+		"Numeric GID applied to the capture file via chown after Open; -1 leaves group unchanged",
+	)
+	_ = viper.BindPFlag(config.SBSH_TERM_CAPTURE_GID.ViperKey, terminalCmd.Flags().Lookup("capture-gid"))
+	_ = viper.BindEnv(config.SBSH_TERM_CAPTURE_GID.ViperKey, config.SBSH_TERM_CAPTURE_GID.EnvVar())
+
+	terminalCmd.Flags().String(
+		"log-file-mode",
+		"",
+		"Octal mode applied to the log file after Open (default 0600)",
+	)
+	_ = viper.BindPFlag(config.SBSH_TERM_LOG_FILE_MODE.ViperKey, terminalCmd.Flags().Lookup("log-file-mode"))
+	_ = viper.BindEnv(config.SBSH_TERM_LOG_FILE_MODE.ViperKey, config.SBSH_TERM_LOG_FILE_MODE.EnvVar())
+
+	terminalCmd.Flags().Int(
+		"log-file-gid",
+		-1,
+		"Numeric GID applied to the log file via chown after Open; -1 leaves group unchanged",
+	)
+	_ = viper.BindPFlag(config.SBSH_TERM_LOG_FILE_GID.ViperKey, terminalCmd.Flags().Lookup("log-file-gid"))
+	_ = viper.BindEnv(config.SBSH_TERM_LOG_FILE_GID.ViperKey, config.SBSH_TERM_LOG_FILE_GID.EnvVar())
 
 	terminalCmd.Flags().StringP("file", "f", "", "Optional JSON file with the terminal spec (use '-' for stdin)")
 	_ = viper.BindPFlag(config.SBSH_TERM_SPEC.ViperKey, terminalCmd.Flags().Lookup("file"))

--- a/docs/profiles/README.md
+++ b/docs/profiles/README.md
@@ -85,6 +85,12 @@ spec:
   socket: # Control-socket permissions (optional)
     mode: "0660" # Octal string; defaults to 0600 if omitted
     gid: 986 # Numeric host GID; omit to leave the group unchanged
+  capture: # Capture-transcript permissions (optional)
+    mode: "0640" # Octal string; defaults to 0600 if omitted
+    gid: 986 # Numeric host GID; omit to leave the group unchanged
+  logFile: # Per-terminal log-file permissions (optional)
+    mode: "0640" # Octal string; defaults to 0600 if omitted
+    gid: 986 # Numeric host GID; omit to leave the group unchanged
 ```
 
 ## Field Reference
@@ -234,6 +240,99 @@ their own flag:
 
 Widening the mode and setting a host group is opt-in for callers that share a
 terminal across uids in the same group; the default (no `socket` block, no
+flag) preserves owner-only access exactly as in earlier releases.
+
+#### `capture` section (optional)
+
+Configures the filesystem permissions of the terminal's capture transcript —
+the on-disk file that records the terminal's PTY output for later replay via
+`sb log <terminal>`. Both fields are optional; omitting the block keeps the
+legacy owner-only behavior (`-rw------- runner-uid:runner-gid`), which is the
+right default when no other uid needs to read the transcript.
+
+```yaml
+spec:
+  # ...
+  capture:
+    mode: "0640" # Octal string; defaults to "0600" if omitted
+    gid: 986 # Numeric host GID; omit to leave group unchanged
+```
+
+**`mode`** (optional, default `"0600"`)
+
+- Octal string applied via `chmod` after each `OpenFile` of the capture path
+  (including reopens triggered by terminal restarts)
+- Quote it (`"0640"`) so YAML does not silently re-parse octal as decimal
+- The leading `0` is optional — both `"0640"` and `"640"` work
+- Mode bits outside `0o7777` are rejected at profile load
+
+**`gid`** (optional, default unset)
+
+- Numeric host GID applied via `chown(captureFile, -1, gid)` after each
+  `OpenFile` of the capture path
+- The runner's uid stays the owner; only the group is rewritten
+- Omit the field (or leave it `null`) to leave the capture file's group at
+  the runner's primary group
+
+The same configuration can also be supplied at launch time and overrides the
+profile when set. The root command and the `terminal` subcommand each take
+their own flag:
+
+- `sbsh --terminal-capture-mode 0640 --terminal-capture-gid 986`
+  (or `SBSH_ROOT_TERM_CAPTURE_MODE=0640` / `SBSH_ROOT_TERM_CAPTURE_GID=986`)
+- `sbsh terminal --capture-mode 0640 --capture-gid 986`
+  (or `SBSH_TERM_CAPTURE_MODE=0640` / `SBSH_TERM_CAPTURE_GID=986`)
+
+Widening the mode and setting a host group is opt-in for callers that need a
+shared group (for example, a `kuke`-style log viewer running under a separate
+uid in the same group) to read the transcript; the default (no `capture`
+block, no flag) preserves owner-only access exactly as in earlier releases.
+
+#### `logFile` section (optional)
+
+Configures the filesystem permissions of the terminal's per-instance log
+file — the structured runner log that `sb log <terminal>` and `kuke log` tail
+for diagnostics. Both fields are optional; omitting the block keeps the legacy
+owner-only behavior (`-rw------- runner-uid:runner-gid`), which is the right
+default when no other uid needs to read the log.
+
+```yaml
+spec:
+  # ...
+  logFile:
+    mode: "0640" # Octal string; defaults to "0600" if omitted
+    gid: 986 # Numeric host GID; omit to leave group unchanged
+```
+
+**`mode`** (optional, default `"0600"`)
+
+- Octal string applied via `chmod` against the log file path after the runner
+  starts (the file itself is opened by the parent process, then re-permed in
+  the runner once the resolved spec is known)
+- Quote it (`"0640"`) so YAML does not silently re-parse octal as decimal
+- The leading `0` is optional — both `"0640"` and `"640"` work
+- Mode bits outside `0o7777` are rejected at profile load
+
+**`gid`** (optional, default unset)
+
+- Numeric host GID applied via `chown(logFile, -1, gid)` after the runner
+  starts
+- The runner's uid stays the owner; only the group is rewritten
+- Omit the field (or leave it `null`) to leave the log file's group at the
+  runner's primary group
+
+The same configuration can also be supplied at launch time and overrides the
+profile when set. The root command and the `terminal` subcommand each take
+their own flag:
+
+- `sbsh --terminal-log-file-mode 0640 --terminal-log-file-gid 986`
+  (or `SBSH_ROOT_TERM_LOG_FILE_MODE=0640` /
+  `SBSH_ROOT_TERM_LOG_FILE_GID=986`)
+- `sbsh terminal --log-file-mode 0640 --log-file-gid 986`
+  (or `SBSH_TERM_LOG_FILE_MODE=0640` / `SBSH_TERM_LOG_FILE_GID=986`)
+
+Widening the mode and setting a host group is opt-in for callers that share a
+log viewer across uids in the same group; the default (no `logFile` block, no
 flag) preserves owner-only access exactly as in earlier releases.
 
 ## Example Profiles

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -99,42 +99,71 @@ func CreateTerminalFromProfile(profile *api.TerminalProfileDoc) (*api.TerminalSp
 		Stages:      profile.Spec.Stages,
 	}
 
-	if profile.Spec.Socket != nil {
-		if profile.Spec.Socket.Mode != "" {
-			mode, errMode := parseSocketMode(profile.Spec.Socket.Mode)
-			if errMode != nil {
-				return nil, fmt.Errorf(
-					"invalid spec.socket.mode in profile %q: %w",
-					profile.Metadata.Name,
-					errMode,
-				)
-			}
-			spec.SocketMode = mode
-		}
-		if profile.Spec.Socket.GID != nil {
-			g := *profile.Spec.Socket.GID
-			if g < 0 {
-				return nil, fmt.Errorf(
-					"invalid spec.socket.gid in profile %q: must be non-negative, got %d",
-					profile.Metadata.Name,
-					g,
-				)
-			}
-			spec.SocketGID = &g
-		}
+	if errPerm := applyProfilePermBlock(
+		profile.Spec.Socket, profile.Metadata.Name, "spec.socket",
+		&spec.SocketMode, &spec.SocketGID,
+	); errPerm != nil {
+		return nil, errPerm
+	}
+	if errPerm := applyProfilePermBlock(
+		profile.Spec.Capture, profile.Metadata.Name, "spec.capture",
+		&spec.CaptureMode, &spec.CaptureGID,
+	); errPerm != nil {
+		return nil, errPerm
+	}
+	if errPerm := applyProfilePermBlock(
+		profile.Spec.LogFile, profile.Metadata.Name, "spec.logFile",
+		&spec.LogFileMode, &spec.LogFileGID,
+	); errPerm != nil {
+		return nil, errPerm
 	}
 
 	return spec, nil
 }
 
+// applyProfilePermBlock validates and copies a profile's permissions block
+// (socket / capture / logFile — all share api.FilePermSpec) into the
+// matching TerminalSpec fields. fieldPath ("spec.socket" etc.) is folded
+// into error messages so callers can locate the offending YAML field.
+func applyProfilePermBlock(
+	block *api.FilePermSpec,
+	profileName, fieldPath string,
+	mode *os.FileMode,
+	gid **int,
+) error {
+	if block == nil {
+		return nil
+	}
+	if block.Mode != "" {
+		m, err := parseFileMode(block.Mode)
+		if err != nil {
+			return fmt.Errorf("invalid %s.mode in profile %q: %w", fieldPath, profileName, err)
+		}
+		*mode = m
+	}
+	if block.GID != nil {
+		g := *block.GID
+		if g < 0 {
+			return fmt.Errorf(
+				"invalid %s.gid in profile %q: must be non-negative, got %d",
+				fieldPath, profileName, g,
+			)
+		}
+		*gid = &g
+	}
+	return nil
+}
+
 // chmodMask is the standard chmod surface: setuid/setgid/sticky plus the nine
-// rwx bits. parseSocketMode rejects any mode with bits outside this mask.
+// rwx bits. parseFileMode rejects any mode with bits outside this mask.
 const chmodMask uint64 = 0o7777
 
-// parseSocketMode parses an octal mode string like "0660" or "660" into an
+// parseFileMode parses an octal mode string like "0660" or "660" into an
 // os.FileMode and rejects modes with bits outside chmodMask. The leading "0"
 // is optional because strconv.ParseUint with base 8 accepts both forms.
-func parseSocketMode(s string) (os.FileMode, error) {
+// Used for the control socket, capture file, and log file permission blocks
+// — all three share the same syntax surface.
+func parseFileMode(s string) (os.FileMode, error) {
 	n, err := strconv.ParseUint(s, 8, 32)
 	if err != nil {
 		return 0, fmt.Errorf("not an octal mode: %w", err)
@@ -176,7 +205,21 @@ type BuildTerminalSpecParams struct {
 	// the profile / leave the group unchanged. A nil pointer is required
 	// because a zero int is a valid GID (root), so we can't conflate it
 	// with "unset".
-	SocketGID        *int
+	SocketGID *int
+	// CaptureMode is the raw octal flag value applied to the capture
+	// file. Empty means "no override; fall through to the profile or the
+	// runner default".
+	CaptureMode string
+	// CaptureGID is the numeric GID flag value for the capture file, or
+	// nil to fall through to the profile / leave the group unchanged.
+	CaptureGID *int
+	// LogFileMode is the raw octal flag value applied to the log file.
+	// Empty means "no override; fall through to the profile or the runner
+	// default".
+	LogFileMode string
+	// LogFileGID is the numeric GID flag value for the log file, or nil
+	// to fall through to the profile / leave the group unchanged.
+	LogFileGID       *int
 	EnvVars          []string
 	DisableSetPrompt bool
 	ShutdownGrace    time.Duration
@@ -303,29 +346,60 @@ func BuildTerminalSpec(
 		return nil, errCreate
 	}
 	addInputValuesToTerminal(terminalSpec, input)
-	if errSocket := applySocketOverrides(terminalSpec, input); errSocket != nil {
-		return nil, errSocket
+	if errOv := applyPermOverrides(terminalSpec, input); errOv != nil {
+		return nil, errOv
 	}
 
 	return terminalSpec, nil
 }
 
-// applySocketOverrides resolves the socket mode/gid precedence: explicit
-// flag/env values win over the profile's spec.socket; unset stays at
-// whatever CreateTerminalFromProfile produced (which is the profile value
-// or the zero value, the latter telling the runner to use 0o600 with no
-// chown).
-func applySocketOverrides(spec *api.TerminalSpec, input *BuildTerminalSpecParams) error {
-	if input.SocketMode != "" {
-		mode, err := parseSocketMode(input.SocketMode)
-		if err != nil {
-			return fmt.Errorf("%w: invalid socket mode %q: %w", errdefs.ErrInvalidFlag, input.SocketMode, err)
-		}
-		spec.SocketMode = mode
+// applyPermOverrides resolves the mode/gid precedence for the socket,
+// capture, and log files: explicit flag/env values win over the profile's
+// matching spec block; unset stays at whatever CreateTerminalFromProfile
+// produced (which is the profile value or the zero value, the latter
+// telling the runner to use 0o600 with no chown).
+func applyPermOverrides(spec *api.TerminalSpec, input *BuildTerminalSpecParams) error {
+	if err := applyOnePermOverride(
+		input.SocketMode, input.SocketGID, "socket",
+		&spec.SocketMode, &spec.SocketGID,
+	); err != nil {
+		return err
 	}
-	if input.SocketGID != nil {
-		g := *input.SocketGID
-		spec.SocketGID = &g
+	if err := applyOnePermOverride(
+		input.CaptureMode, input.CaptureGID, "capture",
+		&spec.CaptureMode, &spec.CaptureGID,
+	); err != nil {
+		return err
+	}
+	if err := applyOnePermOverride(
+		input.LogFileMode, input.LogFileGID, "log-file",
+		&spec.LogFileMode, &spec.LogFileGID,
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
+// applyOnePermOverride applies an explicit flag/env override (rawMode +
+// gidPtr) onto the matching TerminalSpec fields. label is folded into
+// error messages so callers see which artifact rejected the input.
+func applyOnePermOverride(
+	rawMode string,
+	gidPtr *int,
+	label string,
+	mode *os.FileMode,
+	gid **int,
+) error {
+	if rawMode != "" {
+		m, err := parseFileMode(rawMode)
+		if err != nil {
+			return fmt.Errorf("%w: invalid %s mode %q: %w", errdefs.ErrInvalidFlag, label, rawMode, err)
+		}
+		*mode = m
+	}
+	if gidPtr != nil {
+		g := *gidPtr
+		*gid = &g
 	}
 	return nil
 }

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -94,7 +94,7 @@ func TestCreateTerminalFromProfile_AcceptsValidGID(t *testing.T) {
 	}
 }
 
-func TestParseSocketMode(t *testing.T) {
+func TestParseFileMode(t *testing.T) {
 	tests := []struct {
 		name    string
 		in      string
@@ -115,19 +115,200 @@ func TestParseSocketMode(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := parseSocketMode(tc.in)
+			got, err := parseFileMode(tc.in)
 			if tc.wantErr {
 				if err == nil {
-					t.Fatalf("parseSocketMode(%q): want error, got mode 0o%o", tc.in, got)
+					t.Fatalf("parseFileMode(%q): want error, got mode 0o%o", tc.in, got)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("parseSocketMode(%q): unexpected error: %v", tc.in, err)
+				t.Fatalf("parseFileMode(%q): unexpected error: %v", tc.in, err)
 			}
 			if got != tc.want {
-				t.Fatalf("parseSocketMode(%q): want 0o%o, got 0o%o", tc.in, tc.want, got)
+				t.Fatalf("parseFileMode(%q): want 0o%o, got 0o%o", tc.in, tc.want, got)
 			}
 		})
+	}
+}
+
+// CreateTerminalFromProfile must reject negative gids in the capture or
+// logFile permission blocks the same way it does for the socket block. The
+// error messages must name the specific spec.<block>.gid field so the
+// caller can locate the offending YAML key without grepping.
+func TestCreateTerminalFromProfile_RejectsNegativeArtifactGID(t *testing.T) {
+	bad := -1
+	tests := []struct {
+		name      string
+		mutate    func(p *api.TerminalProfileDoc)
+		fieldPath string
+	}{
+		{
+			name: "capture",
+			mutate: func(p *api.TerminalProfileDoc) {
+				p.Spec.Capture = &api.FilePermSpec{GID: &bad}
+			},
+			fieldPath: "spec.capture.gid",
+		},
+		{
+			name: "logFile",
+			mutate: func(p *api.TerminalProfileDoc) {
+				p.Spec.LogFile = &api.FilePermSpec{GID: &bad}
+			},
+			fieldPath: "spec.logFile.gid",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &api.TerminalProfileDoc{
+				APIVersion: api.APIVersionV1Beta1,
+				Kind:       api.KindTerminalProfile,
+				Metadata:   api.TerminalProfileMetadata{Name: "tprof"},
+				Spec: api.TerminalProfileSpec{
+					RunTarget: api.RunTargetLocal,
+					Shell:     api.ShellSpec{Cmd: "/bin/bash"},
+				},
+			}
+			tc.mutate(p)
+			_, err := CreateTerminalFromProfile(p)
+			if err == nil {
+				t.Fatalf("expected error for negative gid in %s", tc.fieldPath)
+			}
+			if !strings.Contains(err.Error(), tc.fieldPath) {
+				t.Fatalf("error %q should mention %s", err.Error(), tc.fieldPath)
+			}
+			if !strings.Contains(err.Error(), "tprof") {
+				t.Fatalf("error %q should mention profile name", err.Error())
+			}
+		})
+	}
+}
+
+// A profile that supplies capture/logFile mode + gid must thread both into
+// the produced TerminalSpec verbatim. The pointer-vs-sentinel discipline
+// (nil = unset, *gid = explicit) must survive the copy.
+func TestCreateTerminalFromProfile_AppliesArtifactPermBlocks(t *testing.T) {
+	gidCapture := 1001
+	gidLog := 2002
+	p := &api.TerminalProfileDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindTerminalProfile,
+		Metadata:   api.TerminalProfileMetadata{Name: "tprof"},
+		Spec: api.TerminalProfileSpec{
+			RunTarget: api.RunTargetLocal,
+			Shell:     api.ShellSpec{Cmd: "/bin/bash"},
+			Capture:   &api.FilePermSpec{Mode: "0640", GID: &gidCapture},
+			LogFile:   &api.FilePermSpec{Mode: "0660", GID: &gidLog},
+		},
+	}
+	spec, err := CreateTerminalFromProfile(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.CaptureMode != 0o640 {
+		t.Fatalf("CaptureMode: want 0o640, got 0o%o", spec.CaptureMode)
+	}
+	if spec.CaptureGID == nil || *spec.CaptureGID != gidCapture {
+		t.Fatalf("CaptureGID: want %d, got %v", gidCapture, spec.CaptureGID)
+	}
+	if spec.LogFileMode != 0o660 {
+		t.Fatalf("LogFileMode: want 0o660, got 0o%o", spec.LogFileMode)
+	}
+	if spec.LogFileGID == nil || *spec.LogFileGID != gidLog {
+		t.Fatalf("LogFileGID: want %d, got %v", gidLog, spec.LogFileGID)
+	}
+}
+
+// Omitting the capture/logFile blocks must leave the spec at the runner
+// defaults: zero-valued FileMode (the runner falls back to 0o600) and a
+// nil gid pointer (the runner leaves the group unchanged).
+func TestCreateTerminalFromProfile_OmittedArtifactBlocksLeaveDefaults(t *testing.T) {
+	p := &api.TerminalProfileDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindTerminalProfile,
+		Metadata:   api.TerminalProfileMetadata{Name: "tprof"},
+		Spec: api.TerminalProfileSpec{
+			RunTarget: api.RunTargetLocal,
+			Shell:     api.ShellSpec{Cmd: "/bin/bash"},
+		},
+	}
+	spec, err := CreateTerminalFromProfile(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.CaptureMode != 0 {
+		t.Fatalf("CaptureMode: want 0 (runner default), got 0o%o", spec.CaptureMode)
+	}
+	if spec.CaptureGID != nil {
+		t.Fatalf("CaptureGID: want nil, got %d", *spec.CaptureGID)
+	}
+	if spec.LogFileMode != 0 {
+		t.Fatalf("LogFileMode: want 0 (runner default), got 0o%o", spec.LogFileMode)
+	}
+	if spec.LogFileGID != nil {
+		t.Fatalf("LogFileGID: want nil, got %d", *spec.LogFileGID)
+	}
+}
+
+// applyOnePermOverride: an empty rawMode and nil gid leave prior values
+// untouched, so profile-resolved values survive when the caller passes
+// nothing.
+func TestApplyOnePermOverride_NoOverrideKeepsPrior(t *testing.T) {
+	gid7 := 7
+	mode := os.FileMode(0o640)
+	gid := &gid7
+	if err := applyOnePermOverride("", nil, "capture", &mode, &gid); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mode != 0o640 {
+		t.Fatalf("mode: want 0o640, got 0o%o", mode)
+	}
+	if gid == nil || *gid != 7 {
+		t.Fatalf("gid: want 7, got %v", gid)
+	}
+}
+
+// applyOnePermOverride: a non-empty mode string parses and overwrites the
+// prior value.
+func TestApplyOnePermOverride_ExplicitModeReplacesPrior(t *testing.T) {
+	mode := os.FileMode(0)
+	var gid *int
+	if err := applyOnePermOverride("0660", nil, "capture", &mode, &gid); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mode != 0o660 {
+		t.Fatalf("mode: want 0o660, got 0o%o", mode)
+	}
+	if gid != nil {
+		t.Fatalf("gid: want nil, got %d", *gid)
+	}
+}
+
+// applyOnePermOverride: a non-nil gid pointer overwrites with the
+// dereferenced value, including the zero value (root).
+func TestApplyOnePermOverride_ExplicitGIDReplacesPrior(t *testing.T) {
+	gid7 := 7
+	mode := os.FileMode(0)
+	var gid *int
+	if err := applyOnePermOverride("", &gid7, "capture", &mode, &gid); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gid == nil || *gid != 7 {
+		t.Fatalf("gid: want 7, got %v", gid)
+	}
+}
+
+// applyOnePermOverride: an invalid octal mode surfaces an
+// ErrInvalidFlag-wrapped error so callers can distinguish bad-input from
+// internal failures.
+func TestApplyOnePermOverride_InvalidModeSurfacesErrInvalidFlag(t *testing.T) {
+	mode := os.FileMode(0)
+	var gid *int
+	err := applyOnePermOverride("rw-", nil, "capture", &mode, &gid)
+	if err == nil {
+		t.Fatal("expected error for invalid mode, got nil")
+	}
+	if !errors.Is(err, errdefs.ErrInvalidFlag) {
+		t.Fatalf("error %v should wrap errdefs.ErrInvalidFlag", err)
 	}
 }

--- a/internal/terminal/terminalrunner/lifecycle.go
+++ b/internal/terminal/terminalrunner/lifecycle.go
@@ -43,29 +43,66 @@ func (sr *Exec) StartTerminal(evCh chan<- Event) error {
 	}
 	sr.evCh = evCh
 
-	// 2) Prepare terminal command
+	// 2) Tighten/relax the per-terminal log file's permissions per the
+	//    spec. The file was created by SetupFileLogger before the runner
+	//    started, so it already exists at 0o600; this re-chmods (and
+	//    optionally chowns the group) to match the resolved mode/gid.
+	//    Skip silently when the spec did not name a log file — some test
+	//    fakes wire a stderr-only logger and leave the path empty.
+	if err := sr.applyLogFilePerms(); err != nil {
+		sr.logger.Error("failed to apply log file perms", "id", sr.id, "err", err)
+		return fmt.Errorf("failed to apply log file perms for terminal %s: %w", sr.id, err)
+	}
+
+	// 3) Prepare terminal command
 	if err := sr.prepareTerminalCommand(); err != nil {
 		sr.logger.Error("failed to run terminal command", "id", sr.id, "err", err)
 		return fmt.Errorf("failed to run terminal command for terminal %s: %w", sr.id, err)
 	}
 
-	// 3) Start PTY
+	// 4) Start PTY
 	if err := sr.startPty(); err != nil {
 		sr.logger.Error("failed to start PTY", "id", sr.id, "err", err)
 		return fmt.Errorf("failed to start PTY for terminal %s: %w", sr.id, err)
 	}
 
-	// 4) Update state to Starting
+	// 5) Update state to Starting
 	if err := sr.updateTerminalState(api.Starting); err != nil {
 		sr.logger.Error("failed to update terminal state on starting", "id", sr.id, "err", err)
 		return fmt.Errorf("failed to update terminal state on starting: %w", err)
 	}
 
-	// 5) Wait for terminal to close in background
+	// 6) Wait for terminal to close in background
 	sr.logger.Info("PTY started", "id", sr.id)
 	go sr.waitOnTerminal()
 
 	return nil
+}
+
+// applyLogFilePerms re-chmods (and optionally chowns the group of) the
+// per-terminal log file. The file is created by SetupFileLogger in the
+// parent process before the runner starts, so by the time we reach this
+// step it already exists at 0o600. The chmod/chown is by path because
+// the runner does not own the file handle.
+//
+// An empty Spec.LogFile is treated as "no log file configured" and the
+// step is a no-op — this keeps test runners that use an io.Discard
+// logger from tripping a missing-file error.
+func (sr *Exec) applyLogFilePerms() error {
+	sr.metadataMu.RLock()
+	logFile := sr.metadata.Spec.LogFile
+	mode := sr.metadata.Spec.LogFileMode
+	var gid *int
+	if g := sr.metadata.Spec.LogFileGID; g != nil {
+		gv := *g
+		gid = &gv
+	}
+	sr.metadataMu.RUnlock()
+
+	if logFile == "" {
+		return nil
+	}
+	return sr.applyArtifactPerms("log-file", logFile, mode, gid)
 }
 
 func (sr *Exec) waitOnTerminal() {

--- a/internal/terminal/terminalrunner/sockets.go
+++ b/internal/terminal/terminalrunner/sockets.go
@@ -31,6 +31,52 @@ import (
 // spec.socket.mode field.
 const defaultSocketMode os.FileMode = 0o600
 
+// defaultArtifactMode is the legacy owner-only mode applied when the
+// spec leaves CaptureMode / LogFileMode at their zero value. Group or
+// world access is opt-in via the matching --capture-* / --log-file-*
+// flags, env vars, or profile blocks. Same contract shape as
+// defaultSocketMode for the control socket.
+const defaultArtifactMode os.FileMode = 0o600
+
+// applyArtifactPerms chmods (and optionally chowns the group of) a
+// per-terminal artifact path that was just opened. Used for the capture
+// transcript and the log file — the control socket has its own helper in
+// OpenSocketCtrl because the path needs to be removed first and the
+// listener has to be torn down on failure.
+//
+// mode == 0 falls back to defaultArtifactMode so callers can pass the
+// raw spec field through without a guard. gid == nil leaves the group
+// unchanged. The chown form is Chown(path, -1, gid) so the listener's
+// uid stays the owner; only the group is rewritten.
+func (sr *Exec) applyArtifactPerms(label, path string, mode os.FileMode, gid *int) error {
+	if mode == 0 {
+		mode = defaultArtifactMode
+	}
+	if errChmod := os.Chmod(path, mode); errChmod != nil {
+		sr.logger.Error(
+			"applyArtifactPerms: chmod failed",
+			"artifact", label,
+			"path", path,
+			"mode", fmt.Sprintf("0o%o", mode),
+			"error", errChmod,
+		)
+		return fmt.Errorf("chmod %s: %w", label, errChmod)
+	}
+	if gid != nil {
+		if errChown := os.Chown(path, -1, *gid); errChown != nil {
+			sr.logger.Error(
+				"applyArtifactPerms: chown failed",
+				"artifact", label,
+				"path", path,
+				"gid", *gid,
+				"error", errChown,
+			)
+			return fmt.Errorf("chown %s: %w", label, errChown)
+		}
+	}
+	return nil
+}
+
 func (sr *Exec) OpenSocketCtrl() error {
 	sr.metadataMu.Lock()
 	socketFile := sr.metadata.Spec.SocketFile

--- a/internal/terminal/terminalrunner/terminal.go
+++ b/internal/terminal/terminalrunner/terminal.go
@@ -180,10 +180,24 @@ func (sr *Exec) startPty() error {
 
 	sr.metadataMu.RLock()
 	captureFile := sr.metadata.Spec.CaptureFile
+	captureMode := sr.metadata.Spec.CaptureMode
+	var captureGID *int
+	if g := sr.metadata.Spec.CaptureGID; g != nil {
+		gv := *g
+		captureGID = &gv
+	}
 	sr.metadataMu.RUnlock()
+	// Open at the legacy 0o600 first; applyArtifactPerms re-chmods to
+	// the resolved mode (and optionally chowns the group). Doing the
+	// permissions step explicitly after Open mirrors the socket path and
+	// also covers reopens of a pre-existing inode (see issue #200).
 	logf, errO := os.OpenFile(captureFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
 	if errO != nil {
 		return fmt.Errorf("open log file: %w", errO)
+	}
+	if errPerm := sr.applyArtifactPerms("capture", captureFile, captureMode, captureGID); errPerm != nil {
+		_ = logf.Close()
+		return errPerm
 	}
 
 	if errU := sr.updateMetadata(); errU != nil {

--- a/pkg/api/profile.go
+++ b/pkg/api/profile.go
@@ -58,21 +58,30 @@ type TerminalProfileMetadata struct {
 }
 
 type TerminalProfileSpec struct {
-	RunTarget     RunTarget     `json:"runTarget"        yaml:"runTarget"`
-	RestartPolicy RestartPolicy `json:"restartPolicy"    yaml:"restartPolicy"`
-	Shell         ShellSpec     `json:"shell"            yaml:"shell"`
-	Stages        StagesSpec    `json:"stages"           yaml:"stages"`
-	Socket        *SocketSpec   `json:"socket,omitempty" yaml:"socket,omitempty"`
+	RunTarget     RunTarget     `json:"runTarget"         yaml:"runTarget"`
+	RestartPolicy RestartPolicy `json:"restartPolicy"     yaml:"restartPolicy"`
+	Shell         ShellSpec     `json:"shell"             yaml:"shell"`
+	Stages        StagesSpec    `json:"stages"            yaml:"stages"`
+	Socket        *FilePermSpec `json:"socket,omitempty"  yaml:"socket,omitempty"`
+	Capture       *FilePermSpec `json:"capture,omitempty" yaml:"capture,omitempty"`
+	LogFile       *FilePermSpec `json:"logFile,omitempty" yaml:"logFile,omitempty"`
 }
 
-// SocketSpec configures the control socket's filesystem permissions. Both
+// FilePermSpec configures the filesystem permissions of a per-terminal
+// runtime artifact (control socket, capture transcript, log file). Both
 // fields are optional; omitting the block keeps the legacy 0600 owner-only
-// behavior. Mode is an octal string ("0660") to avoid YAML's int/octal
-// ambiguity; Gid is a numeric host GID (nil leaves the group unchanged).
-type SocketSpec struct {
+// behavior for that artifact. Mode is an octal string ("0660") to avoid
+// YAML's int/octal ambiguity; GID is a numeric host GID (nil leaves the
+// group unchanged).
+type FilePermSpec struct {
 	Mode string `json:"mode,omitempty" yaml:"mode,omitempty"`
 	GID  *int   `json:"gid,omitempty"  yaml:"gid,omitempty"`
 }
+
+// SocketSpec is the historical name for FilePermSpec introduced in #188 for
+// the spec.socket block. Kept as a type alias so external consumers that
+// reference api.SocketSpec keep compiling unchanged.
+type SocketSpec = FilePermSpec
 
 // ShellSpec describes the base interactive process that owns the terminal lifetime.
 type ShellSpec struct {

--- a/pkg/api/terminal.go
+++ b/pkg/api/terminal.go
@@ -81,6 +81,22 @@ type TerminalSpec struct {
 	// after Listen. nil leaves the group unchanged.
 	SocketGID *int `json:"socketGid,omitempty"`
 
+	// CaptureMode is the chmod applied to the per-terminal capture file
+	// after Open. Zero means "use the runner default" (0600), preserving
+	// owner-only behavior for callers that never set the field.
+	CaptureMode os.FileMode `json:"captureMode,omitempty"`
+	// CaptureGID is the numeric GID applied via chown(capture, -1, gid)
+	// after Open. nil leaves the group unchanged.
+	CaptureGID *int `json:"captureGid,omitempty"`
+
+	// LogFileMode is the chmod applied to the per-terminal log file after
+	// it is opened. Zero means "use the runner default" (0600), preserving
+	// owner-only behavior for callers that never set the field.
+	LogFileMode os.FileMode `json:"logFileMode,omitempty"`
+	// LogFileGID is the numeric GID applied via chown(logfile, -1, gid)
+	// after the log file is opened. nil leaves the group unchanged.
+	LogFileGID *int `json:"logFileGid,omitempty"`
+
 	ProfileName string     `json:"profileName"`
 	Stages      StagesSpec `json:"stages"`
 

--- a/pkg/builder/terminal.go
+++ b/pkg/builder/terminal.go
@@ -42,7 +42,11 @@ type terminalConfig struct {
 	envVars          []string
 	cwd              string
 	captureFile      string
+	captureMode      string
+	captureGID       *int
 	logFile          string
+	logFileMode      string
+	logFileGID       *int
 	logLevel         string
 	socketFile       string
 	socketMode       string
@@ -163,6 +167,46 @@ func WithSocketGID(gid int) TerminalOption {
 	}
 }
 
+// WithCaptureMode sets the chmod mode applied to the capture file
+// after Open, as an octal string ("0640", "640"). Empty means "no
+// override; fall through to the profile or the runner default
+// (0o600)".
+func WithCaptureMode(mode string) TerminalOption {
+	return func(c *terminalConfig) { c.captureMode = mode }
+}
+
+// WithCaptureGID sets the numeric GID applied via chown to the
+// capture file after Open. Calling this option means "explicitly
+// set"; the zero value is a valid GID (root) and is preserved.
+// Omitting the option leaves the group unchanged (or falls through
+// to the profile).
+func WithCaptureGID(gid int) TerminalOption {
+	return func(c *terminalConfig) {
+		g := gid
+		c.captureGID = &g
+	}
+}
+
+// WithLogFileMode sets the chmod mode applied to the log file
+// after Open, as an octal string ("0640", "640"). Empty means "no
+// override; fall through to the profile or the runner default
+// (0o600)".
+func WithLogFileMode(mode string) TerminalOption {
+	return func(c *terminalConfig) { c.logFileMode = mode }
+}
+
+// WithLogFileGID sets the numeric GID applied via chown to the log
+// file after Open. Calling this option means "explicitly set"; the
+// zero value is a valid GID (root) and is preserved. Omitting the
+// option leaves the group unchanged (or falls through to the
+// profile).
+func WithLogFileGID(gid int) TerminalOption {
+	return func(c *terminalConfig) {
+		g := gid
+		c.logFileGID = &g
+	}
+}
+
 // WithDisableSetPrompt disables sbsh's automatic PS1 injection
 // when true. The default (false) preserves the shell-prompt
 // rewriting behavior.
@@ -212,6 +256,10 @@ func BuildTerminalSpec(
 		SocketFile:       cfg.socketFile,
 		SocketMode:       cfg.socketMode,
 		SocketGID:        cfg.socketGID,
+		CaptureMode:      cfg.captureMode,
+		CaptureGID:       cfg.captureGID,
+		LogFileMode:      cfg.logFileMode,
+		LogFileGID:       cfg.logFileGID,
 		EnvVars:          cfg.envVars,
 		DisableSetPrompt: cfg.disableSetPrompt,
 	})

--- a/pkg/builder/terminal_test.go
+++ b/pkg/builder/terminal_test.go
@@ -409,6 +409,141 @@ func TestBuildTerminalSpec_WithSocketGID(t *testing.T) {
 	}
 }
 
+// WithCaptureMode threads the octal mode string through to spec.CaptureMode.
+// Empty leaves spec.CaptureMode at its zero value (runner default, 0o600).
+func TestBuildTerminalSpec_WithCaptureMode(t *testing.T) {
+	runPath := t.TempDir()
+
+	spec, err := builder.BuildTerminalSpec(context.Background(), testLogger(), runPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.CaptureMode != 0 {
+		t.Fatalf("default captureMode: want 0, got 0o%o", spec.CaptureMode)
+	}
+
+	spec, err = builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithCaptureMode("0640"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.CaptureMode != 0o640 {
+		t.Fatalf("captureMode: want 0o640, got 0o%o", spec.CaptureMode)
+	}
+}
+
+// WithCaptureGID preserves the unset/zero distinction the same way
+// WithSocketGID does: never calling it leaves spec.CaptureGID nil; calling
+// WithCaptureGID(0) sets *spec.CaptureGID to 0.
+func TestBuildTerminalSpec_WithCaptureGID(t *testing.T) {
+	runPath := t.TempDir()
+
+	spec, err := builder.BuildTerminalSpec(context.Background(), testLogger(), runPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.CaptureGID != nil {
+		t.Fatalf("default captureGID: want nil, got %d", *spec.CaptureGID)
+	}
+
+	spec, err = builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithCaptureGID(1234),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.CaptureGID == nil || *spec.CaptureGID != 1234 {
+		t.Fatalf("captureGID: want 1234, got %v", spec.CaptureGID)
+	}
+
+	spec, err = builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithCaptureGID(0),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.CaptureGID == nil || *spec.CaptureGID != 0 {
+		t.Fatalf("captureGID(0): want 0, got %v", spec.CaptureGID)
+	}
+}
+
+// WithLogFileMode threads the octal mode string through to spec.LogFileMode.
+// Empty leaves spec.LogFileMode at its zero value (runner default, 0o600).
+func TestBuildTerminalSpec_WithLogFileMode(t *testing.T) {
+	runPath := t.TempDir()
+
+	spec, err := builder.BuildTerminalSpec(context.Background(), testLogger(), runPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.LogFileMode != 0 {
+		t.Fatalf("default logFileMode: want 0, got 0o%o", spec.LogFileMode)
+	}
+
+	spec, err = builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithLogFileMode("0640"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.LogFileMode != 0o640 {
+		t.Fatalf("logFileMode: want 0o640, got 0o%o", spec.LogFileMode)
+	}
+}
+
+// WithLogFileGID preserves the unset/zero distinction the same way the
+// other GID options do.
+func TestBuildTerminalSpec_WithLogFileGID(t *testing.T) {
+	runPath := t.TempDir()
+
+	spec, err := builder.BuildTerminalSpec(context.Background(), testLogger(), runPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.LogFileGID != nil {
+		t.Fatalf("default logFileGID: want nil, got %d", *spec.LogFileGID)
+	}
+
+	spec, err = builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithLogFileGID(1234),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.LogFileGID == nil || *spec.LogFileGID != 1234 {
+		t.Fatalf("logFileGID: want 1234, got %v", spec.LogFileGID)
+	}
+
+	spec, err = builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithLogFileGID(0),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.LogFileGID == nil || *spec.LogFileGID != 0 {
+		t.Fatalf("logFileGID(0): want 0, got %v", spec.LogFileGID)
+	}
+}
+
 // WithCommand with empty argv (or empty argv[0]) is a no-op.
 func TestBuildTerminalSpec_WithCommandEmpty(t *testing.T) {
 	runPath := t.TempDir()


### PR DESCRIPTION
## Summary

- Capture transcript and per-terminal log file were hard-coded to `0o600` owner-only at open time, blocking the same group-read pattern PR #189 unlocked for the control socket. A `kuke`-style log viewer running under a separate uid in the kukeon group could see the socket but still got `EACCES` on `kuke log <cell>`.
- Wires the same flag/env/profile resolution surface (explicit flag > env > profile > default) to the capture file and log file. Defaults remain `0o600` with no chown so existing deployments are byte-identical.
- Profile schema gains `spec.capture.{mode,gid}` and `spec.logFile.{mode,gid}` blocks (parallel to the existing `spec.socket` block); CLI flags `--capture-mode`, `--capture-gid`, `--log-file-mode`, `--log-file-gid` are added to both the root `sbsh` (with `--terminal-` prefix) and the `sbsh terminal` subcommand.
- Apply happens via `chmod`/`chown` after `OpenFile` rather than via the `OpenFile` mode arg, so reopens (terminal restarts) re-assert the configured mode and gid. The capture path runs inside `startPty`; the log file path runs as a new step in `StartTerminal` because `SetupFileLogger` opens the log file in the parent process before the runner has the resolved spec.
- `SocketSpec` is preserved as a `type SocketSpec = FilePermSpec` alias for backward compatibility with PR #189 consumers.

## Test plan

- [x] `make sbsh-sb` (canonical build target; produces `./sbsh` ELF + `./sb` hardlink)
- [x] `file ./sbsh` confirms ELF executable, not Go static archive
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (full CI test target — package tests + integration build tag + e2e)
- [x] `pre-commit run --files \$(git diff --name-only HEAD)` (golangci-lint, gofmt, addlicense, prettier all clean)
- [x] New unit coverage in `internal/profile/profile_test.go`: capture/logFile profile blocks accepted, negative gids rejected with `spec.<block>.gid` error path, omitted blocks leave runner defaults, `applyOnePermOverride` precedence + `ErrInvalidFlag` wrapping
- [x] New unit coverage in `pkg/builder/terminal_test.go`: `WithCaptureMode`/`WithCaptureGID`/`WithLogFileMode`/`WithLogFileGID` thread through, with the same nil-vs-zero discipline as `WithSocketGID`

Closes #200