### PR TITLE
fix(terminalrunner): propagate real shell exit code/signal in non-init watchChildExit

### DIFF
--- a/internal/terminal/terminalrunner/lifecycle.go
+++ b/internal/terminal/terminalrunner/lifecycle.go
@@ -139,8 +139,14 @@ func (sr *Exec) watchChildExit() {
 			_ = sr.cmd.Process.Release()
 		}
 	} else {
-		_ = sr.cmd.Wait()
-		exitErr = errors.New("the shell process has exited")
+		// cmd.Wait()'s *exec.ExitError carries the real exit code (and signal
+		// info on signaled deaths) — propagate it so EvCmdExited consumers can
+		// distinguish "shell exited 0" from "shell killed by SIGSEGV".
+		if werr := sr.cmd.Wait(); werr != nil {
+			exitErr = fmt.Errorf("shell process exited: %w", werr)
+		} else {
+			exitErr = errors.New("shell process exited (code 0)")
+		}
 	}
 
 	sr.logger.Info("child process has exited", "parent_pid", os.Getpid(), "child_pid", pid)

--- a/internal/terminal/terminalrunner/lifecycle_watch_child_exit_test.go
+++ b/internal/terminal/terminalrunner/lifecycle_watch_child_exit_test.go
@@ -1,0 +1,159 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrunner
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os/exec"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// newWatchChildExitTestExec builds a minimal non-init-mode Exec suitable for
+// exercising watchChildExit's cmd.Wait() branch in isolation — no PTY, no RPC,
+// no metadata. The caller is responsible for cmd.Start before calling
+// watchChildExit; watchChildExit then Waits the child and publishes the
+// real exit error on closeReqCh.
+func newWatchChildExitTestExec(t *testing.T, cmd *exec.Cmd) *Exec {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return &Exec{
+		ctx:           ctx,
+		ctxCancel:     cancel,
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		id:            "test",
+		cmd:           cmd,
+		closeReqCh:    make(chan error, 1),
+		childDoneCh:   make(chan struct{}),
+		childDoneOnce: &sync.Once{},
+		initMode:      false,
+	}
+}
+
+// TestWatchChildExit_NonInitMode_PropagatesExitCode asserts the non-init-mode
+// branch of watchChildExit propagates cmd.Wait()'s *exec.ExitError so the
+// exit code is visible on closeReqCh (and therefore in EvCmdExited.Err).
+// Regression: this branch previously discarded cmd.Wait() and substituted a
+// fixed string, losing the code.
+func TestWatchChildExit_NonInitMode_PropagatesExitCode(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "exit 42")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	sr := newWatchChildExitTestExec(t, cmd)
+	go sr.watchChildExit()
+
+	select {
+	case got := <-sr.closeReqCh:
+		if got == nil {
+			t.Fatalf("watchChildExit sent nil err for non-zero exit; want wrapped ExitError")
+		}
+		var ee *exec.ExitError
+		if !errors.As(got, &ee) {
+			t.Fatalf("watchChildExit err does not wrap *exec.ExitError: %v (%T)", got, got)
+		}
+		if ee.ExitCode() != 42 {
+			t.Fatalf("ExitCode()=%d; want 42 (full err: %v)", ee.ExitCode(), got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("watchChildExit did not publish on closeReqCh within timeout")
+	}
+}
+
+// TestWatchChildExit_NonInitMode_PropagatesSignal asserts watchChildExit
+// surfaces signal info when the child dies on a signal — SIGSEGV here per
+// the issue AC. The wrapped *exec.ExitError's WaitStatus must report
+// Signaled() == true and the originating signal.
+func TestWatchChildExit_NonInitMode_PropagatesSignal(t *testing.T) {
+	// Spawn a sh that suspends, then deliver SIGSEGV from the test process.
+	// Using "kill -SEGV $$" from inside the shell is also possible but the
+	// shell can intercept the SIGSEGV in some implementations; signaling the
+	// process from outside is more deterministic.
+	cmd := exec.Command("/bin/sh", "-c", "sleep 30 & wait")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	sr := newWatchChildExitTestExec(t, cmd)
+	go sr.watchChildExit()
+
+	// Give the shell a moment to install its wait before signaling so the
+	// kernel routes the signal to a fully-set-up process.
+	time.Sleep(100 * time.Millisecond)
+	if err := cmd.Process.Signal(syscall.SIGSEGV); err != nil {
+		t.Fatalf("signal: %v", err)
+	}
+
+	select {
+	case got := <-sr.closeReqCh:
+		if got == nil {
+			t.Fatalf("watchChildExit sent nil err for signal death; want wrapped ExitError")
+		}
+		var ee *exec.ExitError
+		if !errors.As(got, &ee) {
+			t.Fatalf("watchChildExit err does not wrap *exec.ExitError: %v (%T)", got, got)
+		}
+		ws, ok := ee.Sys().(syscall.WaitStatus)
+		if !ok {
+			t.Fatalf("ExitError.Sys() not a syscall.WaitStatus: %T", ee.Sys())
+		}
+		if !ws.Signaled() {
+			t.Fatalf("WaitStatus.Signaled()=false; want true for SIGSEGV death (status=%v)", ws)
+		}
+		if ws.Signal() != syscall.SIGSEGV {
+			t.Fatalf("WaitStatus.Signal()=%v; want SIGSEGV", ws.Signal())
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("watchChildExit did not publish on closeReqCh within timeout")
+	}
+}
+
+// TestWatchChildExit_NonInitMode_CleanExit asserts the zero-exit path sends a
+// non-nil sentinel error (the prior shape — fixed string — is preserved for
+// consumers that just log the event; the relevant signal here is "non-nil so
+// downstream knows the shell ended", not the literal string).
+func TestWatchChildExit_NonInitMode_CleanExit(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "exit 0")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	sr := newWatchChildExitTestExec(t, cmd)
+	go sr.watchChildExit()
+
+	select {
+	case got := <-sr.closeReqCh:
+		if got == nil {
+			t.Fatalf("watchChildExit sent nil for clean exit; want non-nil sentinel")
+		}
+		// Clean exit must not surface as a wrapped *exec.ExitError — cmd.Wait
+		// returns nil on code 0.
+		var ee *exec.ExitError
+		if errors.As(got, &ee) {
+			t.Fatalf("watchChildExit wrapped an ExitError on clean exit: %v", got)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("watchChildExit did not publish on closeReqCh within timeout")
+	}
+}


### PR DESCRIPTION
## Summary
- The non-init-mode branch of `watchChildExit` discarded `cmd.Wait()`'s `*exec.ExitError`, substituting a fixed string. Outside container init mode (the default), `EvCmdExited.Err` could not distinguish a clean shell exit from `exit 42` or a SIGSEGV death.
- Wrap `cmd.Wait()`'s error verbatim so consumers can `errors.As` it to `*exec.ExitError` and read both `ExitCode()` and the `syscall.WaitStatus` signal info.
- Clean exits (`cmd.Wait() == nil`) now report `"shell process exited (code 0)"` so the close-path event is still non-nil for log consumers.

## Test plan
- [x] `make test` (full repo target — covers `./cmd/sb...`, `./cmd/sbsh...`, `./internal/terminal...`, `./internal/client...`, integration, e2e)
- [x] `make sbsh-sb` produces an ELF executable (`file ./sbsh`)
- [x] `go build ./...`, `go vet ./...`
- [x] `go test -race ./internal/terminal/terminalrunner/...` — three new regression tests pass:
  - `TestWatchChildExit_NonInitMode_PropagatesExitCode` — child exits 42, asserts wrapped `ExitError.ExitCode() == 42`
  - `TestWatchChildExit_NonInitMode_PropagatesSignal` — child killed by SIGSEGV, asserts `WaitStatus.Signaled() && WaitStatus.Signal() == SIGSEGV`
  - `TestWatchChildExit_NonInitMode_CleanExit` — exit 0 path returns a non-nil sentinel that is *not* a wrapped `ExitError`
- [x] `pre-commit run --files ...` clean
- [x] Grep for the prior literal `"the shell process has exited"` confirms no callers switch on it (only site was the line being changed)

## Notes
- Init-mode branch (already correct via `reaper.TrackedExitCh`) intentionally untouched per issue AC.

Closes #227