### PR TITLE
fix(terminalrunner): clear clients map in Close to prevent nil-map panic

### DIFF
--- a/internal/terminal/terminalrunner/lifecycle.go
+++ b/internal/terminal/terminalrunner/lifecycle.go
@@ -229,14 +229,19 @@ func (sr *Exec) Close(reason error) error {
 	}
 
 	// close clients
+	//
+	// clear() instead of `sr.clients = nil`: a concurrent addClient call
+	// can race past Close's unlock (per-conn RPC handlers outlive the
+	// accept loop's ctx-cancel exit), and writing to a nil map panics.
+	// Emptying the map keeps it addressable so the late write is a benign
+	// stale-entry no-op shape. See #225.
 	sr.clientsMu.Lock()
 	for _, c := range sr.clients {
 		if err := c.conn.Close(); err != nil {
 			sr.logger.Warn("could not close client connection", "id", sr.id, "client", c.id, "err", err)
 		}
 	}
-
-	sr.clients = nil
+	clear(sr.clients)
 	sr.clientsMu.Unlock()
 
 	// close all output subscribers

--- a/internal/terminal/terminalrunner/lifecycle_close_clients_race_test.go
+++ b/internal/terminal/terminalrunner/lifecycle_close_clients_race_test.go
@@ -1,0 +1,143 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrunner
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"runtime/debug"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// newDummyClient mints an ioClient with a real net.Conn so Close's
+// per-client conn.Close call has something to close. net.Pipe returns two
+// connected in-memory conns; we keep just one — the other is GC'd, which
+// is fine for a teardown-only test.
+func newDummyClient(idx int) *ioClient {
+	id := api.ID(fmt.Sprintf("client-%d", idx))
+	c, _ := net.Pipe()
+	return &ioClient{id: &id, conn: c}
+}
+
+// newCloseRaceExec builds the smallest Exec that lets Close() run end-to-end
+// without nil-deref while still exercising the clients-map teardown. Every
+// heavy field Close inspects (cmd, ptmx, lnCtrl, reaper, signal forwarder)
+// is already nil-checked there, and metadata writes are pointed at
+// t.TempDir() so they pass silently. The shape mirrors the existing
+// newShutdownTestExec helper.
+func newCloseRaceExec(t *testing.T) *Exec {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return &Exec{
+		ctx:       ctx,
+		ctxCancel: cancel,
+		logger:    logger,
+		id:        "race-test",
+		metadata: api.TerminalDoc{
+			Spec: api.TerminalSpec{RunPath: t.TempDir()},
+		},
+		clients:       make(map[api.ID]*ioClient),
+		subscribers:   make(map[*subscriberWriter]struct{}),
+		closeReqCh:    make(chan error, 1),
+		closedCh:      make(chan struct{}),
+		childDoneCh:   make(chan struct{}),
+		childDoneOnce: &sync.Once{},
+		ptyPipes:      &ptyPipes{},
+		closePTY:      &sync.Once{},
+	}
+}
+
+// TestExecClose_NoNilMapOnConcurrentAddClient is the regression for #225.
+//
+// Pre-fix, Close() set sr.clients = nil and dropped clientsMu. A concurrent
+// addClient (from a per-conn RPC handler still draining after the accept
+// loop's ctx-cancel exit) then wrote to a nil map and panicked the runner
+// process. Post-fix, clear(sr.clients) leaves the map addressable so the
+// late write is a benign stale-entry no-op.
+//
+// Race-detector enabled (`go test -race`) doubles the value: lock discipline
+// in Close versus addClient is checked at the same time.
+func TestExecClose_NoNilMapOnConcurrentAddClient(t *testing.T) {
+	const concurrentClients = 200
+
+	sr := newCloseRaceExec(t)
+
+	var wg sync.WaitGroup
+	var panicCount atomic.Int32
+	start := make(chan struct{})
+
+	for i := range concurrentClients {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					panicCount.Add(1)
+					t.Errorf("addClient panicked (idx=%d): %v\n%s", idx, r, debug.Stack())
+				}
+			}()
+			<-start
+			sr.addClient(newDummyClient(idx))
+		}(i)
+	}
+
+	close(start)
+	// Small window so a chunk of addClient calls land before Close acquires
+	// clientsMu and a chunk arrive after — the bug window is the post-Close
+	// arrivals, where the pre-fix `sr.clients = nil` turned addClient into
+	// a panic.
+	time.Sleep(2 * time.Millisecond)
+	if err := sr.Close(nil); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	wg.Wait()
+
+	if n := panicCount.Load(); n > 0 {
+		t.Fatalf("addClient panicked %d times under concurrent Close; regression of #225", n)
+	}
+}
+
+// TestExecClose_PostCloseAddClientDoesNotPanic is the narrower deterministic
+// half of the same regression. Close runs to completion first; then a fresh
+// addClient is invoked. Pre-fix this was a guaranteed panic (nil-map write);
+// post-fix the map is empty-but-addressable and the call returns cleanly.
+//
+// This complements the race test above: the race version catches the
+// concurrent ordering, this one is the always-fires single-thread proof.
+func TestExecClose_PostCloseAddClientDoesNotPanic(t *testing.T) {
+	sr := newCloseRaceExec(t)
+
+	if err := sr.Close(nil); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("post-Close addClient panicked: %v\n%s", r, debug.Stack())
+		}
+	}()
+	sr.addClient(newDummyClient(0))
+}


### PR DESCRIPTION
## Summary

- Fixes #225 — the priority-A panic where `Close()` set `sr.clients = nil` and a concurrent `addClient` from a per-conn RPC handler still in flight (handlers outlive the accept loop's ctx-cancel exit) wrote to a nil map and crashed the runner process.
- Replaces `sr.clients = nil` with `clear(sr.clients)` (Option 2 from the issue body) — the lowest-blast-radius fix among the three proposals. The map stays addressable, so a late `addClient` is a benign stale-entry write instead of a panic. Per CLAUDE.md "Decide-or-stall": preferred the minimal one-line change over the broader atomic-shutdown-flag refactor (Option 3); the architectural shutdown-gate work that would also close the sibling `Subscribe`/`Close` race (#226) can land separately without rebasing on this.
- Option 3's `Subscribe`/`CreateNewClient` shutdown-flag short-circuit is not implemented here — that's the post-Close error-surface design call the issue explicitly defers; AC bullet 3 is conditional on choosing Option 3, so it does not apply.
- Adds two regression tests in `lifecycle_close_clients_race_test.go`:
  - `TestExecClose_PostCloseAddClientDoesNotPanic` is the deterministic one — verified to fail with the exact `assignment to entry in nil map` panic when the fix is reverted.
  - `TestExecClose_NoNilMapOnConcurrentAddClient` races 200 concurrent `addClient` calls against `Close()` under `-race`; double-duty as a lock-discipline check.

## Test plan

- [x] `make sbsh-sb` — produces ELF binary
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — full CI test target (cmd/sb, cmd/sbsh, internal/terminal, internal/client, integration, e2e)
- [x] `go test -race -count=3 ./internal/terminal/terminalrunner/`
- [x] Verified the deterministic test fails without the fix and passes with it
- [x] pre-commit hooks pass (golangci-lint, go fmt, addlicense, etc.)

Closes #225