### PR TITLE
feat(logging): expose SetupFileLogger via pkg/logging for out-of-tree callers

### DIFF
--- a/internal/logging/helpers.go
+++ b/internal/logging/helpers.go
@@ -21,59 +21,34 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path/filepath"
 
 	"github.com/eminwux/sbsh/cmd/types"
+	publog "github.com/eminwux/sbsh/pkg/logging"
 	"github.com/spf13/cobra"
 )
 
-func ParseLevel(lvl string) slog.Level {
-	switch lvl {
-	case "debug":
-		return slog.LevelDebug
-	case "info":
-		return slog.LevelInfo
-	case "warn", "warning":
-		return slog.LevelWarn
-	case "error", "err":
-		return slog.LevelError
-	default:
-		// default if unknown
-		return slog.LevelInfo
-	}
-}
+// ReformatHandler aliases the public type so existing CLI references
+// (e.g. cmd/sb/sb.go) keep compiling without an import rewrite.
+type ReformatHandler = publog.ReformatHandler
+
+// ParseLevel re-exports the public ParseLevel for the same reason.
+func ParseLevel(lvl string) slog.Level { return publog.ParseLevel(lvl) }
 
 func SetupFileLogger(cmd *cobra.Command, logfile string, loglevel string) error {
 	if cmd == nil || logfile == "" || loglevel == "" {
 		return fmt.Errorf("cmd, logfile=%s, loglevel=%s must not be empty", logfile, loglevel)
 	}
-	if err := os.MkdirAll(filepath.Dir(logfile), 0o700); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create log directory: %v\n", err)
-		return err
-	}
-
-	f, err := os.OpenFile(logfile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	fl, err := publog.NewFileLogger(logfile, loglevel)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to open log file: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Failed to set up file logger: %v\n", err)
 		return err
 	}
 
-	// Create a new logger that writes to the file with the specified log level
-	levelVar := new(slog.LevelVar)
-	levelVar.Set(ParseLevel(loglevel))
-
-	handler := &ReformatHandler{
-		Inner:  slog.NewTextHandler(f, &slog.HandlerOptions{Level: levelVar}),
-		Writer: f,
-	}
-	logger := slog.New(handler)
-
-	// Store both logger and levelVar in context using struct keys
+	levelVar := fl.LevelVar
 	ctx := cmd.Context()
-	ctx = context.WithValue(ctx, types.CtxLogger, logger)
+	ctx = context.WithValue(ctx, types.CtxLogger, fl.Logger)
 	ctx = context.WithValue(ctx, types.CtxLevelVar, &levelVar)
-	ctx = context.WithValue(ctx, types.CtxHandler, handler)
-
+	ctx = context.WithValue(ctx, types.CtxHandler, fl.Handler)
 	cmd.SetContext(ctx)
 	return nil
 }

--- a/pkg/logging/doc.go
+++ b/pkg/logging/doc.go
@@ -1,0 +1,28 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package logging exposes the file-backed slog.Logger setup used by
+// the sbsh CLI so out-of-tree callers can pre-create the per-terminal
+// log file with the same permissions the runner expects.
+//
+// Callers driving pkg/terminal/server with a TerminalSpec produced by
+// pkg/builder.BuildTerminalSpec must call NewFileLogger (or otherwise
+// create the file at 0o600) before Serve — the runner re-chmods the
+// path during StartTerminal but does not create it.
+//
+// Stability: pre-v1. Symbols in this package may change between minor
+// releases until the umbrella issue (#118) closes.
+package logging

--- a/pkg/logging/handler.go
+++ b/pkg/logging/handler.go
@@ -53,9 +53,9 @@ func (h *ReformatHandler) Handle(_ context.Context, r slog.Record) error {
 }
 
 func (h *ReformatHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	return &ReformatHandler{Inner: h.Inner.WithAttrs(attrs)}
+	return &ReformatHandler{Inner: h.Inner.WithAttrs(attrs), Writer: h.Writer}
 }
 
 func (h *ReformatHandler) WithGroup(name string) slog.Handler {
-	return &ReformatHandler{Inner: h.Inner.WithGroup(name)}
+	return &ReformatHandler{Inner: h.Inner.WithGroup(name), Writer: h.Writer}
 }

--- a/pkg/logging/handler.go
+++ b/pkg/logging/handler.go
@@ -24,6 +24,10 @@ import (
 	"strings"
 )
 
+// ReformatHandler is the sbsh canonical slog.Handler: it formats each
+// record as `<RFC3339-timestamp> <LEVEL> <quoted-message> <attrs>` and
+// writes the line to Writer. Inner is consulted only for the Enabled
+// gate and for attribute/group propagation.
 type ReformatHandler struct {
 	Inner  slog.Handler
 	Writer io.Writer
@@ -36,7 +40,7 @@ func (h *ReformatHandler) Enabled(ctx context.Context, lvl slog.Level) bool {
 func (h *ReformatHandler) Handle(_ context.Context, r slog.Record) error {
 	ts := r.Time.Format("2006-01-02T15:04:05Z07:00")
 	level := strings.ToUpper(r.Level.String())
-	msg := fmt.Sprintf("%q", r.Message) // quoted message
+	msg := fmt.Sprintf("%q", r.Message)
 
 	attrs := ""
 	r.Attrs(func(a slog.Attr) bool {

--- a/pkg/logging/handler_test.go
+++ b/pkg/logging/handler_test.go
@@ -1,0 +1,63 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package logging_test
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/sbsh/pkg/logging"
+)
+
+// TestReformatHandler_WithAttrsPropagatesWriter guards against the
+// derived-handler nil-Writer regression: WithAttrs must thread the
+// Writer through so logger.With(...) does not panic in Handle.
+func TestReformatHandler_WithAttrsPropagatesWriter(t *testing.T) {
+	buf := &bytes.Buffer{}
+	h := &logging.ReformatHandler{
+		Inner:  slog.NewTextHandler(buf, nil),
+		Writer: buf,
+	}
+	logger := slog.New(h).With("attached", "yes")
+
+	logger.Info("hello")
+
+	got := buf.String()
+	if !strings.Contains(got, "INFO") || !strings.Contains(got, `"hello"`) {
+		t.Errorf("derived logger output = %q, missing ReformatHandler markers", got)
+	}
+}
+
+// TestReformatHandler_WithGroupPropagatesWriter mirrors the WithAttrs
+// guard for WithGroup.
+func TestReformatHandler_WithGroupPropagatesWriter(t *testing.T) {
+	buf := &bytes.Buffer{}
+	h := &logging.ReformatHandler{
+		Inner:  slog.NewTextHandler(buf, nil),
+		Writer: buf,
+	}
+	logger := slog.New(h).WithGroup("scope")
+
+	logger.Info("hello")
+
+	got := buf.String()
+	if !strings.Contains(got, "INFO") || !strings.Contains(got, `"hello"`) {
+		t.Errorf("grouped logger output = %q, missing ReformatHandler markers", got)
+	}
+}

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -1,0 +1,105 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package logging
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+// LogDirMode is the permission mode used when creating the parent
+// directory of a per-terminal log file.
+const LogDirMode os.FileMode = 0o700
+
+// LogFileMode is the permission mode used when creating a per-terminal
+// log file. It matches the mode the terminal runner re-applies via
+// chmod during StartTerminal, so pre-creating at this mode avoids a
+// no-op re-chmod and the chmod-on-missing-file failure mode.
+const LogFileMode os.FileMode = 0o600
+
+// ParseLevel maps an sbsh log-level string ("debug", "info", "warn",
+// "error") to a slog.Level. Unknown values resolve to slog.LevelInfo.
+func ParseLevel(lvl string) slog.Level {
+	switch lvl {
+	case "debug":
+		return slog.LevelDebug
+	case "info":
+		return slog.LevelInfo
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error", "err":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+// FileLogger bundles the file-backed slog.Logger and the resources
+// that back it. File is the underlying sink; the caller owns it and
+// must Close it during shutdown to flush and release the OS handle.
+// LevelVar exposes the configured threshold so callers can adjust the
+// minimum level at runtime.
+type FileLogger struct {
+	Logger   *slog.Logger
+	LevelVar *slog.LevelVar
+	Handler  *ReformatHandler
+	File     *os.File
+}
+
+// NewFileLogger creates the parent directory of logfile at LogDirMode
+// if needed, opens or creates logfile with O_CREATE|O_WRONLY|O_APPEND
+// at LogFileMode, and wires a structured slog.Logger that writes to
+// it using ReformatHandler.
+//
+// This is the pre-creation step the sbsh CLI performs before driving
+// the terminal runner. Out-of-tree callers using pkg/terminal/server
+// with a TerminalSpec that names a LogFile (e.g. one produced by
+// pkg/builder.BuildTerminalSpec) must call NewFileLogger (or otherwise
+// create the file at LogFileMode) before Serve — the runner re-chmods
+// the path during StartTerminal but does not create it.
+//
+// Both logfile and loglevel are required.
+func NewFileLogger(logfile, loglevel string) (*FileLogger, error) {
+	if logfile == "" || loglevel == "" {
+		return nil, fmt.Errorf("logging: logfile=%q, loglevel=%q must not be empty", logfile, loglevel)
+	}
+	if err := os.MkdirAll(filepath.Dir(logfile), LogDirMode); err != nil {
+		return nil, fmt.Errorf("logging: mkdir %s: %w", filepath.Dir(logfile), err)
+	}
+	f, err := os.OpenFile(logfile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, LogFileMode)
+	if err != nil {
+		return nil, fmt.Errorf("logging: open %s: %w", logfile, err)
+	}
+
+	levelVar := new(slog.LevelVar)
+	levelVar.Set(ParseLevel(loglevel))
+
+	handler := &ReformatHandler{
+		Inner:  slog.NewTextHandler(f, &slog.HandlerOptions{Level: levelVar}),
+		Writer: f,
+	}
+	logger := slog.New(handler)
+
+	return &FileLogger{
+		Logger:   logger,
+		LevelVar: levelVar,
+		Handler:  handler,
+		File:     f,
+	}, nil
+}

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -1,0 +1,157 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package logging_test
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/sbsh/pkg/logging"
+)
+
+func TestParseLevel(t *testing.T) {
+	cases := map[string]slog.Level{
+		"debug":   slog.LevelDebug,
+		"info":    slog.LevelInfo,
+		"warn":    slog.LevelWarn,
+		"warning": slog.LevelWarn,
+		"error":   slog.LevelError,
+		"err":     slog.LevelError,
+		"":        slog.LevelInfo,
+		"bogus":   slog.LevelInfo,
+	}
+	for in, want := range cases {
+		if got := logging.ParseLevel(in); got != want {
+			t.Errorf("ParseLevel(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestNewFileLogger_RejectsEmptyArgs(t *testing.T) {
+	if _, err := logging.NewFileLogger("", "info"); err == nil {
+		t.Fatal("NewFileLogger(empty path) returned no error")
+	}
+	if _, err := logging.NewFileLogger(filepath.Join(t.TempDir(), "log"), ""); err == nil {
+		t.Fatal("NewFileLogger(empty level) returned no error")
+	}
+}
+
+func TestNewFileLogger_CreatesParentDirAndFileAtExpectedMode(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "subdir")
+	logPath := filepath.Join(dir, "terminal.log")
+
+	fl, err := logging.NewFileLogger(logPath, "info")
+	if err != nil {
+		t.Fatalf("NewFileLogger: %v", err)
+	}
+	defer fl.File.Close()
+
+	dirInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat parent dir: %v", err)
+	}
+	if got := dirInfo.Mode().Perm(); got != logging.LogDirMode.Perm() {
+		t.Errorf("parent dir mode = %#o, want %#o", got, logging.LogDirMode.Perm())
+	}
+
+	fileInfo, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatalf("stat log file: %v", err)
+	}
+	if got := fileInfo.Mode().Perm(); got != logging.LogFileMode.Perm() {
+		t.Errorf("log file mode = %#o, want %#o", got, logging.LogFileMode.Perm())
+	}
+}
+
+func TestNewFileLogger_WritesRecordsViaReformatHandler(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "terminal.log")
+
+	fl, err := logging.NewFileLogger(logPath, "debug")
+	if err != nil {
+		t.Fatalf("NewFileLogger: %v", err)
+	}
+	fl.Logger.Info("hello", "k", "v")
+	if closeErr := fl.File.Close(); closeErr != nil {
+		t.Fatalf("Close: %v", closeErr)
+	}
+
+	body, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	got := string(body)
+	if !strings.Contains(got, "INFO") || !strings.Contains(got, `"hello"`) || !strings.Contains(got, "k=v") {
+		t.Errorf("log contents = %q, missing ReformatHandler markers", got)
+	}
+}
+
+func TestNewFileLogger_AppendsToExistingFile(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "terminal.log")
+	if err := os.WriteFile(logPath, []byte("pre-existing\n"), logging.LogFileMode); err != nil {
+		t.Fatalf("seed log file: %v", err)
+	}
+
+	fl, err := logging.NewFileLogger(logPath, "info")
+	if err != nil {
+		t.Fatalf("NewFileLogger: %v", err)
+	}
+	fl.Logger.Info("after-open")
+	if closeErr := fl.File.Close(); closeErr != nil {
+		t.Fatalf("Close: %v", closeErr)
+	}
+
+	body, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	got := string(body)
+	if !strings.HasPrefix(got, "pre-existing\n") {
+		t.Errorf("log truncated existing content: %q", got)
+	}
+	if !strings.Contains(got, `"after-open"`) {
+		t.Errorf("log missing new record: %q", got)
+	}
+}
+
+func TestNewFileLogger_LevelVarFilters(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "terminal.log")
+
+	fl, err := logging.NewFileLogger(logPath, "warn")
+	if err != nil {
+		t.Fatalf("NewFileLogger: %v", err)
+	}
+	fl.Logger.Info("below-threshold")
+	fl.Logger.Warn("above-threshold")
+	if closeErr := fl.File.Close(); closeErr != nil {
+		t.Fatalf("Close: %v", closeErr)
+	}
+
+	body, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	got := string(body)
+	if strings.Contains(got, "below-threshold") {
+		t.Errorf("expected info record to be filtered, got: %q", got)
+	}
+	if !strings.Contains(got, "above-threshold") {
+		t.Errorf("expected warn record to pass, got: %q", got)
+	}
+}

--- a/pkg/terminal/server/server_test.go
+++ b/pkg/terminal/server/server_test.go
@@ -27,6 +27,8 @@ import (
 	"time"
 
 	"github.com/eminwux/sbsh/pkg/api"
+	"github.com/eminwux/sbsh/pkg/builder"
+	publog "github.com/eminwux/sbsh/pkg/logging"
 	rpcclient "github.com/eminwux/sbsh/pkg/rpcclient/terminal"
 	"github.com/eminwux/sbsh/pkg/terminal/server"
 )
@@ -61,6 +63,66 @@ func TestServer_PingWriteSubscribeStop(t *testing.T) {
 	t.Run("Write", func(t *testing.T) { runWrite(ctx, t, client) })
 	t.Run("SubscribeReceivesPTYBytes", func(t *testing.T) { runSubscribeRead(t, subConn) })
 	t.Run("Stop", func(t *testing.T) { runStop(t, h) })
+}
+
+// TestServer_DrivenByBuildTerminalSpec locks in the contract that an
+// out-of-tree caller can build a TerminalSpec via pkg/builder, pre-create
+// the per-terminal log file with pkg/logging.NewFileLogger, and then
+// drive pkg/terminal/server.Server.Serve to the api.Ready state — without
+// the `spec.LogFile = ""` post-step that issue #204 documented as the
+// workaround. The runner re-chmods spec.LogFile during StartTerminal;
+// before pkg/logging existed, callers depending only on public surfaces
+// hit chmod ENOENT here.
+func TestServer_DrivenByBuildTerminalSpec(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	tmp := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	spec, err := builder.BuildTerminalSpec(ctx, logger, tmp,
+		builder.WithCommand([]string{"/bin/sh"}),
+	)
+	if err != nil {
+		t.Fatalf("BuildTerminalSpec: %v", err)
+	}
+	if spec.LogFile == "" {
+		t.Fatal("BuildTerminalSpec produced an empty LogFile; expected a derived path")
+	}
+
+	fl, err := publog.NewFileLogger(spec.LogFile, spec.LogLevel)
+	if err != nil {
+		t.Fatalf("NewFileLogger: %v", err)
+	}
+	t.Cleanup(func() { _ = fl.File.Close() })
+
+	listener, listenErr := net.Listen("unix", spec.SocketFile)
+	if listenErr != nil {
+		t.Fatalf("net.Listen: %v", listenErr)
+	}
+
+	spec.ShutdownGrace = 500 * time.Millisecond
+
+	srv, newErr := server.New(spec, logger)
+	if newErr != nil {
+		t.Fatalf("server.New: %v", newErr)
+	}
+
+	serveErrCh := make(chan error, 1)
+	go func() { serveErrCh <- srv.Serve(ctx, listener) }()
+
+	if waitErr := waitReady(ctx, srv, 10*time.Second); waitErr != nil {
+		t.Fatalf("waitReady: %v", waitErr)
+	}
+
+	if stopErr := srv.Stop(errors.New("test cleanup")); stopErr != nil {
+		t.Fatalf("Stop: %v", stopErr)
+	}
+	select {
+	case <-serveErrCh:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Serve did not return within 10s after Stop")
+	}
 }
 
 // TestServer_New_RejectsInvalidSpec covers the constructor guards so


### PR DESCRIPTION
## Summary
- Adds a public `pkg/logging` package exposing `NewFileLogger`, `ParseLevel`, and `ReformatHandler`, so out-of-tree callers driving `pkg/terminal/server.Server.Serve` against a `pkg/builder.BuildTerminalSpec` spec can pre-create the per-terminal log file at the same mode the runner's `applyLogFilePerms` re-chmods (proposal 2 from #204).
- `internal/logging.SetupFileLogger` keeps its cobra-context wiring but delegates the file-open and handler-build to `pkg/logging.NewFileLogger`, so CLI behavior is byte-identical (CLI tests under `cmd/sbsh/terminal/`, `cmd/sb/...`, and the e2e suite stay green).
- `internal/logging.ReformatHandler` and `internal/logging.ParseLevel` are now thin re-exports of the public symbols — `cmd/sb/sb.go` keeps compiling unchanged.

## Test plan
- [x] `make sbsh-sb` — produced ELF executables for `sbsh` and `sb`.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages green, including new `pkg/logging` tests and the `pkg/terminal/server.TestServer_DrivenByBuildTerminalSpec` integration test that locks in the contract from #204's acceptance criteria).
- [x] `pre-commit run --files <changed files>` (go-fmt, go-mod-tidy, golangci-lint, addlicense all pass).

Closes #204