### PR TITLE
fix(terminalrunner): bound interactive attacher writer to unblock fan-out

### DIFF
--- a/internal/terminal/terminalrunner/connections.go
+++ b/internal/terminal/terminalrunner/connections.go
@@ -18,57 +18,74 @@ package terminalrunner
 
 import (
 	"net"
+	"sync"
 
 	"github.com/eminwux/sbsh/internal/dualcopier"
 	"github.com/eminwux/sbsh/pkg/api"
 )
 
+// cleanupClient is the converging cleanup path for an interactive attach.
+// It is invoked exactly once per client (guarded by detachOnce at the call
+// site): on graceful Detach, on reader-side error from the dualcopier,
+// and on bounded-writer lagged-detach. It is responsible for removing the
+// attacher from the PTY fan-out, signalling the drain goroutine to exit
+// (the drain owns the conn close on its defer), and updating
+// metadata.Status.Attachers.
 func (sr *Exec) cleanupClient(client *ioClient) {
 	sr.logger.Info("client connection handler exiting", "client", client.id)
 
-	// Drop this client's pipe from the fan-out *before* closing the conn so
-	// no further PTY output targets a dying writer. Without this, an abrupt
-	// disconnect (socket EOF, attacher kill, network drop) leaves the dead
-	// pipeOutW in multiOutW; a later broken pipe used to cascade into a
-	// fatal terminal event and reap the child process.
+	// Drop this client's writer from the fan-out *before* closing it so no
+	// further PTY output targets a dying ring.
 	sr.ptyPipesMu.RLock()
 	multiOutW := sr.ptyPipes.multiOutW
 	sr.ptyPipesMu.RUnlock()
-	if multiOutW != nil && client.pipeOutW != nil {
-		multiOutW.Remove(client.pipeOutW)
+	if multiOutW != nil && client.outWriter != nil {
+		multiOutW.Remove(client.outWriter)
 	}
 
-	// Release the per-client pipe fds; otherwise each Attach/Detach cycle
-	// leaks both ends in the runner process. Close pipeOutW first so any
-	// bytes still buffered in the pipe can drain to the writer copier,
-	// then pipeOutR so its Read unblocks with EOF and the goroutine exits.
-	if client.pipeOutW != nil {
-		if perr := client.pipeOutW.Close(); perr != nil {
-			sr.logger.Debug("error closing client pipeOutW", "err", perr, "client", client.id)
-		}
-	}
-	if client.pipeOutR != nil {
-		if perr := client.pipeOutR.Close(); perr != nil {
-			sr.logger.Debug("error closing client pipeOutR", "err", perr, "client", client.id)
+	// Closing outWriter signals its drain goroutine to flush any pending
+	// bytes and exit; the drain's deferred conn.Close releases the
+	// socketpair fd. We do not close conn directly here so the drain
+	// remains the sole owner of the lifecycle — double-close on a
+	// *net.UnixConn just logs and is harmless, but a single owner keeps
+	// the path easy to reason about.
+	if client.outWriter != nil {
+		_ = client.outWriter.Close()
+	} else if client.conn != nil {
+		// Early-failure fallback: handleClient never wired the writer,
+		// so there is no drain goroutine to take the conn with it.
+		if cerr := client.conn.Close(); cerr != nil {
+			sr.logger.Warn("error closing client connection", "err", cerr, "client", client.id)
 		}
 	}
 
-	if cerr := client.conn.Close(); cerr != nil {
-		sr.logger.Warn("error closing client connection", "err", cerr, "client", client.id)
-	}
+	// removeClient must happen before updateTerminalAttachers so the
+	// metadata snapshot reflects the just-detached client's absence.
+	// Inverting this order leaves the attacher visible until the next
+	// metadata write.
+	sr.removeClient(client)
 	if err := sr.updateTerminalAttachers(); err != nil {
 		sr.logger.Warn("failed to update metadata on client cleanup", "err", err)
 	}
-	sr.removeClient(client)
 }
 
+// handleClient drives an interactive attach end to end:
+//
+//   - WRITER side (pty -> conn): bytes from the PTY arrive via the
+//     DynamicMultiWriter fan-out. To avoid one paused attacher
+//     head-of-line blocking the fan-out (cf. the subscriber path), we
+//     register a subscriberWriter wrapping client.conn instead of an
+//     os.Pipe. The wrapper absorbs PTY output into a bounded ring;
+//     a dedicated drain goroutine drains it to client.conn with a
+//     per-write SetWriteDeadline so a hung peer detaches within a bounded
+//     wait instead of stalling other attachers and the capture sink.
+//
+//   - READER side (conn -> pty): unchanged — dualcopier.RunCopier from
+//     client.conn into the shared pipeInW that feeds the PTY master.
+//     Keeping dualcopier here preserves its semantics for the other
+//     consumer (internal/client/clientrunner/io.go).
 func (sr *Exec) handleClient(client *ioClient) {
 	sr.logger.Info("client connection handler started", "client", client.id)
-
-	if err := sr.setupPipes(client); err != nil {
-		sr.logger.Error("failed to setup pipes for client", "err", err, "client", client.id)
-		return
-	}
 
 	uc, ok := client.conn.(*net.UnixConn)
 	if !ok {
@@ -76,37 +93,45 @@ func (sr *Exec) handleClient(client *ioClient) {
 		return
 	}
 
-	dc := dualcopier.NewCopier(sr.ctx, sr.logger)
-
-	// WRITER: stdout -> socket
-	readyWriter := make(chan struct{})
-	go dc.RunCopier(client.pipeOutR, client.conn, readyWriter, func() {
-		if uc != nil {
-			sr.logger.Debug("closing UnixConn write side", "client", client.id)
-			_ = uc.CloseWrite()
-		}
-	}, nil)
-
-	// READER: socket  -> stdin
-	readyReader := make(chan struct{})
 	sr.ptyPipesMu.RLock()
+	multiOutW := sr.ptyPipes.multiOutW
 	pipeInW := sr.ptyPipes.pipeInW
 	sr.ptyPipesMu.RUnlock()
+
+	// detachOnce funnels every cleanup trigger (reader error, drain
+	// lagged-detach, ctx cancel) into a single cleanupClient call.
+	var detachOnce sync.Once
+	detach := func() {
+		detachOnce.Do(func() {
+			sr.cleanupClient(client)
+		})
+	}
+
+	// WRITER: bounded ring + per-write deadline + lagged-detach. Adding
+	// the writer to multiOutW *before* starting Run is safe — Write just
+	// enqueues into the ring until Run starts draining.
+	aw := newSubscriberWriter(client.conn, defaultSubscriberBufferBytes, detach, sr.logger)
+	client.outWriter = aw
+	multiOutW.Add(aw)
+	go aw.Run()
+
+	// READER: socket -> stdin. Reader-side error triggers detach so an
+	// abrupt client disconnect doesn't park the drain goroutine waiting
+	// for the next PTY byte to discover the broken conn.
+	dc := dualcopier.NewCopier(sr.ctx, sr.logger)
+	readyReader := make(chan struct{})
 	go dc.RunCopier(client.conn, pipeInW, readyReader, func() {
-		if uc != nil {
-			sr.logger.Debug("closing UnixConn read side", "client", client.id)
-			_ = uc.CloseRead()
-		}
+		sr.logger.Debug("closing UnixConn read side", "client", client.id)
+		_ = uc.CloseRead()
+		detach()
 	}, nil)
 
-	<-readyWriter
 	<-readyReader
 
-	// MANAGER
-	go dc.CopierManager(uc, func() {
-		sr.cleanupClient(client)
-		_ = sr.updateTerminalAttachers()
-	})
+	// MANAGER: ctx cancel also funnels to detach. CopierManager's errgroup
+	// arm is intentionally not given a finish func — detach above already
+	// covers the reader-error path.
+	go dc.CopierManager(uc, detach)
 
 	if errAttach := sr.updateTerminalAttachers(); errAttach != nil {
 		sr.logger.Warn("failed to update metadata on attach", "err", errAttach)

--- a/internal/terminal/terminalrunner/io.go
+++ b/internal/terminal/terminalrunner/io.go
@@ -20,21 +20,6 @@ import (
 	"os"
 )
 
-func (sr *Exec) setupPipes(client *ioClient) error {
-	var err error
-	client.pipeOutR, client.pipeOutW, err = os.Pipe()
-	if err != nil {
-		sr.logger.Warn("failed to create pipe", "err", err)
-		return err
-	}
-	sr.ptyPipesMu.RLock()
-	multiOutW := sr.ptyPipes.multiOutW
-	sr.ptyPipesMu.RUnlock()
-	multiOutW.Add(client.pipeOutW)
-
-	return nil
-}
-
 func (sr *Exec) readLogFile() ([]byte, error) {
 	sr.metadataMu.RLock()
 	captureFile := sr.metadata.Status.CaptureFile

--- a/internal/terminal/terminalrunner/lifecycle.go
+++ b/internal/terminal/terminalrunner/lifecycle.go
@@ -324,29 +324,18 @@ func (sr *Exec) Detach(id *api.ID) error {
 		return fmt.Errorf("client %s not found among clients", *id)
 	}
 
-	// 2) Remove from fan-out paths first so no more writes target it
+	// 2) Remove the bounded writer from the fan-out first so no more PTY
+	// bytes target this attacher's ring.
 	sr.ptyPipesMu.RLock()
 	multiOutW := sr.ptyPipes.multiOutW
 	sr.ptyPipesMu.RUnlock()
-	multiOutW.Remove(ioClient.pipeOutW)
-	// TODO: remove from stdin fan-in if you have that side too
-	// sr.ptyPipes.multiInR.Remove(ioClient.pipeInR)
-
-	// 2a) Release the per-client pipe fds. cleanupClient (which would
-	// otherwise close them) never fires on Detach because CopierManager
-	// only invokes finish() on ctx.Done(), so without this every
-	// Attach/Detach cycle leaks both pipe ends in the runner process.
-	// Closing pipeOutR also unblocks the writer copier's Read so its
-	// goroutine exits instead of parking until terminal shutdown.
-	if ioClient.pipeOutW != nil {
-		if perr := ioClient.pipeOutW.Close(); perr != nil {
-			sr.logger.Debug("error closing client pipeOutW", "err", perr, "client", ioClient.id)
-		}
-	}
-	if ioClient.pipeOutR != nil {
-		if perr := ioClient.pipeOutR.Close(); perr != nil {
-			sr.logger.Debug("error closing client pipeOutR", "err", perr, "client", ioClient.id)
-		}
+	if ioClient.outWriter != nil {
+		multiOutW.Remove(ioClient.outWriter)
+		// Close signals the drain goroutine to flush any pending bytes
+		// and exit. The drain's deferred conn.Close releases the
+		// socketpair fd. The async block below force-closes the conn
+		// after a short grace so a stuck drain can't pin the fd.
+		_ = ioClient.outWriter.Close()
 	}
 
 	// 3) Drop from the registry so it’s no longer discoverable

--- a/internal/terminal/terminalrunner/terminal_runner_exec.go
+++ b/internal/terminal/terminalrunner/terminal_runner_exec.go
@@ -101,10 +101,9 @@ type ptyPipes struct {
 }
 
 type ioClient struct {
-	id       *api.ID
-	conn     net.Conn
-	pipeOutR *os.File
-	pipeOutW *os.File
+	id        *api.ID
+	conn      net.Conn
+	outWriter *subscriberWriter
 }
 
 func NewTerminalRunnerExec(ctx context.Context, logger *slog.Logger, spec *api.TerminalSpec) TerminalRunner {

--- a/pkg/terminal/server/server_attach_pausedattacher_linux_test.go
+++ b/pkg/terminal/server/server_attach_pausedattacher_linux_test.go
@@ -1,0 +1,187 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package server_test
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/pkg/api"
+	rpcclient "github.com/eminwux/sbsh/pkg/rpcclient/terminal"
+)
+
+// TestServer_PausedAttacher_DoesNotHeadOfLineBlock pins down the fix for
+// issue #214: the interactive Attach path used to write PTY output to
+// client.conn via dualcopier.RunCopier with no SetWriteDeadline and no
+// bounded ring. A single attacher whose receiver was paused (suspended
+// SSH session, blocked terminal emulator, paused tmux pane) would fill
+// the socketpair send buffer and head-of-line block the fan-out — every
+// other attacher and the capture sink stopped receiving PTY output until
+// the paused peer drained or the runner died.
+//
+// The fix swaps the writer-side dualcopier for a subscriberWriter-style
+// wrapper around client.conn: bounded in-memory ring, per-write
+// SetWriteDeadline, and lagged-detach funnelled through cleanupClient.
+// This test verifies the end-to-end behavior: with one paused attacher
+// and one active drainer, the drainer keeps receiving output, and the
+// paused attacher is reaped from metadata.Status.Attachers within a
+// bounded wait.
+func TestServer_PausedAttacher_DoesNotHeadOfLineBlock(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	h := startTestServer(ctx, t)
+	defer h.cleanup()
+
+	client := rpcclient.NewUnix(h.socketPath, h.logger)
+	defer client.Close()
+
+	// Paused attacher: never read. Simulates a receiver that has stopped
+	// draining the PTY output stream (suspended SSH session, blocked
+	// emulator, paused tmux pane). The kernel socketpair buffer fills,
+	// the server-side drain goroutine's per-write deadline trips, and
+	// the bounded ring overflows — all of which must funnel through
+	// cleanupClient. attachClient registers t.Cleanup for the conn so
+	// the returned value isn't needed in the test body.
+	pausedID := api.ID("paused-attacher")
+	_ = attachClient(ctx, t, client, pausedID)
+
+	// Drainer: reads continuously. With the head-of-line blocking bug,
+	// this attacher would also stall as soon as the paused peer's send
+	// buffer filled. With the fix, it keeps receiving PTY output even
+	// while the paused peer is being reaped.
+	drainID := api.ID("drainer-attacher")
+	drainConn := attachClient(ctx, t, client, drainID)
+
+	drainedBytes := startDrainCounter(drainConn)
+
+	// Push ~2 MiB of PTY output. With the default ring at 1 MiB and the
+	// Linux socketpair kernel buffer at ~208 KiB, this is comfortably
+	// over the threshold where a stalled attacher would have wedged the
+	// pre-#214 fan-out. `yes X | head -c …` is deterministic, the shell
+	// returns to the prompt afterward, and the SBSH_DONE_MARKER tail
+	// makes the run easy to debug from the capture file.
+	cmd := []byte("yes X | head -c 2000000; echo SBSH_DONE_MARKER\n")
+	if werr := client.Write(ctx, &api.WriteRequest{Data: cmd}); werr != nil {
+		t.Fatalf("Write(cmd): %v", werr)
+	}
+
+	// Drainer must see at least ~1.5 MiB before the deadline. If the
+	// fan-out head-of-line blocks on the paused attacher, drainedBytes
+	// stalls well below this threshold.
+	waitForDrainerOrFail(t, drainedBytes, 1_500_000, 30*time.Second)
+
+	// The paused attacher must be reaped from metadata.Status.Attachers
+	// within a bounded wait. The bound is subscriberWriteTimeout (5s
+	// default) per in-flight conn.Write, plus a small margin for the
+	// cleanup goroutine to run and rewrite metadata.
+	md := waitForAttacherReaped(ctx, t, client, pausedID, 15*time.Second)
+
+	if containsAttacher(md.Status.Attachers, string(pausedID)) {
+		t.Fatalf(
+			"paused attacher %q still listed in metadata.Status.Attachers after bounded wait: %v",
+			pausedID, md.Status.Attachers,
+		)
+	}
+	if !containsAttacher(md.Status.Attachers, string(drainID)) {
+		t.Fatalf(
+			"drainer attacher %q missing from metadata.Status.Attachers (should still be present): %v",
+			drainID, md.Status.Attachers,
+		)
+	}
+}
+
+func attachClient(ctx context.Context, t *testing.T, client rpcclient.Client, id api.ID) net.Conn {
+	t.Helper()
+	conn, err := client.Attach(ctx, &id, nil)
+	if err != nil {
+		t.Fatalf("Attach(%s): %v", id, err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+func startDrainCounter(conn net.Conn) *atomic.Int64 {
+	var drained atomic.Int64
+	go func() {
+		buf := make([]byte, 32*1024)
+		for {
+			if rderr := conn.SetReadDeadline(time.Now().Add(15 * time.Second)); rderr != nil {
+				return
+			}
+			n, rerr := conn.Read(buf)
+			if n > 0 {
+				drained.Add(int64(n))
+			}
+			if rerr != nil {
+				return
+			}
+		}
+	}()
+	return &drained
+}
+
+func waitForDrainerOrFail(t *testing.T, drained *atomic.Int64, want int64, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for drained.Load() < want && time.Now().Before(deadline) {
+		time.Sleep(50 * time.Millisecond)
+	}
+	if got := drained.Load(); got < want {
+		t.Fatalf(
+			"drainer only received %d bytes (want >= %d) before timeout — fan-out likely head-of-line blocked on the paused attacher",
+			got,
+			want,
+		)
+	}
+}
+
+func waitForAttacherReaped(
+	ctx context.Context,
+	t *testing.T,
+	client rpcclient.Client,
+	id api.ID,
+	timeout time.Duration,
+) api.TerminalDoc {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var md api.TerminalDoc
+	for time.Now().Before(deadline) {
+		if mdErr := client.Metadata(ctx, &md); mdErr != nil {
+			t.Fatalf("Metadata: %v", mdErr)
+		}
+		if !containsAttacher(md.Status.Attachers, string(id)) {
+			return md
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return md
+}
+
+func containsAttacher(list []string, s string) bool {
+	for _, item := range list {
+		if item == s {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/terminal/server/server_attach_pipefdleak_linux_test.go
+++ b/pkg/terminal/server/server_attach_pipefdleak_linux_test.go
@@ -30,18 +30,18 @@ import (
 	rpcclient "github.com/eminwux/sbsh/pkg/rpcclient/terminal"
 )
 
-// TestServer_AttachDetachCycles_NoPipeFDLeak locks in the fix for
-// issue #215: setupPipes allocates an os.Pipe pair per Attach that
-// cleanupClient (and the Detach fast-path) used to leave open for the
-// lifetime of the runner process. The sibling SCM_RIGHTS test counts
-// only socket-typed fds because, before this fix, the pipe leak (two
-// fds per cycle) would dwarf the socket signal.
+// TestServer_AttachDetachCycles_NoPipeFDLeak locks in the no-pipe-fd-leak
+// invariant for Attach/Detach. Originally the leak source was the
+// per-Attach os.Pipe pair in setupPipes (issue #215). Issue #214 then
+// removed setupPipes outright in favor of a bounded subscriberWriter
+// wrapping client.conn, so the runner no longer allocates per-attach
+// pipe fds at all — but the invariant is still worth pinning down so a
+// future refactor that re-introduces a per-attach pipe doesn't quietly
+// resurrect the leak.
 //
 // This test counts only pipe-typed fds (`/proc/self/fd` entries whose
 // readlink starts with `pipe:`) so the SCM_RIGHTS regression and this
-// one stay independent. Without the cleanup fix every Attach/Detach
-// cycle leaks two pipe fds in the runner process; with it the count is
-// flat across cycles.
+// one stay independent.
 func TestServer_AttachDetachCycles_NoPipeFDLeak(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
@@ -82,11 +82,10 @@ func TestServer_AttachDetachCycles_NoPipeFDLeak(t *testing.T) {
 		t.Fatalf("countOpenPipeFDs (after): %v", err)
 	}
 
-	// Without the cleanup fix every cycle leaks two pipe fds (the
-	// pipeOutR/pipeOutW pair allocated in setupPipes), so 20 cycles
-	// produced +40. The tolerance covers any in-flight Go-runtime pipes
-	// (netpoll wake-up, gc) that briefly appear under load. Anything
-	// close to 2*cycles means the leak is back.
+	// Pre-issue-#214 every cycle leaked two pipe fds (the pipeOutR/pipeOutW
+	// pair allocated in setupPipes); post-#214 the runner allocates no
+	// per-attach pipes at all. The tolerance covers any in-flight Go-runtime
+	// pipes (netpoll wake-up, gc) that briefly appear under load.
 	delta := after - baseline
 	tolerance := cycles / 2
 	if delta > tolerance {


### PR DESCRIPTION
## Summary

- The interactive Attach path (`internal/terminal/terminalrunner/connections.go`) used to write PTY output to `client.conn` via `dualcopier.RunCopier` with no `SetWriteDeadline` and no bounded ring between the PTY reader and the conn. A single attacher whose receiver was paused (suspended SSH session, blocked emulator, paused tmux pane) would fill the socketpair send buffer and head-of-line block the shared fan-out — every other attacher and the capture sink stopped receiving PTY output until the paused peer drained or the runner died. Issue #214 flagged this as the adjacent finding deferred from PR #213's SCM_RIGHTS fix.
- Per the issue's preferred Option A, the writer-side `dualcopier.RunCopier` goroutine is replaced with a `subscriberWriter`-style wrapper around `client.conn`: bounded in-memory ring (1 MiB default), per-write `SetWriteDeadline` (5 s default), and lagged-detach funnelled through `cleanupClient`. `dualcopier` semantics are unchanged — the reader-side dualcopier and the `internal/client/clientrunner/io.go` consumer keep their existing behavior, so this PR isolates the bounded-output policy to the server side of the interactive attach path.
- The per-attach `os.Pipe` pair allocated by `setupPipes` is no longer needed and is removed; `cleanupClient`, `Detach`, and `ioClient` are simplified accordingly. `cleanupClient` now also calls `removeClient` before `updateTerminalAttachers` so the detached attacher actually drops out of `metadata.Status.Attachers` in a single metadata write (the previous order produced a transient stale snapshot that was only fixed by a follow-up call in the old `handleClient`).
- Reader-side errors (abrupt client disconnect) now feed into the same `detachOnce` funnel via the dualcopier's `errFunc`, so the drain goroutine is woken even when no further PTY bytes arrive — closing a pre-existing latent gap in the cleanup path.
- `pkg/terminal/server/server_attach_pipefdleak_linux_test.go`'s docstring is updated: the test still asserts the same invariant (no per-attach pipe-fd leak) but the underlying architecture changed — the runner allocates no per-attach pipes at all now.

## Test plan

- [x] `make sbsh-sb` (canonical build) + `file ./sbsh` returns ELF executable.
- [x] `go build ./...`, `go vet ./...`.
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` — full unit test suite passes, including:
  - `internal/client/clientrunner/...` (the other `dualcopier.RunCopier` consumer; semantics unchanged).
  - `internal/terminal/terminalrunner/...` (existing subscriber and runner tests).
  - `pkg/terminal/server/...` (existing fdleak and pipefdleak regression tests still pass + new regression below).
- [x] New regression: `pkg/terminal/server/server_attach_pausedattacher_linux_test.go` exercises the paused-attacher signal end to end. It attaches a paused client (never reads) and a drainer (reads continuously), pumps ~2 MiB through the PTY, and asserts that (a) the drainer keeps receiving past 1.5 MiB, and (b) the paused attacher is reaped from `metadata.Status.Attachers` within a bounded wait while the drainer remains listed.
- [x] `go test -tags=integration ./cmd/sb/get/...` (CI integration step).
- [x] `cd docs/examples/library-consumer && go build ./... && go vet ./...` (CI library-consumer step).
- [x] `pre-commit run` on the staged files — clean (no `golangci-lint` issues).

Closes #214