### PR TITLE
fix(terminalrunner): test-double gate bugs and dead error vars

### DIFF
--- a/internal/terminal/terminalrunner/errors.go
+++ b/internal/terminal/terminalrunner/errors.go
@@ -23,8 +23,3 @@ var (
 	ErrPipeWrite error = errors.New("could not write pty->pipe")
 	ErrPipeRead  error = errors.New("could not read pipe->pipe")
 )
-
-var (
-	ErrTerminalRead  error = errors.New("could not read pipe->pty")
-	ErrTerminalWrite error = errors.New("could not write pty->pipe")
-)

--- a/internal/terminal/terminalrunner/terminal_runner_fake.go
+++ b/internal/terminal/terminalrunner/terminal_runner_fake.go
@@ -76,7 +76,7 @@ func (sr *Test) StartServer(
 }
 
 func (sr *Test) StartTerminal(evCh chan<- Event) error {
-	if sr.OpenSocketCtrlFunc != nil {
+	if sr.StartTerminalFunc != nil {
 		return sr.StartTerminalFunc(evCh)
 	}
 	return nil
@@ -118,7 +118,7 @@ func (sr *Test) Attach(id *api.ID, response *api.ResponseWithFD) error {
 
 func (sr *Test) Detach(id *api.ID) error {
 	if sr.DetachFunc != nil {
-		_ = sr.DetachFunc(id)
+		return sr.DetachFunc(id)
 	}
 	return errdefs.ErrFuncNotSet
 }


### PR DESCRIPTION
## Summary

Per the audit sweep in #219, three small obvious fixes land here; six deeper bugs surfaced by the audit are filed as follow-ups (#225–#230).

In-PR fixes:

- `terminal_runner_fake.go` `StartTerminal` gated on `OpenSocketCtrlFunc != nil` instead of `StartTerminalFunc != nil` (copy-paste regression). A test that only wires `StartTerminalFunc` silently no-ops; one that wires only `OpenSocketCtrlFunc` would nil-panic. Existing tests in `internal/terminal/controller_test.go` happen to always set both fields, masking the bug.
- `terminal_runner_fake.go` `Detach` discarded the func's return error and always returned `errdefs.ErrFuncNotSet`. Inconsistent with `Attach`/`SetupShell`/etc. — now returns the func's result.
- `errors.go` `ErrTerminalRead` and `ErrTerminalWrite` were exported but referenced nowhere in the tree (verified via grep). The package's actually-used error sentinels (`ErrPipeRead`, `ErrPipeWrite`, `ErrCloseReq`) are kept.

## Audit follow-ups (filed)

| # | Severity | Defect |
|---|----------|--------|
| #225 | `priority:A` | `Close()` panics on concurrent `Attach` — `sr.clients = nil` then `addClient` writes to nil map |
| #226 | `priority:B` | `Subscribe`/`Close` race orphans a subscriber whose drain goroutine parks forever |
| #227 | `priority:B` | Non-init-mode `watchChildExit` discards real shell exit code |
| #228 | `priority:C` | `StartServer` reports misleading `unknown rpc server error` on graceful ctx-cancel shutdown |
| #229 | `priority:C` | `Close()` leaks capture-file fd (`logf` never closed) |
| #230 | `priority:C` | `Close()` doesn't explicitly tear down attacher outWriters (latent race) |

Audit scope: every `.go` file under `internal/terminal/terminalrunner/` (28 files, ~3.7k LOC) read with the lens listed in #219 — fd-ownership across attach/detach/cleanup, goroutine lifetimes vs. shutdown order, writer fan-out under slow/dead consumers, error paths skipping cleanup, signal/reaper interaction.

## Test plan

- [x] `make sbsh-sb` (canonical build target per project CLAUDE.md)
- [x] `file ./sbsh` confirms ELF 64-bit LSB executable
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (full CI test target — internal/terminal, internal/client, cmd/*, integration tag)
- [x] `make e2e` (E2E_BIN_DIR=$(pwd) go test ./e2e)
- [x] `go test ./internal/terminal/terminalrunner/...` — package tests pass after edits
- [x] Verified via grep that `ErrTerminalRead`/`ErrTerminalWrite` are referenced nowhere outside `errors.go`
- [x] Verified via grep that every existing test wiring `StartTerminalFunc` also wires `OpenSocketCtrlFunc` (so the gate fix doesn't change current test behavior)

Closes #219