### PR TITLE
fix(terminal): apply socket mode/gid on UseListener path

### DIFF
--- a/internal/terminal/terminalrunner/sockets.go
+++ b/internal/terminal/terminalrunner/sockets.go
@@ -38,11 +38,48 @@ const defaultSocketMode os.FileMode = 0o600
 // defaultSocketMode for the control socket.
 const defaultArtifactMode os.FileMode = 0o600
 
+// applySocketPerms chmods (and optionally chowns the group of) the
+// control-socket inode after a listener has been bound to it. Called
+// from both OpenSocketCtrl (runner binds the socket itself) and
+// UseListener (caller hands in a pre-bound listener — pkg/terminal/server
+// facade case), so both paths land at the same on-disk permissions.
+//
+// mode == 0 falls back to defaultSocketMode so callers can pass the
+// raw spec field through without a guard. gid == nil leaves the group
+// unchanged. The chown form is Chown(path, -1, gid) so the listener's
+// uid stays the owner; only the group is rewritten.
+func (sr *Exec) applySocketPerms(path string, mode os.FileMode, gid *int) error {
+	if mode == 0 {
+		mode = defaultSocketMode
+	}
+	if errChmod := os.Chmod(path, mode); errChmod != nil {
+		sr.logger.Error(
+			"applySocketPerms: chmod failed",
+			"socket", path,
+			"mode", fmt.Sprintf("0o%o", mode),
+			"error", errChmod,
+		)
+		return fmt.Errorf("chmod socket: %w", errChmod)
+	}
+	if gid != nil {
+		if errChown := os.Chown(path, -1, *gid); errChown != nil {
+			sr.logger.Error(
+				"applySocketPerms: chown failed",
+				"socket", path,
+				"gid", *gid,
+				"error", errChown,
+			)
+			return fmt.Errorf("chown socket: %w", errChown)
+		}
+	}
+	return nil
+}
+
 // applyArtifactPerms chmods (and optionally chowns the group of) a
 // per-terminal artifact path that was just opened. Used for the capture
-// transcript and the log file — the control socket has its own helper in
-// OpenSocketCtrl because the path needs to be removed first and the
-// listener has to be torn down on failure.
+// transcript and the log file — the control socket goes through
+// applySocketPerms instead because the listener has to be torn down on
+// failure.
 //
 // mode == 0 falls back to defaultArtifactMode so callers can pass the
 // raw spec field through without a guard. gid == nil leaves the group
@@ -89,10 +126,6 @@ func (sr *Exec) OpenSocketCtrl() error {
 	sr.metadata.Status.SocketFile = socketFile
 	sr.metadataMu.Unlock()
 
-	if socketMode == 0 {
-		socketMode = defaultSocketMode
-	}
-
 	sr.logger.Debug("OpenSocketCtrl: preparing to listen", "socket", socketFile)
 	errMetadata := sr.updateMetadata()
 	if errMetadata != nil {
@@ -122,37 +155,9 @@ func (sr *Exec) OpenSocketCtrl() error {
 	// keep references for Close()
 	sr.lnCtrl = ctrlLn
 
-	if errChmod := os.Chmod(socketFile, socketMode); errChmod != nil {
-		sr.logger.Error(
-			"OpenSocketCtrl: failed to chmod socket file",
-			"socket",
-			socketFile,
-			"mode",
-			fmt.Sprintf("0o%o", socketMode),
-			"error",
-			errChmod,
-		)
+	if errPerms := sr.applySocketPerms(socketFile, socketMode, socketGID); errPerms != nil {
 		_ = ctrlLn.Close()
-		return errChmod
-	}
-
-	if socketGID != nil {
-		// Chown(-1, gid) keeps the listener's uid as owner and only
-		// rewrites the group, so the inode permits group-mode access
-		// without changing the controlling identity.
-		if errChown := os.Chown(socketFile, -1, *socketGID); errChown != nil {
-			sr.logger.Error(
-				"OpenSocketCtrl: failed to chown socket file",
-				"socket",
-				socketFile,
-				"gid",
-				*socketGID,
-				"error",
-				errChown,
-			)
-			_ = ctrlLn.Close()
-			return errChown
-		}
+		return errPerms
 	}
 
 	// update metadata with socket file path

--- a/internal/terminal/terminalrunner/terminal_runner.go
+++ b/internal/terminal/terminalrunner/terminal_runner.go
@@ -29,8 +29,11 @@ type TerminalRunner interface {
 	// UseListener injects a pre-bound control-socket listener so callers
 	// that need to claim the socket inode before forking (e.g.
 	// pkg/terminal/server) can hand it over without going through
-	// OpenSocketCtrl. Must be called before StartServer.
-	UseListener(ln net.Listener)
+	// OpenSocketCtrl. Must be called before StartServer. The runner
+	// applies Spec.SocketMode / Spec.SocketGID to the inode resolved
+	// from ln.Addr() so on-disk permissions match the OpenSocketCtrl
+	// path; callers do not re-implement the chmod/chown dance.
+	UseListener(ln net.Listener) error
 	StartServer(ctx context.Context, sc *terminalrpc.TerminalControllerRPC, readyCh chan error, doneCh chan error)
 	StartTerminal(evCh chan<- Event) error
 	ID() api.ID

--- a/internal/terminal/terminalrunner/terminal_runner_exec.go
+++ b/internal/terminal/terminalrunner/terminal_runner_exec.go
@@ -201,6 +201,23 @@ func (sr *Exec) ID() api.ID {
 // loop. Intended for the public pkg/terminal/server facade where the
 // caller owns the inode (e.g. kuketty claims it before fork+exec).
 // Must be called before StartServer.
-func (sr *Exec) UseListener(ln net.Listener) {
+//
+// Spec.SocketMode and Spec.SocketGID are applied to the inode resolved
+// from ln.Addr() so the on-disk permissions match what the
+// OpenSocketCtrl path produces. The listener is stored before the
+// chmod/chown so a failure here leaves it owned by the runner — the
+// caller can rely on runner.Close to tear it down.
+func (sr *Exec) UseListener(ln net.Listener) error {
 	sr.lnCtrl = ln
+
+	sr.metadataMu.RLock()
+	socketMode := sr.metadata.Spec.SocketMode
+	var socketGID *int
+	if g := sr.metadata.Spec.SocketGID; g != nil {
+		gv := *g
+		socketGID = &gv
+	}
+	sr.metadataMu.RUnlock()
+
+	return sr.applySocketPerms(ln.Addr().String(), socketMode, socketGID)
 }

--- a/internal/terminal/terminalrunner/terminal_runner_fake.go
+++ b/internal/terminal/terminalrunner/terminal_runner_fake.go
@@ -29,7 +29,7 @@ import (
 type Test struct {
 	mu                  sync.RWMutex // protects function pointer fields
 	OpenSocketCtrlFunc  func() error
-	UseListenerFunc     func(ln net.Listener)
+	UseListenerFunc     func(ln net.Listener) error
 	StartServerFunc     func(ctx context.Context, sc *terminalrpc.TerminalControllerRPC, readyCh chan error, doneCh chan error)
 	StartTerminalFunc   func(evCh chan<- Event) error
 	CloseFunc           func(reason error) error
@@ -57,10 +57,11 @@ func (sr *Test) OpenSocketCtrl() error {
 	return nil
 }
 
-func (sr *Test) UseListener(ln net.Listener) {
+func (sr *Test) UseListener(ln net.Listener) error {
 	if sr.UseListenerFunc != nil {
-		sr.UseListenerFunc(ln)
+		return sr.UseListenerFunc(ln)
 	}
+	return nil
 }
 
 func (sr *Test) StartServer(

--- a/pkg/terminal/server/server.go
+++ b/pkg/terminal/server/server.go
@@ -121,7 +121,11 @@ func (s *Server) bringUp(
 	rpcDoneCh := make(chan error, 1)
 
 	runner := terminalrunner.NewTerminalRunnerExec(ctx, s.logger, s.spec)
-	runner.UseListener(listener)
+	if err := runner.UseListener(listener); err != nil {
+		s.mu.Unlock()
+		_ = runner.Close(err)
+		return nil, nil, nil, fmt.Errorf("server: UseListener: %w", err)
+	}
 	s.runner = runner
 	s.mu.Unlock()
 

--- a/pkg/terminal/server/server_test.go
+++ b/pkg/terminal/server/server_test.go
@@ -22,7 +22,9 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
@@ -74,6 +76,82 @@ func TestServer_New_RejectsInvalidSpec(t *testing.T) {
 	}
 	if _, err := server.New(&api.TerminalSpec{}, logger); err == nil {
 		t.Fatal("New(spec with empty Command) returned no error")
+	}
+}
+
+// TestServer_UseListener_AppliesSocketPerms locks in the contract from
+// issue #205: when a caller hands a pre-bound listener to Serve and the
+// spec carries SocketMode / SocketGID, the runner chmods + chowns the
+// inode itself instead of leaving the umask-clipped Listen default in
+// place. The bug was that UseListener stored the listener and skipped
+// the perm dance — out-of-tree callers (e.g. kuketty) had to replicate
+// it manually. The fix routes both OpenSocketCtrl and UseListener
+// through the same applySocketPerms helper.
+func TestServer_UseListener_AppliesSocketPerms(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	tmp := t.TempDir()
+	socketPath := filepath.Join(tmp, "ctrl.sock")
+	capturePath := filepath.Join(tmp, "capture.log")
+
+	listener, listenErr := net.Listen("unix", socketPath)
+	if listenErr != nil {
+		t.Fatalf("net.Listen: %v", listenErr)
+	}
+
+	wantMode := os.FileMode(0o660)
+	wantGID := os.Getgid()
+
+	spec := &api.TerminalSpec{
+		ID:            api.ID("test-uselistener-perms"),
+		Name:          "test-uselistener-perms",
+		Labels:        map[string]string{},
+		Command:       "/bin/sh",
+		CommandArgs:   []string{},
+		EnvInherit:    true,
+		RunPath:       tmp,
+		SocketFile:    socketPath,
+		CaptureFile:   capturePath,
+		SocketMode:    wantMode,
+		SocketGID:     &wantGID,
+		ShutdownGrace: 500 * time.Millisecond,
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv, newErr := server.New(spec, logger)
+	if newErr != nil {
+		t.Fatalf("server.New: %v", newErr)
+	}
+
+	serveErrCh := make(chan error, 1)
+	go func() { serveErrCh <- srv.Serve(ctx, listener) }()
+	defer func() {
+		_ = srv.Stop(errors.New("test cleanup"))
+		select {
+		case <-serveErrCh:
+		case <-time.After(5 * time.Second):
+			t.Logf("Serve did not return within 5s of cleanup Stop")
+		}
+	}()
+
+	if waitErr := waitReady(ctx, srv, 10*time.Second); waitErr != nil {
+		t.Fatalf("waitReady: %v", waitErr)
+	}
+
+	info, statErr := os.Stat(socketPath)
+	if statErr != nil {
+		t.Fatalf("os.Stat(%q): %v", socketPath, statErr)
+	}
+	if gotMode := info.Mode().Perm(); gotMode != wantMode {
+		t.Errorf("socket mode = 0o%o, want 0o%o", gotMode, wantMode)
+	}
+	sys, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatalf("info.Sys() type = %T, want *syscall.Stat_t", info.Sys())
+	}
+	if int(sys.Gid) != wantGID {
+		t.Errorf("socket gid = %d, want %d", sys.Gid, wantGID)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Routes both `OpenSocketCtrl` and `UseListener` through a shared `applySocketPerms` helper so the on-disk control-socket permissions are identical regardless of which path bound the listener — out-of-tree callers (e.g. kuketty) of `pkg/terminal/server` no longer have to replicate the chmod/chown dance after `net.Listen`.
- `UseListener` now returns `error`. The runner stores `lnCtrl` first and resolves the inode from `ln.Addr().String()`, so a perm-apply failure leaves the listener owned by the runner (Close tears it down) — chosen over folding into `StartServer` because it keeps the `OpenSocketCtrl` vs `UseListener` symmetry the interface already exposes.
- Picked proposal 1 from #205 over proposal 2 to keep the black-box contract: `Spec.SocketMode` / `Spec.SocketGID` always apply to the resulting inode without callers needing to know how the listener got bound.

## Test plan
- [x] `make sbsh-sb` — produced ELF executables for `sbsh` and `sb`.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages green, including the new `pkg/terminal/server.TestServer_UseListener_AppliesSocketPerms` that stats the inode after `waitReady` and asserts `Mode().Perm()` matches `0o660` and `Stat_t.Gid` matches `Spec.SocketGID`; existing `OpenSocketCtrl`-path coverage continues to pass).
- [x] `pre-commit run --files <changed files>` (trailing-whitespace, EOF, go-fmt, go-mod-tidy, golangci-lint, addlicense all pass).

Closes #205