### PR TITLE
fix(terminalrunner): send nil on doneCh for graceful ctx-cancel shutdown

### DIFF
--- a/internal/terminal/controller.go
+++ b/internal/terminal/controller.go
@@ -216,6 +216,14 @@ func (c *Controller) Run(spec *api.TerminalSpec) error {
 			c.handleEvent(ev)
 
 		case err := <-c.rpcDoneCh:
+			if err == nil {
+				c.logger.InfoContext(c.ctx, "rpc server exited gracefully")
+				if errC := c.Close(nil); errC != nil {
+					c.logger.ErrorContext(c.ctx, "error during Close after rpc server graceful exit", "err", errC)
+					return fmt.Errorf("%w: %w", errdefs.ErrRPCServerExited, errC)
+				}
+				return errdefs.ErrRPCServerExited
+			}
 			c.logger.ErrorContext(c.ctx, "rpc server has failed", "err", err)
 			if errC := c.Close(err); err != nil {
 				c.logger.ErrorContext(c.ctx, "error during Close after rpc server failure", "err", errC)

--- a/internal/terminal/terminalrunner/control_server.go
+++ b/internal/terminal/terminalrunner/control_server.go
@@ -71,7 +71,7 @@ func (sr *Exec) StartServer(
 			// Normal path: listener closed by ctx cancel
 			if errors.Is(err, net.ErrClosed) || sr.ctx.Err() != nil {
 				select {
-				case doneCh <- errors.New("unknown rpc server error"):
+				case doneCh <- nil:
 				default:
 				}
 				close(doneCh)

--- a/internal/terminal/terminalrunner/control_server_graceful_test.go
+++ b/internal/terminal/terminalrunner/control_server_graceful_test.go
@@ -1,0 +1,114 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrunner
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/internal/terminal/terminalrpc"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// newStartServerTestExec returns a minimal Exec wired with ctx, logger, and
+// a Unix listener bound to a temp socket. StartServer only touches lnCtrl
+// and sr.ctx on the accept path, so the heavier runner state can stay nil.
+func newStartServerTestExec(t *testing.T, logger *slog.Logger) (*Exec, func()) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	sockPath := filepath.Join(t.TempDir(), "ctrl.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		cancel()
+		t.Fatalf("listen unix: %v", err)
+	}
+	sr := &Exec{
+		ctx:           ctx,
+		ctxCancel:     cancel,
+		logger:        logger,
+		id:            "graceful-test",
+		lnCtrl:        ln,
+		clients:       make(map[api.ID]*ioClient),
+		subscribers:   make(map[*subscriberWriter]struct{}),
+		closeReqCh:    make(chan error, 1),
+		closedCh:      make(chan struct{}),
+		childDoneCh:   make(chan struct{}),
+		childDoneOnce: &sync.Once{},
+		ptyPipes:      &ptyPipes{},
+		closePTY:      &sync.Once{},
+	}
+	cleanup := func() {
+		cancel()
+		_ = ln.Close()
+	}
+	return sr, cleanup
+}
+
+// TestStartServer_GracefulCtxCancelSendsNil is the regression for #228.
+//
+// Pre-fix, StartServer sent `errors.New("unknown rpc server error")` on the
+// graceful ctx-cancel path, causing consumers (controller.go,
+// pkg/terminal/server/server.go) to treat a clean shutdown as an abnormal
+// failure and emit a misleading "rpc server has failed" log line.
+// Post-fix, doneCh receives `nil` on this path, matching the clientrunner
+// sibling at internal/client/clientrunner/control_server.go.
+func TestStartServer_GracefulCtxCancelSendsNil(t *testing.T) {
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	sr, cleanup := newStartServerTestExec(t, logger)
+	defer cleanup()
+
+	readyCh := make(chan error, 1)
+	doneCh := make(chan error, 1)
+
+	svc := &terminalrpc.TerminalControllerRPC{Core: nil}
+
+	go sr.StartServer(sr.ctx, svc, readyCh, doneCh)
+
+	select {
+	case err := <-readyCh:
+		if err != nil {
+			t.Fatalf("StartServer ready returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("StartServer did not signal ready within 2s")
+	}
+
+	sr.ctxCancel()
+
+	select {
+	case err := <-doneCh:
+		if err != nil {
+			t.Fatalf("graceful ctx-cancel path delivered non-nil err on doneCh: %v "+
+				"(want nil, matching clientrunner sibling)", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("StartServer did not exit within 2s after ctx cancel")
+	}
+
+	if got := logBuf.String(); strings.Contains(got, "rpc server has failed") {
+		t.Fatalf("graceful shutdown emitted spurious 'rpc server has failed' log line; got:\n%s", got)
+	}
+}

--- a/pkg/terminal/server/server.go
+++ b/pkg/terminal/server/server.go
@@ -183,6 +183,10 @@ func (s *Server) runLoop(
 			if err != nil {
 				return err
 			}
+			// graceful: listener closed by ctx cancel; mirror the ctx.Done branch.
+			if cerr := ctx.Err(); cerr != nil {
+				return cerr
+			}
 			return errors.New("server: rpc server exited")
 		case err := <-s.stopCh:
 			if err != nil {


### PR DESCRIPTION
## Summary

- StartServer (`internal/terminal/terminalrunner/control_server.go`) now sends `nil` on `doneCh` when the listener is closed by ctx cancel, matching the clientrunner sibling. Previously it sent `errors.New("unknown rpc server error")`, causing consumers to treat a clean shutdown as an abnormal failure.
- Controller's `rpcDoneCh` consumer (`internal/terminal/controller.go`) splits the graceful (`err == nil`) path: it logs at Info, calls `Close(nil)`, and returns the bare `errdefs.ErrRPCServerExited` sentinel — no more bogus "rpc server has failed" log line, and no more `%!w(<nil>)` rendering from `fmt.Errorf("%w: %w", ErrRPCServerExited, nil)`.
- Server facade's `runLoop` (`pkg/terminal/server/server.go`) mirrors the ctx.Done branch when `rpcDoneCh` delivers `nil`: returns `ctx.Err()` so callers see the cancellation cause rather than a synthetic "server: rpc server exited" string.

## Scope notes

- The wrong-variable check at `internal/terminal/controller.go:220` (`if errC := c.Close(err); err != nil` — assignment is to `errC`, condition gates on `err`) is left as-is per the issue's "Out of scope" note. Tracked separately in #232.
- Out-of-band: this is part of the audit cluster around #219.

## Test plan

- [x] `make sbsh-sb` + `file ./sbsh` (ELF 64-bit LSB executable)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')`
- [x] `go test -tags=integration ./cmd/sb/get/...`
- [x] `E2E_BIN_DIR=$(pwd) go test ./e2e`
- [x] `go test -run TestStartServer_GracefulCtxCancelSendsNil -race ./internal/terminal/terminalrunner/`
- [x] `pre-commit run --files ...`

Closes #228