### PR TITLE
test(e2e): use t.TempDir for run-path scratch

### DIFF
--- a/e2e/e2e_sb_test.go
+++ b/e2e/e2e_sb_test.go
@@ -42,8 +42,7 @@ func TestSb_NoTerminals(t *testing.T) {
 		{"g", "t"},
 	}
 	for _, args := range tests {
-		runPath := getRandomRunPath(t)
-		mkdirRunPath(t, runPath)
+		runPath := newRunPath(t)
 		runPathEnv := buildSbRunPathEnv(t, runPath)
 		out = runReturningBinary(t, []string{runPathEnv}, sb, args...)
 		expected = discovery.NoTerminalsString
@@ -63,8 +62,7 @@ func TestSb_NoClients(t *testing.T) {
 		{"get", "clients"},
 	}
 	for _, args := range tests {
-		runPath := getRandomRunPath(t)
-		mkdirRunPath(t, runPath)
+		runPath := newRunPath(t)
 		runPathEnv := buildSbRunPathEnv(t, runPath)
 		out = runReturningBinary(t, []string{runPathEnv}, sb, args...)
 		expected = discovery.NoClientsString

--- a/e2e/e2e_sb_write_read_test.go
+++ b/e2e/e2e_sb_write_read_test.go
@@ -32,8 +32,7 @@ import (
 // command's output appears in both the capture file (`sb read`) and the
 // live stream (`sb read -f`).
 func TestSb_WriteRead_Roundtrip(t *testing.T) {
-	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
+	runPath := newRunPath(t)
 
 	termName := "e2e-writeread"
 	runPathEnv := buildSbRunPathEnv(t, runPath)
@@ -113,8 +112,7 @@ func TestSb_WriteRead_Roundtrip(t *testing.T) {
 // sending bogus bytes.
 func TestSb_Write_CaretParsingErrors(t *testing.T) {
 	t.Parallel()
-	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
+	runPath := newRunPath(t)
 	runPathEnv := buildSbRunPathEnv(t, runPath)
 
 	// No terminal needs to be running — parsing happens before we dial

--- a/e2e/e2e_sbsh_test.go
+++ b/e2e/e2e_sbsh_test.go
@@ -33,8 +33,7 @@ func TestSbsh_Help(t *testing.T) {
 }
 
 func TestSbsh_Default(t *testing.T) {
-	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
+	runPath := newRunPath(t)
 
 	t.Cleanup(func() {
 		runPathEnv := buildSbRunPathEnv(t, runPath)
@@ -111,8 +110,7 @@ func TestSbsh_Default(t *testing.T) {
 }
 
 func TestSbsh_CustomId(t *testing.T) {
-	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
+	runPath := newRunPath(t)
 
 	t.Cleanup(func() {
 		runPathEnv := buildSbRunPathEnv(t, runPath)
@@ -189,8 +187,7 @@ func TestSbsh_CustomId(t *testing.T) {
 }
 
 func TestSbsh_Detach(t *testing.T) {
-	runPath := getRandomRunPath(t)
-	mkdirRunPath(t, runPath)
+	runPath := newRunPath(t)
 
 	t.Cleanup(func() {
 		runPathEnv := buildSbRunPathEnv(t, runPath)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"regexp"
 	"syscall"
@@ -28,7 +27,6 @@ import (
 	"time"
 
 	"github.com/creack/pty"
-	"github.com/eminwux/sbsh/internal/naming"
 	"github.com/eminwux/sbsh/internal/terminal/terminalrunner"
 )
 
@@ -217,23 +215,9 @@ func setupPromptDetector(t *testing.T, pipeExpectR *os.File, regex *regexp.Regex
 	return promptCh
 }
 
-func mkdirRunPath(t *testing.T, fullDir string) {
+func newRunPath(t *testing.T) string {
 	t.Helper()
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("could not get working dir: %v", err)
-	}
-	fullDir = filepath.Join(cwd, fullDir)
-	if err = os.MkdirAll(fullDir, 0o755); err != nil {
-		t.Fatalf("could not create dir %s: %v", fullDir, err)
-	}
-}
-
-func getRandomRunPath(t *testing.T) string {
-	t.Helper()
-	rndDir := naming.RandomID()
-	fullDir := path.Join("tmp", rndDir)
-	return fullDir
+	return t.TempDir()
 }
 
 func buildSbRunPathEnv(t *testing.T, runPath string) string {


### PR DESCRIPTION
## Summary
- E2E tests previously wrote scratch dirs into `e2e/tmp/<rnd>` under the source tree (via `path.Join("tmp", rndDir)` resolved against `os.Getwd()` and `os.MkdirAll`), with no cleanup registered. Every `go test ./...` run left untracked `e2e/tmp/` paths, forcing manual `rm -rf` before any commit.
- Collapsed the `getRandomRunPath` + `mkdirRunPath` pair into a single `newRunPath(t)` that returns `t.TempDir()`. The Go test runtime creates the directory and registers a `t.Cleanup` to remove it on completion, so the source tree stays pristine even when tests fail or are interrupted by `go test -run`.
- All eight call sites in `e2e/e2e_sb_test.go`, `e2e/e2e_sb_write_read_test.go`, and `e2e/e2e_sbsh_test.go` updated; `path` and `internal/naming` imports dropped from `e2e_test.go` (no other consumers in that file).
- Chose option 1 from the issue's "Suggested fix" list (preferred there); options 2 and 3 are intentionally not pursued — `t.TempDir` is strictly stronger than the manual `t.Cleanup` variant (handles `t.Run` subtests and panics for free) and avoids the disk-accretion downside of a `.gitignore` entry.

## Test plan
- [x] `make sbsh-sb` — canonical build produces ELF (`file ./sbsh` = `ELF 64-bit LSB executable`).
- [x] `go build ./...` — clean.
- [x] `go vet ./...` — clean.
- [x] `go test ./...` — all packages pass, including `github.com/eminwux/sbsh/e2e` (2.713s).
- [x] `git status` after the full test run shows only the intended source edits — **no `e2e/tmp/` untracked path** (the bug repro from the issue body no longer reproduces).
- [x] `pre-commit run --files <changed>` — all hooks pass (`go fmt`, `golangci-lint`, `go-mod-tidy`, `addlicense`).

Closes #207