### PR TITLE
feat(builder): profile-free TerminalSpec construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+All notable user-visible changes to sbsh are recorded here. The format
+loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## Unreleased
+
+### Added
+
+- `pkg/builder` gained five new `TerminalOption` helpers so SDK
+  consumers can populate every shell-shaped field of a `TerminalSpec`
+  without writing a YAML profile to disk:
+  - `WithStages(api.StagesSpec)` overlays the full lifecycle stages.
+  - `WithOnInit([]api.ExecStep)` and `WithPostAttach([]api.ExecStep)`
+    overlay only their respective sub-fields.
+  - `WithPrompt(string)` stamps `Spec.Prompt`.
+  - `WithEnvInherit(bool)` stamps `Spec.EnvInherit` (set-sentinel
+    discipline; `false` is a valid distinct value from "unset").
+- `pkg/builder.BuildTerminalSpecFromProfile` preserves the legacy
+  profile-driven build path (empty `WithProfile` resolves to
+  `"default"`, `pkg/discovery` lookup, hardcoded-default fallback for
+  the `"default"` name only).
+
+### Changed
+
+- **Breaking:** `pkg/builder.BuildTerminalSpec` now builds a
+  `TerminalSpec` from inline options only. It no longer calls
+  `pkg/discovery`, no longer resolves an implicit `"default"`
+  profile, and no longer falls back to the hardcoded default profile.
+  Stages / Prompt / EnvInherit stay zero unless the matching `With*`
+  option is passed; Cmd / CmdArgs default to `/bin/bash -i` so the
+  runner has a sensible shell.
+- **Breaking:** Passing `WithProfile` or `WithProfilesDir` to the
+  inline `BuildTerminalSpec` returns `errdefs.ErrInvalidOption`. Use
+  `BuildTerminalSpecFromProfile` instead.
+
+### Migration
+
+- In-tree CLI / test callers that previously relied on the implicit
+  profile resolution should switch to `BuildTerminalSpecFromProfile`.
+  The `cmd/sbsh` entry points have already been migrated.
+- Out-of-tree SDK callers (e.g., kukeon's `kuketty`) should keep using
+  `BuildTerminalSpec` for the inline lane and adopt `WithPrompt` /
+  `WithStages` / `WithOnInit` / `WithPostAttach` / `WithEnvInherit`
+  instead of relying on `WithDisableSetPrompt(true)` as a safety belt
+  against the old hardcoded prompt.

--- a/cmd/sbsh/sbsh.go
+++ b/cmd/sbsh/sbsh.go
@@ -152,7 +152,7 @@ You can also use sbsh with parameters. For example:
 				)
 			}
 
-			terminalSpec, buildErr := profile.BuildTerminalSpec(
+			terminalSpec, buildErr := profile.BuildTerminalSpecFromProfile(
 				cmd.Context(),
 				logger,
 				&profile.BuildTerminalSpecParams{

--- a/cmd/sbsh/terminal/terminal.go
+++ b/cmd/sbsh/terminal/terminal.go
@@ -140,7 +140,7 @@ func buildTerminalSpecFromFlags(
 		terminalCmdArgs = workload[1:]
 	}
 
-	spec, buildErr := profile.BuildTerminalSpec(
+	spec, buildErr := profile.BuildTerminalSpecFromProfile(
 		cmd.Context(),
 		logger,
 		&profile.BuildTerminalSpecParams{

--- a/docs/site/reference/library.md
+++ b/docs/site/reference/library.md
@@ -12,15 +12,15 @@ A complete, build-tested example lives at
 
 The public library lives under [`github.com/eminwux/sbsh/pkg`](https://pkg.go.dev/github.com/eminwux/sbsh/pkg):
 
-| Package                  | Purpose                                                                                                                                                                                                                                                 |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `pkg/api`                | Declarative document types (`TerminalDoc`, `TerminalSpec`, `ClientDoc`, `TerminalProfileDoc`, …) and RPC payload types (`PingMessage`, `WriteRequest`, `SubscribeRequest`, `StopArgs`, …). Counterpart of the YAML/JSON manifests.                      |
-| `pkg/builder`            | Construct a `TerminalSpec` or `ClientDoc` from a profile name plus inline overrides (`WithProfile`, `WithProfilesDir`, `WithCommand`, `WithEnv`, `WithClientMode`, …). No YAML round-trip.                                                              |
-| `pkg/spawn`              | Launch detached `Terminal` and `Client` subprocesses (`NewTerminal`, `NewClient`). Returns `TerminalHandle` / `ClientHandle` with `PID`, `SocketPath`, `WaitReady`, `WaitClose`, `Close`.                                                               |
-| `pkg/discovery`          | Enumerate live terminals/clients or look them up by ID/Name under a run path (`ScanTerminals`, `FindTerminalByID`, `FindTerminalByName`, `ScanClients`, `FindClientByName`). Load profiles from disk (`LoadProfilesFromDir`, `FindProfileByNameInDir`). |
-| `pkg/rpcclient/terminal` | JSON-RPC client for the `TerminalController` socket (`Ping`, `Resize`, `Attach`, `Detach`, `Metadata`, `State`, `Stop`, `Write`, `Subscribe`).                                                                                                          |
-| `pkg/rpcclient/client`   | JSON-RPC client for the `ClientController` socket (`Ping`, `Metadata`, `State`, `Stop`, `Detach`).                                                                                                                                                      |
-| `pkg/errors`             | Curated error sentinels re-exported from `internal/errdefs`. Use `errors.Is` to branch on well-known failure modes without importing internal packages.                                                                                                 |
+| Package                  | Purpose                                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `pkg/api`                | Declarative document types (`TerminalDoc`, `TerminalSpec`, `ClientDoc`, `TerminalProfileDoc`, …) and RPC payload types (`PingMessage`, `WriteRequest`, `SubscribeRequest`, `StopArgs`, …). Counterpart of the YAML/JSON manifests.                                                                                                                                 |
+| `pkg/builder`            | Construct a `TerminalSpec` or `ClientDoc` from inline options. `BuildTerminalSpec` is the profile-free lane (`WithCommand`, `WithEnv`, `WithStages`, `WithOnInit`, `WithPostAttach`, `WithPrompt`, `WithEnvInherit`, …); `BuildTerminalSpecFromProfile` is the profile-driven lane that additionally honors `WithProfile` / `WithProfilesDir`. No YAML round-trip. |
+| `pkg/spawn`              | Launch detached `Terminal` and `Client` subprocesses (`NewTerminal`, `NewClient`). Returns `TerminalHandle` / `ClientHandle` with `PID`, `SocketPath`, `WaitReady`, `WaitClose`, `Close`.                                                                                                                                                                          |
+| `pkg/discovery`          | Enumerate live terminals/clients or look them up by ID/Name under a run path (`ScanTerminals`, `FindTerminalByID`, `FindTerminalByName`, `ScanClients`, `FindClientByName`). Load profiles from disk (`LoadProfilesFromDir`, `FindProfileByNameInDir`).                                                                                                            |
+| `pkg/rpcclient/terminal` | JSON-RPC client for the `TerminalController` socket (`Ping`, `Resize`, `Attach`, `Detach`, `Metadata`, `State`, `Stop`, `Write`, `Subscribe`).                                                                                                                                                                                                                     |
+| `pkg/rpcclient/client`   | JSON-RPC client for the `ClientController` socket (`Ping`, `Metadata`, `State`, `Stop`, `Detach`).                                                                                                                                                                                                                                                                 |
+| `pkg/errors`             | Curated error sentinels re-exported from `internal/errdefs`. Use `errors.Is` to branch on well-known failure modes without importing internal packages.                                                                                                                                                                                                            |
 
 Nothing under `internal/` is part of the supported surface and
 Go's visibility rules prevent external modules from importing it.
@@ -117,18 +117,38 @@ The steps below mirror
 
 ### 1. Build a `TerminalSpec`
 
+`pkg/builder` exposes two entry points. `BuildTerminalSpec` is the
+profile-free lane — it never touches `pkg/discovery`, never resolves
+an implicit `"default"` profile, and rejects `WithProfile` /
+`WithProfilesDir` with `errdefs.ErrInvalidOption` so misuse fails
+loud:
+
 ```go
 spec, err := builder.BuildTerminalSpec(ctx, logger, stateRoot,
     builder.WithName("library-consumer-example"),
     builder.WithCommand([]string{"/bin/bash", "--norc", "--noprofile"}),
     builder.WithEnv(map[string]string{"PS1": "example> "}),
-    builder.WithDisableSetPrompt(true),
+    builder.WithPrompt("example> "),
+    builder.WithOnInit([]api.ExecStep{{Script: "echo init"}}),
 )
 ```
 
-`runPath` is required; everything else has a sane default. Set
-`WithProfile(name)` + `WithProfilesDir(dir)` to load from a profiles
-directory. Inline `With*` values override profile values.
+Use `BuildTerminalSpecFromProfile` instead when the caller wants a
+YAML profile on disk to provide defaults (empty `WithProfile`
+resolves to `"default"`, missing `"default"` falls back to the
+hardcoded profile). Inline `With*` values override profile values
+on this lane:
+
+```go
+spec, err := builder.BuildTerminalSpecFromProfile(ctx, logger, stateRoot,
+    builder.WithProfilesDir("/etc/sbsh/profiles.d"),
+    builder.WithProfile("dev"),
+    builder.WithName("library-consumer-example"),
+)
+```
+
+`runPath` is required on both lanes; everything else has a sane
+default.
 
 ### 2. Spawn the terminal
 

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -52,6 +52,11 @@ var (
 	ErrConfig                   = errors.New("config error")
 	ErrLoggerNotFound           = errors.New("logger not found in context")
 	ErrInvalidFlag              = errors.New("invalid flag usage")
+	// ErrInvalidOption flags programmer misuse of a builder option — e.g.,
+	// passing WithProfile to the inline (profile-free) BuildTerminalSpec
+	// lane. Distinct from ErrInvalidFlag so library consumers can tell a
+	// CLI-flag parse error from an SDK call-site misuse.
+	ErrInvalidOption            = errors.New("invalid builder option")
 	ErrStdinStat                = errors.New("failed to stat stdin")
 	ErrStdinEmpty               = errors.New("no data on stdin: use a pipe or redirect when using '-'")
 	ErrInvalidArgument          = errors.New("invalid positional argument")

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -223,48 +223,59 @@ type BuildTerminalSpecParams struct {
 	EnvVars          []string
 	DisableSetPrompt bool
 	ShutdownGrace    time.Duration
+	// Stages carries the inline-overlay values for Spec.Stages. The
+	// *Overlay sentinels below decide which sub-fields are applied; an
+	// unset overlay leaves the profile-derived value untouched. For the
+	// inline lane the spec starts from zero, so the overlay flags decide
+	// whether the field is populated at all.
+	Stages api.StagesSpec
+	// StagesOverlay overlays the full Stages value; takes precedence over
+	// OnInitOverlay / PostAttachOverlay so a caller that mixes them gets
+	// the full-replacement semantics they asked for.
+	StagesOverlay bool
+	// OnInitOverlay overlays only Stages.OnInit when StagesOverlay is
+	// false.
+	OnInitOverlay bool
+	// PostAttachOverlay overlays only Stages.PostAttach when
+	// StagesOverlay is false.
+	PostAttachOverlay bool
+	// Prompt + PromptSet: PromptSet=true means "stamp Prompt onto the
+	// spec"; false leaves the profile-derived (or zero) value alone.
+	Prompt    string
+	PromptSet bool
+	// EnvInherit + EnvInheritSet follow the same set-sentinel discipline
+	// — false is a valid value, so we need an explicit "did the caller
+	// set this" bit.
+	EnvInherit    bool
+	EnvInheritSet bool
 }
 
-// BuildTerminalSpec builds a TerminalSpec from command-line inputs and/or a profile.
-// It applies defaults for missing values, and if a profile name is given, it loads
-// the profiles file and merges the profile into the spec.
-// The returned TerminalSpec is ready to be used to spawn a terminal.
+// applyParamDefaults resolves the per-terminal defaults that both
+// BuildTerminalSpecFromProfile and BuildTerminalSpecInline need: random
+// ID / name, runPath-derived paths for log/capture/socket, the inline
+// command default, and the profiles-dir fallback. Mutates input in place
+// the same way the legacy single-function path did, so caller-visible
+// fields the CLI later round-trips into TerminalStatus stay populated.
 //
-// RunPath is required. Callers (CLI or library consumers) must resolve their own
-// state-root default before invoking this function; an empty RunPath returns
-// errdefs.ErrRunPathRequired.
-//
-//nolint:funlen // For understandability, this function is long but straightforward.
-func BuildTerminalSpec(
-	ctx context.Context,
-	logger *slog.Logger,
-	input *BuildTerminalSpecParams,
-) (*api.TerminalSpec, error) {
-	if input.RunPath == "" {
-		return nil, errdefs.ErrRunPathRequired
-	}
-
+// RunPath is the only required input; callers must pre-check it before
+// invoking this helper.
+func applyParamDefaults(input *BuildTerminalSpecParams) {
 	if input.TerminalID == "" {
-		// Default terminal ID to a random one
 		input.TerminalID = naming.RandomID()
 	}
-
 	if input.TerminalName == "" {
 		input.TerminalName = naming.RandomName()
 	}
-
 	if input.ProfilesDir == "" {
 		// Fallback: sit next to run state under $RUN_PATH so profile lookup
 		// still has a well-defined path when the caller has not resolved the
 		// $HOME-based default (which normally happens in LoadConfig).
 		input.ProfilesDir = filepath.Join(input.RunPath, ".sbsh", "profiles.d")
 	}
-
 	if input.TerminalCmd == "" {
 		input.TerminalCmd = "/bin/bash"
 		input.TerminalCmdArgs = []string{"-i"}
 	}
-
 	if input.LogFile == "" {
 		input.LogFile = filepath.Join(
 			input.RunPath,
@@ -273,11 +284,9 @@ func BuildTerminalSpec(
 			"log",
 		)
 	}
-
 	if input.LogLevel == "" {
 		input.LogLevel = "info"
 	}
-
 	if input.CaptureFile == "" {
 		input.CaptureFile = filepath.Join(
 			input.RunPath,
@@ -286,7 +295,6 @@ func BuildTerminalSpec(
 			"capture",
 		)
 	}
-
 	if input.SocketFile == "" {
 		input.SocketFile = filepath.Join(
 			input.RunPath,
@@ -295,6 +303,31 @@ func BuildTerminalSpec(
 			"socket",
 		)
 	}
+}
+
+// BuildTerminalSpecFromProfile builds a TerminalSpec by loading a YAML
+// profile from pkg/discovery and overlaying the caller-provided inline
+// values. The legacy behavior of this package: empty ProfileName resolves
+// to "default", and a missing "default" falls back to the hardcoded
+// profile from GetDefaultHardcodedProfile.
+//
+// RunPath is required; an empty RunPath returns errdefs.ErrRunPathRequired.
+//
+// SDK callers that want a profile-free path (no disk lookup, no implicit
+// "default" resolution) should call BuildTerminalSpecInline instead.
+//
+
+func BuildTerminalSpecFromProfile(
+	ctx context.Context,
+	logger *slog.Logger,
+	input *BuildTerminalSpecParams,
+) (*api.TerminalSpec, error) {
+	if input.RunPath == "" {
+		return nil, errdefs.ErrRunPathRequired
+	}
+
+	applyParamDefaults(input)
+
 	if input.ProfileName == "" {
 		input.ProfileName = "default"
 	}
@@ -310,7 +343,12 @@ func BuildTerminalSpec(
 
 	var terminalSpec *api.TerminalSpec
 
-	profileSpec, warnings, errFind := discovery.FindProfileByNameInDir(ctx, logger, input.ProfilesDir, input.ProfileName)
+	profileSpec, warnings, errFind := discovery.FindProfileByNameInDir(
+		ctx,
+		logger,
+		input.ProfilesDir,
+		input.ProfileName,
+	)
 	for _, w := range warnings {
 		logger.WarnContext(ctx, "profile loader warning", "file", w.File, "doc", w.DocIndex, "reason", w.Reason)
 	}
@@ -344,6 +382,47 @@ func BuildTerminalSpec(
 	terminalSpec, errCreate = CreateTerminalFromProfile(profileSpec)
 	if errCreate != nil {
 		return nil, errCreate
+	}
+	addInputValuesToTerminal(terminalSpec, input)
+	if errOv := applyPermOverrides(terminalSpec, input); errOv != nil {
+		return nil, errOv
+	}
+
+	return terminalSpec, nil
+}
+
+// BuildTerminalSpecInline builds a TerminalSpec from inline fields only.
+// It does not touch pkg/discovery, does not resolve an implicit "default"
+// profile, and does not invoke GetDefaultHardcodedProfile. The returned
+// spec has zero-valued Stages / Prompt / EnvInherit unless the caller's
+// *Overlay / *Set sentinels are true, modulo the Cmd / CmdArgs defaults
+// that applyParamDefaults applies so the runner has a sensible shell.
+//
+// RunPath is required; an empty RunPath returns errdefs.ErrRunPathRequired.
+//
+// Misuse — passing a ProfileName or ProfilesDir — must be rejected by the
+// caller (pkg/builder enforces this at the public boundary).
+func BuildTerminalSpecInline(
+	ctx context.Context,
+	logger *slog.Logger,
+	input *BuildTerminalSpecParams,
+) (*api.TerminalSpec, error) {
+	if input.RunPath == "" {
+		return nil, errdefs.ErrRunPathRequired
+	}
+
+	applyParamDefaults(input)
+
+	logger.DebugContext(
+		ctx,
+		"Building terminal spec from inline options (no profile lookup)",
+		"terminalID", input.TerminalID,
+	)
+
+	terminalSpec := &api.TerminalSpec{
+		Kind:        api.TerminalLocal,
+		Command:     input.TerminalCmd,
+		CommandArgs: append([]string(nil), input.TerminalCmdArgs...),
 	}
 	addInputValuesToTerminal(terminalSpec, input)
 	if errOv := applyPermOverrides(terminalSpec, input); errOv != nil {
@@ -407,6 +486,8 @@ func applyOnePermOverride(
 // addInputValuesToTerminal mutates terminalSpec by overriding its fields with non-empty values from input.
 // It sets ID, Name, RunPath, CaptureFile, LogFile, LogLevel, SocketFile, and appends EnvVars, avoiding duplicates.
 // Cwd overrides the profile's Shell.Cwd only when non-empty so profile values stay sticky by default.
+// Stages / Prompt / EnvInherit overlays follow the *Overlay / *Set sentinels — false leaves whatever
+// the profile path (or zero-init) produced untouched.
 func addInputValuesToTerminal(terminalSpec *api.TerminalSpec, input *BuildTerminalSpecParams) {
 	terminalSpec.ID = api.ID(input.TerminalID)
 	terminalSpec.Name = input.TerminalName
@@ -423,6 +504,23 @@ func addInputValuesToTerminal(terminalSpec *api.TerminalSpec, input *BuildTermin
 	terminalSpec.SetPrompt = !input.DisableSetPrompt
 	if input.ShutdownGrace > 0 {
 		terminalSpec.ShutdownGrace = input.ShutdownGrace
+	}
+	switch {
+	case input.StagesOverlay:
+		terminalSpec.Stages = input.Stages
+	default:
+		if input.OnInitOverlay {
+			terminalSpec.Stages.OnInit = input.Stages.OnInit
+		}
+		if input.PostAttachOverlay {
+			terminalSpec.Stages.PostAttach = input.Stages.PostAttach
+		}
+	}
+	if input.PromptSet {
+		terminalSpec.Prompt = input.Prompt
+	}
+	if input.EnvInheritSet {
+		terminalSpec.EnvInherit = input.EnvInherit
 	}
 }
 

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -29,10 +29,19 @@ import (
 	"github.com/eminwux/sbsh/pkg/api"
 )
 
-func TestBuildTerminalSpec_EmptyRunPath_ReturnsErrRunPathRequired(t *testing.T) {
+func TestBuildTerminalSpecFromProfile_EmptyRunPath_ReturnsErrRunPathRequired(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	_, err := BuildTerminalSpec(context.Background(), logger, &BuildTerminalSpecParams{})
+	_, err := BuildTerminalSpecFromProfile(context.Background(), logger, &BuildTerminalSpecParams{})
+	if !errors.Is(err, errdefs.ErrRunPathRequired) {
+		t.Fatalf("expected errdefs.ErrRunPathRequired, got %v", err)
+	}
+}
+
+func TestBuildTerminalSpecInline_EmptyRunPath_ReturnsErrRunPathRequired(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	_, err := BuildTerminalSpecInline(context.Background(), logger, &BuildTerminalSpecParams{})
 	if !errors.Is(err, errdefs.ErrRunPathRequired) {
 		t.Fatalf("expected errdefs.ErrRunPathRequired, got %v", err)
 	}

--- a/pkg/builder/terminal.go
+++ b/pkg/builder/terminal.go
@@ -35,25 +35,35 @@ type TerminalOption func(*terminalConfig)
 // values. It mirrors the subset of profile.BuildTerminalSpecParams
 // that external callers are expected to control.
 type terminalConfig struct {
-	id               string
-	name             string
-	command          string
-	commandArgs      []string
-	envVars          []string
-	cwd              string
-	captureFile      string
-	captureMode      string
-	captureGID       *int
-	logFile          string
-	logFileMode      string
-	logFileGID       *int
-	logLevel         string
-	socketFile       string
-	socketMode       string
-	socketGID        *int
-	profileName      string
-	profilesDir      string
-	disableSetPrompt bool
+	id                string
+	name              string
+	command           string
+	commandArgs       []string
+	envVars           []string
+	cwd               string
+	captureFile       string
+	captureMode       string
+	captureGID        *int
+	logFile           string
+	logFileMode       string
+	logFileGID        *int
+	logLevel          string
+	socketFile        string
+	socketMode        string
+	socketGID         *int
+	profileName       string
+	profilesDir       string
+	profileSet        bool
+	profilesDirSet    bool
+	disableSetPrompt  bool
+	stages            api.StagesSpec
+	stagesOverlay     bool
+	onInitOverlay     bool
+	postAttachOverlay bool
+	prompt            string
+	promptSet         bool
+	envInherit        bool
+	envInheritSet     bool
 }
 
 // WithID sets the terminal ID. Empty means "generate a random ID".
@@ -71,16 +81,28 @@ func WithName(name string) TerminalOption {
 // resolved via WithProfilesDir (or the default location if no
 // explicit path is set). Empty resolves to the hardcoded "default"
 // profile.
+//
+// Honored only by BuildTerminalSpecFromProfile. Passing this option to
+// the inline BuildTerminalSpec returns an errdefs.ErrInvalidOption.
 func WithProfile(name string) TerminalOption {
-	return func(c *terminalConfig) { c.profileName = name }
+	return func(c *terminalConfig) {
+		c.profileName = name
+		c.profileSet = true
+	}
 }
 
 // WithProfilesDir points the builder at a directory that is scanned
 // recursively for *.yaml / *.yml files containing TerminalProfile
 // documents. Empty means "use the default profiles directory
 // ($HOME/.sbsh/profiles.d/)".
+//
+// Honored only by BuildTerminalSpecFromProfile. Passing this option to
+// the inline BuildTerminalSpec returns an errdefs.ErrInvalidOption.
 func WithProfilesDir(path string) TerminalOption {
-	return func(c *terminalConfig) { c.profilesDir = path }
+	return func(c *terminalConfig) {
+		c.profilesDir = path
+		c.profilesDirSet = true
+	}
 }
 
 // WithCommand sets the terminal's command and its argv. argv[0] is
@@ -214,13 +236,78 @@ func WithDisableSetPrompt(disable bool) TerminalOption {
 	return func(c *terminalConfig) { c.disableSetPrompt = disable }
 }
 
-// BuildTerminalSpec produces a TerminalSpec from a runPath plus an
-// optional profile selection and inline overrides. It wraps
-// internal/profile.BuildTerminalSpec and keeps the same resolution
-// rules: inline option values override profile values, and a
-// missing profile falls back to the hardcoded "default" profile
-// only when the requested profile name is literally "default" (or
-// empty).
+// WithStages overlays the full StagesSpec onto the resulting
+// TerminalSpec.Stages. Takes precedence over WithOnInit /
+// WithPostAttach when called: a later WithStages replaces both
+// sub-fields with whatever the StagesSpec carries (including empty
+// slices).
+func WithStages(s api.StagesSpec) TerminalOption {
+	return func(c *terminalConfig) {
+		c.stages = s
+		c.stagesOverlay = true
+		c.onInitOverlay = false
+		c.postAttachOverlay = false
+	}
+}
+
+// WithOnInit overlays only Spec.Stages.OnInit. Compose with
+// WithPostAttach to populate both sub-fields independently. If a
+// later WithStages call follows, it replaces everything WithOnInit
+// set.
+func WithOnInit(steps []api.ExecStep) TerminalOption {
+	return func(c *terminalConfig) {
+		c.stages.OnInit = append([]api.ExecStep(nil), steps...)
+		c.onInitOverlay = true
+		// A bare WithOnInit must not promote to a full-stages overlay,
+		// otherwise PostAttach would silently be cleared on the inline
+		// lane.
+		c.stagesOverlay = false
+	}
+}
+
+// WithPostAttach overlays only Spec.Stages.PostAttach. Mirror of
+// WithOnInit.
+func WithPostAttach(steps []api.ExecStep) TerminalOption {
+	return func(c *terminalConfig) {
+		c.stages.PostAttach = append([]api.ExecStep(nil), steps...)
+		c.postAttachOverlay = true
+		c.stagesOverlay = false
+	}
+}
+
+// WithPrompt stamps Spec.Prompt with the supplied value. Empty is a
+// valid value — callers that want sbsh's runner to skip the prompt
+// rewrite should pair this with WithDisableSetPrompt(true) instead
+// of relying on emptiness.
+func WithPrompt(prompt string) TerminalOption {
+	return func(c *terminalConfig) {
+		c.prompt = prompt
+		c.promptSet = true
+	}
+}
+
+// WithEnvInherit stamps Spec.EnvInherit. The set-sentinel discipline
+// is required because false is a meaningful value distinct from
+// "caller did not say".
+func WithEnvInherit(b bool) TerminalOption {
+	return func(c *terminalConfig) {
+		c.envInherit = b
+		c.envInheritSet = true
+	}
+}
+
+// BuildTerminalSpec produces a TerminalSpec from a runPath plus
+// inline TerminalOption values. It does not load a YAML profile, does
+// not run pkg/discovery, and does not fall back to the hardcoded
+// "default" profile — every shell-shaped field on the resulting spec
+// comes from the With* options the caller passed (modulo the
+// Cmd/CmdArgs default of /bin/bash -i so the runner has a sensible
+// shell when the caller does not set one).
+//
+// Passing WithProfile or WithProfilesDir is rejected with
+// errdefs.ErrInvalidOption — those options are only honored by
+// BuildTerminalSpecFromProfile. Mixing the two lanes silently would
+// hide a programmer bug; fail loud instead.
 //
 // runPath is required; an empty runPath returns
 // errdefs.ErrRunPathRequired.
@@ -240,27 +327,90 @@ func BuildTerminalSpec(
 			opt(&cfg)
 		}
 	}
+	if cfg.profileSet {
+		return nil, fmt.Errorf(
+			"%w: WithProfile is only honored by BuildTerminalSpecFromProfile",
+			errdefs.ErrInvalidOption,
+		)
+	}
+	if cfg.profilesDirSet {
+		return nil, fmt.Errorf(
+			"%w: WithProfilesDir is only honored by BuildTerminalSpecFromProfile",
+			errdefs.ErrInvalidOption,
+		)
+	}
 
-	return profile.BuildTerminalSpec(ctx, logger, &profile.BuildTerminalSpecParams{
-		TerminalID:       cfg.id,
-		TerminalName:     cfg.name,
-		TerminalCmd:      cfg.command,
-		TerminalCmdArgs:  cfg.commandArgs,
-		Cwd:              cfg.cwd,
-		CaptureFile:      cfg.captureFile,
-		RunPath:          runPath,
-		ProfilesDir:      cfg.profilesDir,
-		ProfileName:      cfg.profileName,
-		LogFile:          cfg.logFile,
-		LogLevel:         cfg.logLevel,
-		SocketFile:       cfg.socketFile,
-		SocketMode:       cfg.socketMode,
-		SocketGID:        cfg.socketGID,
-		CaptureMode:      cfg.captureMode,
-		CaptureGID:       cfg.captureGID,
-		LogFileMode:      cfg.logFileMode,
-		LogFileGID:       cfg.logFileGID,
-		EnvVars:          cfg.envVars,
-		DisableSetPrompt: cfg.disableSetPrompt,
-	})
+	return profile.BuildTerminalSpecInline(ctx, logger, paramsFromConfig(&cfg, runPath))
+}
+
+// BuildTerminalSpecFromProfile produces a TerminalSpec by loading a
+// YAML profile from pkg/discovery and overlaying inline With* values
+// on top. It preserves the legacy resolution rules: an empty
+// WithProfile resolves to "default", a missing "default" falls back
+// to the hardcoded profile, and inline options override profile-derived
+// values for the matching fields.
+//
+// Use this entry point when the caller wants profile-driven defaults
+// (the in-tree CLI lane, profile-driven tests). SDK consumers that
+// want to build a spec entirely from in-memory fields should call
+// BuildTerminalSpec instead.
+//
+// runPath is required; an empty runPath returns
+// errdefs.ErrRunPathRequired.
+func BuildTerminalSpecFromProfile(
+	ctx context.Context,
+	logger *slog.Logger,
+	runPath string,
+	opts ...TerminalOption,
+) (*api.TerminalSpec, error) {
+	if runPath == "" {
+		return nil, errdefs.ErrRunPathRequired
+	}
+
+	cfg := terminalConfig{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+
+	return profile.BuildTerminalSpecFromProfile(ctx, logger, paramsFromConfig(&cfg, runPath))
+}
+
+// paramsFromConfig is the single conversion point between the
+// builder's option accumulator and the internal/profile parameter
+// struct. Keeping it in one place ensures the two lanes share the
+// exact same set of inline fields — adding a new With* option means
+// editing exactly one mapping.
+func paramsFromConfig(cfg *terminalConfig, runPath string) *profile.BuildTerminalSpecParams {
+	return &profile.BuildTerminalSpecParams{
+		TerminalID:        cfg.id,
+		TerminalName:      cfg.name,
+		TerminalCmd:       cfg.command,
+		TerminalCmdArgs:   cfg.commandArgs,
+		Cwd:               cfg.cwd,
+		CaptureFile:       cfg.captureFile,
+		RunPath:           runPath,
+		ProfilesDir:       cfg.profilesDir,
+		ProfileName:       cfg.profileName,
+		LogFile:           cfg.logFile,
+		LogLevel:          cfg.logLevel,
+		SocketFile:        cfg.socketFile,
+		SocketMode:        cfg.socketMode,
+		SocketGID:         cfg.socketGID,
+		CaptureMode:       cfg.captureMode,
+		CaptureGID:        cfg.captureGID,
+		LogFileMode:       cfg.logFileMode,
+		LogFileGID:        cfg.logFileGID,
+		EnvVars:           cfg.envVars,
+		DisableSetPrompt:  cfg.disableSetPrompt,
+		Stages:            cfg.stages,
+		StagesOverlay:     cfg.stagesOverlay,
+		OnInitOverlay:     cfg.onInitOverlay,
+		PostAttachOverlay: cfg.postAttachOverlay,
+		Prompt:            cfg.prompt,
+		PromptSet:         cfg.promptSet,
+		EnvInherit:        cfg.envInherit,
+		EnvInheritSet:     cfg.envInheritSet,
+	}
 }

--- a/pkg/builder/terminal_test.go
+++ b/pkg/builder/terminal_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/pkg/api"
 	"github.com/eminwux/sbsh/pkg/builder"
 )
 
@@ -74,8 +75,9 @@ func TestBuildTerminalSpec_EmptyRunPath(t *testing.T) {
 	}
 }
 
-// InlineOnly: no profile file, no profile name — falls back to the
-// hardcoded "default" profile with the inline command/env.
+// InlineOnly: BuildTerminalSpec is the profile-free lane — the
+// resulting spec carries the inline command/env verbatim and never
+// touches pkg/discovery or the hardcoded "default" profile.
 func TestBuildTerminalSpec_InlineOnly(t *testing.T) {
 	runPath := t.TempDir()
 	spec, err := builder.BuildTerminalSpec(
@@ -119,7 +121,7 @@ func TestBuildTerminalSpec_ProfileByName(t *testing.T) {
 	runPath := t.TempDir()
 	profiles := writeProfiles(t, twoProfilesYAML)
 
-	spec, err := builder.BuildTerminalSpec(
+	spec, err := builder.BuildTerminalSpecFromProfile(
 		context.Background(),
 		testLogger(),
 		runPath,
@@ -153,7 +155,7 @@ func TestBuildTerminalSpec_UnknownProfile(t *testing.T) {
 	runPath := t.TempDir()
 	profiles := writeProfiles(t, twoProfilesYAML)
 
-	_, err := builder.BuildTerminalSpec(
+	_, err := builder.BuildTerminalSpecFromProfile(
 		context.Background(),
 		testLogger(),
 		runPath,
@@ -233,7 +235,7 @@ func TestBuildTerminalSpec_MissingProfilesDir(t *testing.T) {
 	runPath := t.TempDir()
 	missing := filepath.Join(runPath, "no-such-profiles-dir")
 
-	_, err := builder.BuildTerminalSpec(
+	_, err := builder.BuildTerminalSpecFromProfile(
 		context.Background(),
 		testLogger(),
 		runPath,
@@ -299,7 +301,7 @@ spec:
 	profiles := writeProfiles(t, profilesYAML)
 
 	// No WithCwd: profile value sticks.
-	spec, err := builder.BuildTerminalSpec(
+	spec, err := builder.BuildTerminalSpecFromProfile(
 		context.Background(),
 		testLogger(),
 		runPath,
@@ -314,7 +316,7 @@ spec:
 	}
 
 	// With WithCwd: inline wins.
-	spec, err = builder.BuildTerminalSpec(
+	spec, err = builder.BuildTerminalSpecFromProfile(
 		context.Background(),
 		testLogger(),
 		runPath,
@@ -563,5 +565,361 @@ func TestBuildTerminalSpec_WithCommandEmpty(t *testing.T) {
 	}
 	if !reflect.DeepEqual(spec.CommandArgs, []string{"-i"}) {
 		t.Fatalf("args: got %v", spec.CommandArgs)
+	}
+}
+
+// WithStages stamps the full StagesSpec on the inline lane — no
+// profile, no hardcoded default, just the bytes the caller passed.
+func TestBuildTerminalSpec_WithStages_Inline(t *testing.T) {
+	runPath := t.TempDir()
+	stages := api.StagesSpec{
+		OnInit:     []api.ExecStep{{Script: "echo init"}},
+		PostAttach: []api.ExecStep{{Script: "echo attach"}},
+	}
+	spec, err := builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithStages(stages),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(spec.Stages, stages) {
+		t.Fatalf("Stages: want %+v, got %+v", stages, spec.Stages)
+	}
+}
+
+// WithOnInit / WithPostAttach populate only their respective
+// sub-field on the inline lane, leaving the other side at zero.
+func TestBuildTerminalSpec_WithOnInitWithPostAttach_Inline(t *testing.T) {
+	runPath := t.TempDir()
+	onInit := []api.ExecStep{{Script: "init"}}
+	post := []api.ExecStep{{Script: "post"}}
+
+	t.Run("OnInit only", func(t *testing.T) {
+		spec, err := builder.BuildTerminalSpec(
+			context.Background(),
+			testLogger(),
+			runPath,
+			builder.WithOnInit(onInit),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !reflect.DeepEqual(spec.Stages.OnInit, onInit) {
+			t.Fatalf("OnInit: want %+v, got %+v", onInit, spec.Stages.OnInit)
+		}
+		if len(spec.Stages.PostAttach) != 0 {
+			t.Fatalf("PostAttach: want empty, got %+v", spec.Stages.PostAttach)
+		}
+	})
+	t.Run("PostAttach only", func(t *testing.T) {
+		spec, err := builder.BuildTerminalSpec(
+			context.Background(),
+			testLogger(),
+			runPath,
+			builder.WithPostAttach(post),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !reflect.DeepEqual(spec.Stages.PostAttach, post) {
+			t.Fatalf("PostAttach: want %+v, got %+v", post, spec.Stages.PostAttach)
+		}
+		if len(spec.Stages.OnInit) != 0 {
+			t.Fatalf("OnInit: want empty, got %+v", spec.Stages.OnInit)
+		}
+	})
+	t.Run("OnInit + PostAttach compose", func(t *testing.T) {
+		spec, err := builder.BuildTerminalSpec(
+			context.Background(),
+			testLogger(),
+			runPath,
+			builder.WithOnInit(onInit),
+			builder.WithPostAttach(post),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !reflect.DeepEqual(spec.Stages.OnInit, onInit) {
+			t.Fatalf("OnInit: got %+v", spec.Stages.OnInit)
+		}
+		if !reflect.DeepEqual(spec.Stages.PostAttach, post) {
+			t.Fatalf("PostAttach: got %+v", spec.Stages.PostAttach)
+		}
+	})
+}
+
+// WithPrompt populates Spec.Prompt on the inline lane.
+func TestBuildTerminalSpec_WithPrompt_Inline(t *testing.T) {
+	runPath := t.TempDir()
+	spec, err := builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithPrompt("> "),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.Prompt != "> " {
+		t.Fatalf("Prompt: want %q, got %q", "> ", spec.Prompt)
+	}
+}
+
+// WithEnvInherit populates Spec.EnvInherit on the inline lane, with
+// the set-sentinel discipline that distinguishes "caller passed
+// false" from "caller did not pass anything".
+func TestBuildTerminalSpec_WithEnvInherit_Inline(t *testing.T) {
+	runPath := t.TempDir()
+
+	// Default: no WithEnvInherit → zero value (false). This is a
+	// behavior change from the FromProfile lane's hardcoded-default
+	// (which sets EnvInherit=true), and the contract for the inline
+	// lane is "zero unless set".
+	spec, err := builder.BuildTerminalSpec(context.Background(), testLogger(), runPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.EnvInherit {
+		t.Fatalf("default EnvInherit: want false, got true")
+	}
+
+	// Explicit true.
+	spec, err = builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithEnvInherit(true),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !spec.EnvInherit {
+		t.Fatalf("WithEnvInherit(true): want true, got false")
+	}
+}
+
+// Inline lane must reject WithProfile / WithProfilesDir with
+// errdefs.ErrInvalidOption. Silently ignoring them would hide a
+// programmer bug — fail loud.
+func TestBuildTerminalSpec_RejectsWithProfile(t *testing.T) {
+	runPath := t.TempDir()
+	_, err := builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithProfile("anything"),
+	)
+	if !errors.Is(err, errdefs.ErrInvalidOption) {
+		t.Fatalf("expected errdefs.ErrInvalidOption, got %v", err)
+	}
+}
+
+func TestBuildTerminalSpec_RejectsWithProfilesDir(t *testing.T) {
+	runPath := t.TempDir()
+	_, err := builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithProfilesDir("/tmp/whatever"),
+	)
+	if !errors.Is(err, errdefs.ErrInvalidOption) {
+		t.Fatalf("expected errdefs.ErrInvalidOption, got %v", err)
+	}
+}
+
+// Inline lane must not touch disk — even when the runPath-derived
+// default profilesDir does not exist, the build must succeed.
+// Passing WithProfilesDir is rejected upfront (see above), so the
+// "did not touch disk" guarantee turns on the absence of any
+// discovery call in the no-profile-option case.
+func TestBuildTerminalSpec_InlineDoesNotTouchDisk(t *testing.T) {
+	runPath := t.TempDir()
+	// Deliberately wipe out the runPath so any opportunistic
+	// directory scan would surface as an error.
+	if err := os.RemoveAll(runPath); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+
+	_, err := builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithCommand([]string{"/bin/sh"}),
+	)
+	if err != nil {
+		t.Fatalf("inline lane should not touch disk; got %v", err)
+	}
+}
+
+// FromProfile lane must accept the new With* options as overlays on
+// top of a profile-derived spec.
+func TestBuildTerminalSpecFromProfile_WithStages_Overlay(t *testing.T) {
+	const profilesYAML = `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: stages-profile
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/bash
+  stages:
+    onInit:
+      - script: profile-init
+`
+	runPath := t.TempDir()
+	profiles := writeProfiles(t, profilesYAML)
+
+	// Profile alone: OnInit comes from YAML, PostAttach is zero.
+	spec, err := builder.BuildTerminalSpecFromProfile(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithProfilesDir(filepath.Dir(profiles)),
+		builder.WithProfile("stages-profile"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(spec.Stages.OnInit) != 1 || spec.Stages.OnInit[0].Script != "profile-init" {
+		t.Fatalf("profile-derived OnInit: got %+v", spec.Stages.OnInit)
+	}
+
+	// Inline override of OnInit only: PostAttach stays zero,
+	// OnInit is replaced wholesale.
+	spec, err = builder.BuildTerminalSpecFromProfile(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithProfilesDir(filepath.Dir(profiles)),
+		builder.WithProfile("stages-profile"),
+		builder.WithOnInit([]api.ExecStep{{Script: "inline-init"}}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(spec.Stages.OnInit) != 1 || spec.Stages.OnInit[0].Script != "inline-init" {
+		t.Fatalf("overlay OnInit: got %+v", spec.Stages.OnInit)
+	}
+
+	// Inline override with WithStages: replaces both sub-fields.
+	spec, err = builder.BuildTerminalSpecFromProfile(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithProfilesDir(filepath.Dir(profiles)),
+		builder.WithProfile("stages-profile"),
+		builder.WithStages(api.StagesSpec{
+			OnInit:     []api.ExecStep{{Script: "new-init"}},
+			PostAttach: []api.ExecStep{{Script: "new-post"}},
+		}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(spec.Stages.OnInit) != 1 || spec.Stages.OnInit[0].Script != "new-init" {
+		t.Fatalf("WithStages OnInit: got %+v", spec.Stages.OnInit)
+	}
+	if len(spec.Stages.PostAttach) != 1 || spec.Stages.PostAttach[0].Script != "new-post" {
+		t.Fatalf("WithStages PostAttach: got %+v", spec.Stages.PostAttach)
+	}
+}
+
+// FromProfile + WithPrompt overlays prompt onto the profile-derived
+// value.
+func TestBuildTerminalSpecFromProfile_WithPrompt_Overlay(t *testing.T) {
+	const profilesYAML = `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: prompt-profile
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/bash
+    prompt: "(profile) "
+`
+	runPath := t.TempDir()
+	profiles := writeProfiles(t, profilesYAML)
+
+	// Profile alone.
+	spec, err := builder.BuildTerminalSpecFromProfile(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithProfilesDir(filepath.Dir(profiles)),
+		builder.WithProfile("prompt-profile"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.Prompt != "(profile) " {
+		t.Fatalf("profile Prompt: got %q", spec.Prompt)
+	}
+
+	// Inline override wins.
+	spec, err = builder.BuildTerminalSpecFromProfile(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithProfilesDir(filepath.Dir(profiles)),
+		builder.WithProfile("prompt-profile"),
+		builder.WithPrompt("(inline) "),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.Prompt != "(inline) " {
+		t.Fatalf("inline Prompt: got %q", spec.Prompt)
+	}
+}
+
+// FromProfile + WithEnvInherit overlays EnvInherit. The profile
+// schema's `inheritEnv: true` is overlaid by WithEnvInherit(false)
+// without losing the "did the caller say so" sentinel.
+func TestBuildTerminalSpecFromProfile_WithEnvInherit_Overlay(t *testing.T) {
+	const profilesYAML = `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: env-profile
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/bash
+    inheritEnv: true
+`
+	runPath := t.TempDir()
+	profiles := writeProfiles(t, profilesYAML)
+
+	// Profile alone: EnvInherit=true.
+	spec, err := builder.BuildTerminalSpecFromProfile(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithProfilesDir(filepath.Dir(profiles)),
+		builder.WithProfile("env-profile"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !spec.EnvInherit {
+		t.Fatalf("profile EnvInherit: want true, got false")
+	}
+
+	// Inline EnvInherit(false) wins.
+	spec, err = builder.BuildTerminalSpecFromProfile(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithProfilesDir(filepath.Dir(profiles)),
+		builder.WithProfile("env-profile"),
+		builder.WithEnvInherit(false),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.EnvInherit {
+		t.Fatalf("overlay EnvInherit(false): want false, got true")
 	}
 }


### PR DESCRIPTION
## Summary

Splits `pkg/builder.BuildTerminalSpec` into two entry points so SDK consumers can build a `TerminalSpec` from in-memory fields, without writing a YAML profile to disk or accepting the hardcoded `"default"` profile fallback.

- `BuildTerminalSpec(ctx, logger, runPath, opts...)` — **inline-only**. No `pkg/discovery`, no implicit `"default"` resolution, no `GetDefaultHardcodedProfile`. Stages / Prompt / EnvInherit stay zero unless the matching `With*` option is passed; Cmd / CmdArgs default to `/bin/bash -i` to preserve a sensible runner default.
- `BuildTerminalSpecFromProfile(ctx, logger, runPath, opts...)` — legacy profile path. Empty `WithProfile` resolves to `"default"`, runs disk discovery, falls back to `GetDefaultHardcodedProfile` for the `"default"` name only. Inline `With*` options overlay onto the profile-derived spec.
- New options: `WithStages`, `WithOnInit`, `WithPostAttach`, `WithPrompt`, `WithEnvInherit`. All five are plumbed end-to-end into `Spec.Stages` / `Spec.Prompt` / `Spec.EnvInherit`, on both lanes.
- Passing `WithProfile` or `WithProfilesDir` to the inline lane returns `errdefs.ErrInvalidOption` — fail loud, never silently ignore.

`cmd/sbsh` and `cmd/sbsh/terminal` migrated to `BuildTerminalSpecFromProfile`. CHANGELOG.md created with migration notes for both audiences.

## Test plan

- [x] `make sbsh-sb` — produces ELF binaries `sbsh` and `sb`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` — full unit suite (mirrors CI)
- [x] `go test -tags=integration ./cmd/sb/get/...`
- [x] `cd docs/examples/library-consumer && go build ./... && go vet ./...` — out-of-tree consumer compiles unchanged on the inline lane
- [x] `pre-commit run --files ...` — fmt / golangci-lint / addlicense / prettier all clean
- [ ] `make test-e2e` — not run; e2e suite excluded by both `make test` and CI's unit job (`grep -v '/e2e$'`), and exercises the same CLI entry points covered by the migrated unit tests

Closes #209