### PR TITLE
fix(terminalrunner): close client pipe fds on cleanup and detach

### DIFF
--- a/internal/terminal/terminalrunner/connections.go
+++ b/internal/terminal/terminalrunner/connections.go
@@ -38,6 +38,21 @@ func (sr *Exec) cleanupClient(client *ioClient) {
 		multiOutW.Remove(client.pipeOutW)
 	}
 
+	// Release the per-client pipe fds; otherwise each Attach/Detach cycle
+	// leaks both ends in the runner process. Close pipeOutW first so any
+	// bytes still buffered in the pipe can drain to the writer copier,
+	// then pipeOutR so its Read unblocks with EOF and the goroutine exits.
+	if client.pipeOutW != nil {
+		if perr := client.pipeOutW.Close(); perr != nil {
+			sr.logger.Debug("error closing client pipeOutW", "err", perr, "client", client.id)
+		}
+	}
+	if client.pipeOutR != nil {
+		if perr := client.pipeOutR.Close(); perr != nil {
+			sr.logger.Debug("error closing client pipeOutR", "err", perr, "client", client.id)
+		}
+	}
+
 	if cerr := client.conn.Close(); cerr != nil {
 		sr.logger.Warn("error closing client connection", "err", cerr, "client", client.id)
 	}

--- a/internal/terminal/terminalrunner/lifecycle.go
+++ b/internal/terminal/terminalrunner/lifecycle.go
@@ -332,6 +332,23 @@ func (sr *Exec) Detach(id *api.ID) error {
 	// TODO: remove from stdin fan-in if you have that side too
 	// sr.ptyPipes.multiInR.Remove(ioClient.pipeInR)
 
+	// 2a) Release the per-client pipe fds. cleanupClient (which would
+	// otherwise close them) never fires on Detach because CopierManager
+	// only invokes finish() on ctx.Done(), so without this every
+	// Attach/Detach cycle leaks both pipe ends in the runner process.
+	// Closing pipeOutR also unblocks the writer copier's Read so its
+	// goroutine exits instead of parking until terminal shutdown.
+	if ioClient.pipeOutW != nil {
+		if perr := ioClient.pipeOutW.Close(); perr != nil {
+			sr.logger.Debug("error closing client pipeOutW", "err", perr, "client", ioClient.id)
+		}
+	}
+	if ioClient.pipeOutR != nil {
+		if perr := ioClient.pipeOutR.Close(); perr != nil {
+			sr.logger.Debug("error closing client pipeOutR", "err", perr, "client", ioClient.id)
+		}
+	}
+
 	// 3) Drop from the registry so it’s no longer discoverable
 	sr.removeClient(ioClient)
 

--- a/pkg/terminal/server/server_attach_pipefdleak_linux_test.go
+++ b/pkg/terminal/server/server_attach_pipefdleak_linux_test.go
@@ -1,0 +1,121 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package server_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/pkg/api"
+	rpcclient "github.com/eminwux/sbsh/pkg/rpcclient/terminal"
+)
+
+// TestServer_AttachDetachCycles_NoPipeFDLeak locks in the fix for
+// issue #215: setupPipes allocates an os.Pipe pair per Attach that
+// cleanupClient (and the Detach fast-path) used to leave open for the
+// lifetime of the runner process. The sibling SCM_RIGHTS test counts
+// only socket-typed fds because, before this fix, the pipe leak (two
+// fds per cycle) would dwarf the socket signal.
+//
+// This test counts only pipe-typed fds (`/proc/self/fd` entries whose
+// readlink starts with `pipe:`) so the SCM_RIGHTS regression and this
+// one stay independent. Without the cleanup fix every Attach/Detach
+// cycle leaks two pipe fds in the runner process; with it the count is
+// flat across cycles.
+func TestServer_AttachDetachCycles_NoPipeFDLeak(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	h := startTestServer(ctx, t)
+	defer h.cleanup()
+
+	client := rpcclient.NewUnix(h.socketPath, h.logger)
+	defer client.Close()
+
+	// Warm-up cycle: surface one-shot allocations (lazy pipes, goroutines
+	// holding read-side fds) before the baseline.
+	if err := attachDetachOnce(ctx, client, "warmup"); err != nil {
+		t.Fatalf("warmup attach/detach: %v", err)
+	}
+	// Detach closes the runner-side conn asynchronously after a 100ms
+	// grace window; wait past that so the baseline is steady.
+	time.Sleep(300 * time.Millisecond)
+
+	baseline, err := countOpenPipeFDs()
+	if err != nil {
+		t.Fatalf("countOpenPipeFDs (baseline): %v", err)
+	}
+
+	const cycles = 20
+	for i := range cycles {
+		clientID := api.ID(fmt.Sprintf("pipeleak-%d", i))
+		if cycleErr := attachDetachOnce(ctx, client, clientID); cycleErr != nil {
+			t.Fatalf("cycle %d: %v", i, cycleErr)
+		}
+	}
+	// Same grace as above: let the runner's deferred conn.Close fire on
+	// the last cycle before counting.
+	time.Sleep(300 * time.Millisecond)
+
+	after, err := countOpenPipeFDs()
+	if err != nil {
+		t.Fatalf("countOpenPipeFDs (after): %v", err)
+	}
+
+	// Without the cleanup fix every cycle leaks two pipe fds (the
+	// pipeOutR/pipeOutW pair allocated in setupPipes), so 20 cycles
+	// produced +40. The tolerance covers any in-flight Go-runtime pipes
+	// (netpoll wake-up, gc) that briefly appear under load. Anything
+	// close to 2*cycles means the leak is back.
+	delta := after - baseline
+	tolerance := cycles / 2
+	if delta > tolerance {
+		t.Fatalf(
+			"open pipe fd count grew by %d over %d attach/detach cycles (tolerance %d, baseline %d, after %d) — cleanupClient/Detach likely leaking the setupPipes pair again",
+			delta,
+			cycles,
+			tolerance,
+			baseline,
+			after,
+		)
+	}
+}
+
+func countOpenPipeFDs() (int, error) {
+	entries, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		return 0, err
+	}
+	n := 0
+	for _, e := range entries {
+		target, lerr := os.Readlink("/proc/self/fd/" + e.Name())
+		if lerr != nil {
+			// fd may have been reaped between ReadDir and Readlink; skip.
+			continue
+		}
+		if strings.HasPrefix(target, "pipe:") {
+			n++
+		}
+	}
+	return n, nil
+}


### PR DESCRIPTION
## Summary
- `setupPipes` allocates an `os.Pipe` pair per Attach and stashes it on the `ioClient`; neither end was ever closed, so each Attach/Detach cycle leaked two pipe fds in the runner process (issue #215). PR #213's SCM_RIGHTS regression test counted only socket-typed fds for exactly this reason — without that filter the pipe leak would have dwarfed the socket signal it was measuring.
- Add the close to `cleanupClient` (matching the issue's proposed location) **and** to `Detach`. The issue's proposal targets `cleanupClient` alone, but in the current code path `CopierManager` only invokes its `finish()` callback on `ctx.Done()` (terminal shutdown) — so `cleanupClient` never fires on a normal `Detach` and a `cleanupClient`-only fix would not close the per-cycle leak the issue measures or unblock the writer-copier goroutine on the multiwriter side (AC #4). Treating this as the "premise rotted but intent inferable" case per `dev/CLAUDE.md`: proceeding with the broader scope and documenting it here. Reviewer push-back welcome if the preferred fix is instead to make `Detach` route through `cleanupClient`, or to fix `CopierManager`'s errgroup branch to also call `finish()`.
- Order in both call sites matches the proposal: `multiOutW.Remove(pipeOutW)` first, then close `pipeOutW` (let any buffered bytes drain to the writer copier), then `pipeOutR` (unblocks the writer's `Read` with EOF so its goroutine exits).

## Test plan
- [x] `make sbsh-sb` — produces ELF `sbsh` and hardlinks `sb`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` — full CI unit-test surface
- [x] `make test` — includes integration + e2e
- [x] `pre-commit run --files <changed files>` — go-fmt, golangci-lint, addlicense all pass
- [x] New regression test `TestServer_AttachDetachCycles_NoPipeFDLeak` in `pkg/terminal/server/server_attach_pipefdleak_linux_test.go` counts pipe-typed fds across 20 Attach/Detach cycles; flat with the fix, +40 without (matches the issue's repro number)
- [x] Existing `TestServer_AttachDetachCycles_NoFDLeak` (SCM_RIGHTS regression) still passes — the two tests stay independent (socket-typed vs pipe-typed fd counting)

Closes #215