### PR TITLE
feat(terminal): expose RPC server as public package pkg/terminal/server

### DIFF
--- a/internal/terminal/terminalrunner/terminal_runner.go
+++ b/internal/terminal/terminalrunner/terminal_runner.go
@@ -18,6 +18,7 @@ package terminalrunner
 
 import (
 	"context"
+	"net"
 
 	"github.com/eminwux/sbsh/internal/terminal/terminalrpc"
 	"github.com/eminwux/sbsh/pkg/api"
@@ -25,6 +26,11 @@ import (
 
 type TerminalRunner interface {
 	OpenSocketCtrl() error
+	// UseListener injects a pre-bound control-socket listener so callers
+	// that need to claim the socket inode before forking (e.g.
+	// pkg/terminal/server) can hand it over without going through
+	// OpenSocketCtrl. Must be called before StartServer.
+	UseListener(ln net.Listener)
 	StartServer(ctx context.Context, sc *terminalrpc.TerminalControllerRPC, readyCh chan error, doneCh chan error)
 	StartTerminal(evCh chan<- Event) error
 	ID() api.ID

--- a/internal/terminal/terminalrunner/terminal_runner_exec.go
+++ b/internal/terminal/terminalrunner/terminal_runner_exec.go
@@ -195,3 +195,12 @@ func (sr *Exec) childDone() bool {
 func (sr *Exec) ID() api.ID {
 	return sr.id
 }
+
+// UseListener installs an externally-bound control-socket listener so
+// that OpenSocketCtrl is not the only path that can prime the accept
+// loop. Intended for the public pkg/terminal/server facade where the
+// caller owns the inode (e.g. kuketty claims it before fork+exec).
+// Must be called before StartServer.
+func (sr *Exec) UseListener(ln net.Listener) {
+	sr.lnCtrl = ln
+}

--- a/internal/terminal/terminalrunner/terminal_runner_fake.go
+++ b/internal/terminal/terminalrunner/terminal_runner_fake.go
@@ -18,6 +18,7 @@ package terminalrunner
 
 import (
 	"context"
+	"net"
 	"sync"
 
 	"github.com/eminwux/sbsh/internal/errdefs"
@@ -28,6 +29,7 @@ import (
 type Test struct {
 	mu                  sync.RWMutex // protects function pointer fields
 	OpenSocketCtrlFunc  func() error
+	UseListenerFunc     func(ln net.Listener)
 	StartServerFunc     func(ctx context.Context, sc *terminalrpc.TerminalControllerRPC, readyCh chan error, doneCh chan error)
 	StartTerminalFunc   func(evCh chan<- Event) error
 	CloseFunc           func(reason error) error
@@ -53,6 +55,12 @@ func (sr *Test) OpenSocketCtrl() error {
 		return sr.OpenSocketCtrlFunc()
 	}
 	return nil
+}
+
+func (sr *Test) UseListener(ln net.Listener) {
+	if sr.UseListenerFunc != nil {
+		sr.UseListenerFunc(ln)
+	}
 }
 
 func (sr *Test) StartServer(

--- a/pkg/terminal/server/adapter.go
+++ b/pkg/terminal/server/adapter.go
@@ -1,0 +1,119 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// rpcAdapter satisfies api.TerminalController for the RPC layer by
+// forwarding to the Server's runner. The Server's public Stop signature
+// takes a Go error rather than *api.StopArgs, so the adapter is needed
+// to bridge those two shapes without polluting the public surface.
+type rpcAdapter struct {
+	srv *Server
+}
+
+func (a *rpcAdapter) Run(_ *api.TerminalSpec) error {
+	return errors.New("server: Run not implemented on facade; use Serve")
+}
+
+func (a *rpcAdapter) WaitReady() error { return nil }
+func (a *rpcAdapter) WaitClose() error { return nil }
+
+func (a *rpcAdapter) Close(reason error) error { return a.srv.Stop(reason) }
+
+func (a *rpcAdapter) Ping(in *api.PingMessage) (*api.PingMessage, error) {
+	if in != nil && in.Message == "PING" {
+		return &api.PingMessage{Message: "PONG"}, nil
+	}
+	msg := ""
+	if in != nil {
+		msg = in.Message
+	}
+	return &api.PingMessage{}, fmt.Errorf("unexpected ping message: %s", msg)
+}
+
+func (a *rpcAdapter) Resize(args api.ResizeArgs) {
+	if r := a.srv.getRunner(); r != nil {
+		r.Resize(args)
+	}
+}
+
+func (a *rpcAdapter) Detach(id *api.ID) error {
+	r := a.srv.getRunner()
+	if r == nil {
+		return errors.New("server: terminal not running")
+	}
+	return r.Detach(id)
+}
+
+func (a *rpcAdapter) Attach(id *api.ID, response *api.ResponseWithFD) error {
+	r := a.srv.getRunner()
+	if r == nil {
+		return errors.New("server: terminal not running")
+	}
+	if err := r.Attach(id, response); err != nil {
+		return err
+	}
+	return r.PostAttachShell()
+}
+
+func (a *rpcAdapter) Metadata() (*api.TerminalDoc, error) {
+	return a.srv.Metadata()
+}
+
+func (a *rpcAdapter) State() (*api.TerminalStatusMode, error) {
+	md, err := a.srv.Metadata()
+	if err != nil {
+		return nil, err
+	}
+	return &md.Status.State, nil
+}
+
+func (a *rpcAdapter) Stop(args *api.StopArgs) error {
+	reason := "stop requested"
+	if args != nil && args.Reason != "" {
+		reason = args.Reason
+	}
+	// Trigger shutdown asynchronously so the RPC reply lands before the
+	// server socket is torn down — matches Controller.Stop semantics.
+	go func() { _ = a.srv.Stop(fmt.Errorf("stop: %s", reason)) }()
+	return nil
+}
+
+func (a *rpcAdapter) Write(req *api.WriteRequest) error {
+	r := a.srv.getRunner()
+	if r == nil {
+		return errors.New("server: terminal not running")
+	}
+	if req == nil || len(req.Data) == 0 {
+		return nil
+	}
+	return r.WritePTY(req.Data)
+}
+
+func (a *rpcAdapter) Subscribe(req *api.SubscribeRequest, response *api.ResponseWithFD) error {
+	r := a.srv.getRunner()
+	if r == nil {
+		return errors.New("server: terminal not running")
+	}
+	return r.Subscribe(req, response)
+}

--- a/pkg/terminal/server/server.go
+++ b/pkg/terminal/server/server.go
@@ -1,0 +1,228 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package server exposes the sbsh terminal RPC server as a reusable
+// facade so out-of-tree binaries can serve the same wire protocol
+// pkg/attach consumes. The facade hides the multi-subscriber state
+// machine, JSON-RPC codec, SCM_RIGHTS FD passing, PID-1 reaper, and
+// signal forwarder behind a minimal API whose inputs are an existing
+// public api.TerminalSpec and a caller-bound net.Listener.
+//
+// Typical use case is a process that needs to bind the control socket
+// before paying the fork+exec cost — claim the inode, signal readiness,
+// then call Serve so the PTY spawns over the already-listening socket.
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+
+	"github.com/eminwux/sbsh/internal/terminal/terminalrpc"
+	"github.com/eminwux/sbsh/internal/terminal/terminalrunner"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// Server is a single-use terminal server. Construct one with New, then
+// call Serve. Stop initiates graceful shutdown from another goroutine.
+type Server struct {
+	spec   *api.TerminalSpec
+	logger *slog.Logger
+
+	mu          sync.Mutex
+	serveCalled bool
+	runner      terminalrunner.TerminalRunner
+
+	stopOnce sync.Once
+	stopCh   chan error
+}
+
+// New constructs a server bound to spec. The PTY is not spawned here —
+// the wrapped child is forked on Serve so a caller can listen on the
+// control socket and signal readiness first.
+func New(spec *api.TerminalSpec, logger *slog.Logger) (*Server, error) {
+	if spec == nil {
+		return nil, errors.New("server: nil TerminalSpec")
+	}
+	if len(spec.Command) == 0 {
+		return nil, errors.New("server: empty Command in TerminalSpec")
+	}
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	return &Server{
+		spec:   spec,
+		logger: logger,
+		stopCh: make(chan error, 1),
+	}, nil
+}
+
+// Serve accepts on listener and dispatches the TerminalController
+// service surface. Blocks until ctx is cancelled, the wrapped child
+// exits, Stop is called, or the RPC server fails. Returns the
+// terminating cause. The listener is closed by the underlying runner
+// during shutdown — the caller transfers ownership for the lifetime of
+// Serve.
+func (s *Server) Serve(ctx context.Context, listener net.Listener) error {
+	if listener == nil {
+		return errors.New("server: nil listener")
+	}
+
+	sctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	runner, eventsCh, rpcDoneCh, err := s.bringUp(sctx, listener)
+	if err != nil {
+		return err
+	}
+
+	cause := s.runLoop(sctx, eventsCh, rpcDoneCh)
+	_ = runner.Close(cause)
+	return cause
+}
+
+// bringUp performs the one-shot pre-Serve dance: claim the
+// serveCalled latch, construct the runner, hand it the listener,
+// write the metadata file, kick off the RPC accept loop, wait for it
+// to bind, spawn the PTY, and run the SetupShell + OnInitShell
+// preroll. Returns the channels Serve needs for its event loop or an
+// error if any step fails (in which case the runner is closed and
+// the error is wrapped with the failing stage).
+func (s *Server) bringUp(
+	ctx context.Context,
+	listener net.Listener,
+) (terminalrunner.TerminalRunner, <-chan terminalrunner.Event, <-chan error, error) {
+	s.mu.Lock()
+	if s.serveCalled {
+		s.mu.Unlock()
+		return nil, nil, nil, errors.New("server: Serve already called")
+	}
+	s.serveCalled = true
+
+	eventsCh := make(chan terminalrunner.Event, eventBufferSize)
+	rpcReadyCh := make(chan error, 1)
+	rpcDoneCh := make(chan error, 1)
+
+	runner := terminalrunner.NewTerminalRunnerExec(ctx, s.logger, s.spec)
+	runner.UseListener(listener)
+	s.runner = runner
+	s.mu.Unlock()
+
+	if err := runner.CreateMetadata(); err != nil {
+		_ = runner.Close(err)
+		return nil, nil, nil, fmt.Errorf("server: CreateMetadata: %w", err)
+	}
+
+	svc := &terminalrpc.TerminalControllerRPC{Core: &rpcAdapter{srv: s}}
+	go runner.StartServer(ctx, svc, rpcReadyCh, rpcDoneCh)
+
+	if err := <-rpcReadyCh; err != nil {
+		_ = runner.Close(err)
+		return nil, nil, nil, fmt.Errorf("server: StartServer: %w", err)
+	}
+
+	if err := runner.StartTerminal(eventsCh); err != nil {
+		_ = runner.Close(err)
+		return nil, nil, nil, fmt.Errorf("server: StartTerminal: %w", err)
+	}
+
+	if err := runner.SetupShell(); err != nil {
+		_ = runner.Close(err)
+		return nil, nil, nil, fmt.Errorf("server: SetupShell: %w", err)
+	}
+
+	if err := runner.OnInitShell(); err != nil {
+		_ = runner.Close(err)
+		return nil, nil, nil, fmt.Errorf("server: OnInitShell: %w", err)
+	}
+
+	return runner, eventsCh, rpcDoneCh, nil
+}
+
+// runLoop blocks on the first terminating signal — ctx cancel,
+// terminal exit/error event, RPC server exit, or a Stop call — and
+// returns the cause to be passed to runner.Close.
+func (s *Server) runLoop(
+	ctx context.Context,
+	eventsCh <-chan terminalrunner.Event,
+	rpcDoneCh <-chan error,
+) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ev := <-eventsCh:
+			if ev.Type == terminalrunner.EvError || ev.Type == terminalrunner.EvCmdExited {
+				if ev.Err != nil {
+					return ev.Err
+				}
+				return errors.New("server: terminal exited")
+			}
+		case err := <-rpcDoneCh:
+			if err != nil {
+				return err
+			}
+			return errors.New("server: rpc server exited")
+		case err := <-s.stopCh:
+			if err != nil {
+				return err
+			}
+			return errors.New("server: Stop called")
+		}
+	}
+}
+
+// Stop initiates graceful shutdown. Safe to call from another
+// goroutine while Serve blocks. Returns immediately; the actual
+// SIGTERM → grace → SIGKILL sequence runs on the Serve goroutine and
+// the Serve call returns once it completes. Multiple calls collapse
+// to the first.
+func (s *Server) Stop(reason error) error {
+	s.stopOnce.Do(func() {
+		if reason == nil {
+			reason = errors.New("server: Stop called")
+		}
+		select {
+		case s.stopCh <- reason:
+		default:
+		}
+	})
+	return nil
+}
+
+// Metadata returns the same TerminalDoc the RPC Metadata method
+// returns. Errors if called before Serve initializes the runner.
+func (s *Server) Metadata() (*api.TerminalDoc, error) {
+	r := s.getRunner()
+	if r == nil {
+		return nil, errors.New("server: not started")
+	}
+	return r.Metadata()
+}
+
+func (s *Server) getRunner() terminalrunner.TerminalRunner {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.runner
+}
+
+// eventBufferSize matches the controller-side buffer so a momentarily
+// busy Serve loop never stalls the PTY-reader goroutine.
+const eventBufferSize = 32

--- a/pkg/terminal/server/server_test.go
+++ b/pkg/terminal/server/server_test.go
@@ -1,0 +1,243 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/pkg/api"
+	rpcclient "github.com/eminwux/sbsh/pkg/rpcclient/terminal"
+	"github.com/eminwux/sbsh/pkg/terminal/server"
+)
+
+// TestServer_PingWriteSubscribeStop exercises the public facade
+// end-to-end against the wire protocol: dial via pkg/rpcclient/terminal,
+// run Ping, push bytes through Write, register a Subscribe stream
+// (FD-passing via SCM_RIGHTS), then drive a graceful Stop.
+//
+// The test deliberately uses the public surface only — no peeking at
+// internal runner state — to mirror how an out-of-tree consumer would
+// exercise the facade.
+func TestServer_PingWriteSubscribeStop(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	h := startTestServer(ctx, t)
+	defer h.cleanup()
+
+	client := rpcclient.NewUnix(h.socketPath, h.logger)
+	defer client.Close()
+
+	t.Run("Ping", func(t *testing.T) { runPing(ctx, t, client) })
+
+	clientID := api.ID("subscriber-1")
+	subConn, subErr := client.Subscribe(ctx, &api.SubscribeRequest{ClientID: clientID}, nil)
+	if subErr != nil {
+		t.Fatalf("Subscribe: %v", subErr)
+	}
+	defer subConn.Close()
+
+	t.Run("Write", func(t *testing.T) { runWrite(ctx, t, client) })
+	t.Run("SubscribeReceivesPTYBytes", func(t *testing.T) { runSubscribeRead(t, subConn) })
+	t.Run("Stop", func(t *testing.T) { runStop(t, h) })
+}
+
+// TestServer_New_RejectsInvalidSpec covers the constructor guards so
+// downstream consumers get a clear error rather than a panic deep in
+// the runner.
+func TestServer_New_RejectsInvalidSpec(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	if _, err := server.New(nil, logger); err == nil {
+		t.Fatal("New(nil, ...) returned no error")
+	}
+	if _, err := server.New(&api.TerminalSpec{}, logger); err == nil {
+		t.Fatal("New(spec with empty Command) returned no error")
+	}
+}
+
+// TestServer_Serve_RejectsNilListener guards against the easiest
+// caller mistake: passing nil.
+func TestServer_Serve_RejectsNilListener(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv, newErr := server.New(&api.TerminalSpec{Command: "/bin/sh"}, logger)
+	if newErr != nil {
+		t.Fatalf("New: %v", newErr)
+	}
+	if err := srv.Serve(context.Background(), nil); err == nil {
+		t.Fatal("Serve(nil listener) returned no error")
+	}
+}
+
+// testHarness bundles the resources a single integration test needs so
+// the test functions stay readable and gocognit stays happy.
+type testHarness struct {
+	srv        *server.Server
+	logger     *slog.Logger
+	socketPath string
+	serveErrCh chan error
+	cleanup    func()
+}
+
+func startTestServer(ctx context.Context, t *testing.T) *testHarness {
+	t.Helper()
+
+	tmp := t.TempDir()
+	socketPath := filepath.Join(tmp, "ctrl.sock")
+	capturePath := filepath.Join(tmp, "capture.log")
+
+	listener, listenErr := net.Listen("unix", socketPath)
+	if listenErr != nil {
+		t.Fatalf("net.Listen: %v", listenErr)
+	}
+
+	spec := &api.TerminalSpec{
+		ID:          api.ID("test-server-1"),
+		Name:        "test-server-1",
+		Labels:      map[string]string{},
+		Command:     "/bin/sh",
+		CommandArgs: []string{},
+		EnvInherit:  true,
+		RunPath:     tmp,
+		SocketFile:  socketPath,
+		CaptureFile: capturePath,
+		// LogFile intentionally empty; the runner skips perm-apply for it.
+
+		// Keep the SIGTERM → SIGKILL grace tight so Stop returns
+		// quickly even when /bin/sh ignores SIGTERM under PTY.
+		ShutdownGrace: 500 * time.Millisecond,
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	srv, newErr := server.New(spec, logger)
+	if newErr != nil {
+		t.Fatalf("server.New: %v", newErr)
+	}
+
+	serveErrCh := make(chan error, 1)
+	go func() { serveErrCh <- srv.Serve(ctx, listener) }()
+
+	if waitErr := waitReady(ctx, srv, 10*time.Second); waitErr != nil {
+		t.Fatalf("waitReady: %v", waitErr)
+	}
+
+	cleanup := func() {
+		_ = srv.Stop(errors.New("test cleanup"))
+		select {
+		case <-serveErrCh:
+		case <-time.After(5 * time.Second):
+			t.Logf("Serve did not return within 5s of cleanup Stop")
+		}
+	}
+
+	return &testHarness{
+		srv:        srv,
+		logger:     logger,
+		socketPath: socketPath,
+		serveErrCh: serveErrCh,
+		cleanup:    cleanup,
+	}
+}
+
+func runPing(ctx context.Context, t *testing.T, client rpcclient.Client) {
+	t.Helper()
+	var pong api.PingMessage
+	if err := client.Ping(ctx, &api.PingMessage{Message: "PING"}, &pong); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	if pong.Message != "PONG" {
+		t.Fatalf("Ping reply = %q, want %q", pong.Message, "PONG")
+	}
+}
+
+func runWrite(ctx context.Context, t *testing.T, client rpcclient.Client) {
+	t.Helper()
+	if err := client.Write(ctx, &api.WriteRequest{Data: []byte("echo hi\n")}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+}
+
+func runSubscribeRead(t *testing.T, conn net.Conn) {
+	t.Helper()
+	// The PTY echoes input; the shell also runs "echo hi" and prints
+	// "hi". Either is enough — we just need to see *some* bytes
+	// arrive on the subscribe stream to verify FD passing wired up
+	// and the multiwriter is fanning out to subscribers.
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	buf := make([]byte, 256)
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("subscribe read: %v (n=%d)", err, n)
+	}
+	if n == 0 {
+		t.Fatal("subscribe read returned 0 bytes")
+	}
+	t.Logf("subscribe read %d bytes: %q", n, buf[:n])
+}
+
+func runStop(t *testing.T, h *testHarness) {
+	t.Helper()
+	stopReason := errors.New("test stop")
+	if err := h.srv.Stop(stopReason); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	select {
+	case serveErr := <-h.serveErrCh:
+		if serveErr == nil || serveErr.Error() == "" {
+			t.Fatalf("Serve returned %v; expected stop reason to propagate", serveErr)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Serve did not return within 10s after Stop")
+	}
+	// Drain the cleanup-side Stop so the deferred cleanup is a no-op
+	// instead of waiting on a Serve that already returned.
+	h.cleanup = func() {}
+}
+
+// waitReady polls Metadata until the runner reports api.Ready or the
+// deadline expires. Returns the most recent error if the deadline hits
+// first.
+func waitReady(ctx context.Context, srv *server.Server, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		md, err := srv.Metadata()
+		if err == nil && md != nil && md.Status.State == api.Ready {
+			return nil
+		}
+		lastErr = err
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	return errors.New("timed out waiting for api.Ready")
+}


### PR DESCRIPTION
## Summary
- New `pkg/terminal/server` facade so out-of-tree binaries (e.g. kuketty) can serve the same JSON-RPC + SCM_RIGHTS terminal protocol `pkg/attach` consumes, without reimplementing the codec, multi-subscriber state machine, PID-1 reaper, or signal forwarder.
- Minimal surface: `New(*api.TerminalSpec, *slog.Logger)`, `Serve(ctx, net.Listener)`, `Stop(error)`, `Metadata()`. PTY is spawned on `Serve` so callers can claim the socket inode before paying the fork+exec cost.
- Implementation is a thin wrapper around `internal/terminal/terminalrunner.Exec` + `internal/terminal/terminalrpc.TerminalControllerRPC`. No behavior change to the wire protocol or to in-tree consumers; an unexported `rpcAdapter` bridges the facade's `Stop(error)` to the `*api.StopArgs` shape `TerminalControllerRPC.Stop` expects.
- Adds a single new method to the unexported `TerminalRunner` interface — `UseListener(net.Listener)` — so the facade can hand a pre-bound listener to the runner instead of going through `OpenSocketCtrl`. The runner's existing `Close` continues to own listener teardown for the Serve lifetime; the caller transfers ownership.

## Test plan
- [x] `make sbsh-sb` builds the canonical executable (verified `file ./sbsh` reports ELF).
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (CI suite — cmd, internal/terminal, internal/client, integration tag, e2e).
- [x] `make test-race` (includes `./pkg/...` and the new package).
- [x] `pre-commit run --files <touched>` (golangci-lint clean).
- [x] New unit test `pkg/terminal/server.TestServer_PingWriteSubscribeStop` boots a server, dials via `pkg/rpcclient/terminal`, exercises `Ping` (round-trip), `Write` (PTY input), `Subscribe` (FD-passing + multiwriter fan-out), and a graceful `Stop`, against the public surface only.

## Notes for reviewer
- Why a facade instead of promoting `internal/terminal.Controller`? Controller owns the listener via `OpenSocketCtrl` and bundles a wider set of in-tree concerns (manager, supervisor wiring). The facade goes directly to `terminalrunner.Exec` + `terminalrpc.TerminalControllerRPC` so the surface stays minimal and the wider runner is free to evolve.
- `UseListener` was added to the runner interface (and the `Test` fake) rather than parameterizing `OpenSocketCtrl`, so existing in-tree call sites are unchanged.
- `Status.SocketFile` is left blank in the facade's metadata write (the runner's existing `OpenSocketCtrl` is what populates it). Acceptable for the kuketty use case — the caller owns the socket path and writes its own metadata file. Happy to add a setter if the reviewer prefers populating it from `listener.Addr()`.
- Tag as v0.11.0 once merged, per the issue.

Closes #202