### PR TITLE
ci: run e2e suite in GitHub Actions pipeline

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,3 +57,42 @@ jobs:
         run: |
           go build ./...
           go vet ./...
+
+  # sbsh's e2e suite drives the CLI through a creack/pty PTY (`/dev/ptmx`)
+  # and does not require root, docker, containerd, or CNI plugins — so the
+  # host-prereq install steps from kukeon's e2e job (the precedent cited in
+  # issue #235) are intentionally omitted. Runs in parallel with the unit
+  # job above; the e2e Makefile target reads the binaries from $(CURDIR)
+  # via E2E_BIN_DIR, so we build them in this job too.
+  e2e:
+    name: E2E
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build binary
+        run: make sbsh-sb
+
+      - name: Verify binary
+        run: file ./sbsh | grep -q 'ELF 64-bit LSB executable'
+
+      # `timeout-minutes` bounds blast radius for a hung PTY child (the
+      # terminalrunner fan-out / fd-leak class of bug that #216, #217, #233
+      # fixed). `stdbuf -oL -eL` forces line-buffered stdout/stderr so each
+      # `go test -v` PASS/FAIL line streams to the runner log immediately
+      # rather than waiting on libc's 4 KiB pipe-buffer flush. `</dev/null`
+      # detaches stdin, and `> >(cat) 2> >(cat >&2)` re-parents stdout/stderr
+      # through fresh process-substitution pipes that close when `make`
+      # itself exits — without this, an inherited PTY fd in a stuck child
+      # can keep the step's pipes open after `go test` returns and stall
+      # the runner past `timeout-minutes`.
+      - name: Run e2e suite
+        timeout-minutes: 15
+        run: stdbuf -oL -eL make e2e </dev/null > >(cat) 2> >(cat >&2)


### PR DESCRIPTION
## Summary
- Adds an `E2E` job to `.github/workflows/test.yaml` that runs in parallel with `Build & Test` and invokes `make e2e` against binaries built in the same job.
- Mirrors kukeon's diagnostic hygiene where it applies to sbsh's PTY-based e2e: `timeout-minutes: 15`, `stdbuf -oL -eL` for line-buffered streaming, and `</dev/null` + `> >(cat) 2> >(cat >&2)` so an inherited PTY fd in a stuck child can't keep the step's pipes open past `go test`'s exit.
- Intentionally omits kukeon's host-prereq install steps (root, docker, containerd, CNI plugins) — sbsh's e2e drives the CLI through `/dev/ptmx` via `creack/pty` and needs none of them. The new job's comment block calls this out explicitly so a future reader doesn't try to copy them across.
- The existing `Unit tests` step keeps `grep -v '/e2e$'`, so the e2e package runs only in the new job (no double-run).

## Test plan
- [x] `make sbsh-sb` produces an ELF binary (`file ./sbsh` → `ELF 64-bit LSB executable`).
- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` — same line CI's `Unit tests` step runs — passes.
- [x] `make e2e` passes locally (the new job's exact target).
- [x] `pre-commit run --files .github/workflows/test.yaml` passes.
- [ ] The new job runs green on this PR's CI — to be verified by Actions on push.

Closes #235