### PR TITLE
fix(terminalrunner): close capture file fd in Close to prevent leak

### DIFF
--- a/internal/terminal/terminalrunner/lifecycle.go
+++ b/internal/terminal/terminalrunner/lifecycle.go
@@ -263,6 +263,18 @@ func (sr *Exec) Close(reason error) error {
 		}
 	}
 
+	// Close the capture file fd. Sequenced after closeAllSubscribers and
+	// ptmx teardown so the PTY reader has stopped writing to multiOutW
+	// (which holds captureFile as its always-on writer). closeCapture
+	// guards against double-Close per #229's idempotency AC.
+	if sr.captureFile != nil && sr.closeCapture != nil {
+		sr.closeCapture.Do(func() {
+			if err := sr.captureFile.Close(); err != nil {
+				sr.logger.Warn("could not close capture file", "id", sr.id, "err", err)
+			}
+		})
+	}
+
 	// remove Ctrl socket
 	sr.metadataMu.RLock()
 	socketFile := sr.metadata.Status.SocketFile

--- a/internal/terminal/terminalrunner/lifecycle_capture_fd_test.go
+++ b/internal/terminal/terminalrunner/lifecycle_capture_fd_test.go
@@ -1,0 +1,158 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrunner
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// newCaptureFDExec builds a minimal Exec wired with a real *os.File as the
+// owned capture-file handle. Mirrors newCloseRaceExec in shape; the only
+// extra step is opening the temp capture file and assigning it through the
+// same path startPty does after applyArtifactPerms succeeds.
+func newCaptureFDExec(t *testing.T) (*Exec, *os.File) {
+	t.Helper()
+	dir := t.TempDir()
+	logf, err := os.OpenFile(
+		filepath.Join(dir, "capture.log"),
+		os.O_CREATE|os.O_APPEND|os.O_WRONLY,
+		0o600,
+	)
+	if err != nil {
+		t.Fatalf("open capture file: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	sr := &Exec{
+		ctx:       ctx,
+		ctxCancel: cancel,
+		logger:    logger,
+		id:        "capture-fd-test",
+		metadata: api.TerminalDoc{
+			Spec: api.TerminalSpec{RunPath: dir},
+		},
+		clients:       make(map[api.ID]*ioClient),
+		subscribers:   make(map[*subscriberWriter]struct{}),
+		closeReqCh:    make(chan error, 1),
+		closedCh:      make(chan struct{}),
+		childDoneCh:   make(chan struct{}),
+		childDoneOnce: &sync.Once{},
+		ptyPipes:      &ptyPipes{},
+		closePTY:      &sync.Once{},
+		closeCapture:  &sync.Once{},
+		captureFile:   logf,
+	}
+	return sr, logf
+}
+
+// TestExecClose_CapturesFileFD is the direct regression for #229's first AC:
+// Close must close the capture file fd. Verified by asking the *os.File for
+// a second Close — a fd already closed by Close returns os.ErrClosed; a
+// leaked fd would return nil.
+func TestExecClose_CapturesFileFD(t *testing.T) {
+	sr, logf := newCaptureFDExec(t)
+
+	if err := sr.Close(nil); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	if err := logf.Close(); !errors.Is(err, os.ErrClosed) {
+		t.Fatalf("captureFile not closed by Close: second Close returned %v, want os.ErrClosed", err)
+	}
+}
+
+// TestExecClose_CaptureFileDoubleCloseIsHarmless is the regression for #229's
+// idempotency AC. closeCapture is a sync.Once, so a second Close on the
+// runner must not double-close the underlying fd (which would error and log
+// a warning), and must not panic.
+func TestExecClose_CaptureFileDoubleCloseIsHarmless(t *testing.T) {
+	sr, _ := newCaptureFDExec(t)
+
+	if err := sr.Close(nil); err != nil {
+		t.Fatalf("first Close returned error: %v", err)
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("second Close panicked: %v", r)
+		}
+	}()
+	// Reset closedCh so the second Close's `close(sr.closedCh)` does not
+	// panic on a closed channel — that's an orthogonal Close-idempotency
+	// concern, not what this test is asserting. The sync.Once on
+	// closeCapture is what protects the capture fd from a double-close.
+	sr.closedCh = make(chan struct{})
+	if err := sr.Close(nil); err != nil {
+		t.Fatalf("second Close returned error: %v", err)
+	}
+}
+
+// TestExecClose_CaptureFileFDNoAccumulation is the regression for #229's
+// loop AC: repeated New→assign→Close cycles must not leak one fd per cycle.
+// Counts /proc/self/fd entries before and after a tight loop; a per-cycle
+// leak would scale the delta linearly with iterations, so we assert the
+// delta is well below the loop count.
+//
+// Linux-only: /proc/self/fd is the cheapest cross-runtime fd inventory; on
+// other platforms the test skips rather than hand-roll a portable count.
+func TestExecClose_CaptureFileFDNoAccumulation(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("requires /proc/self/fd (linux); GOOS=%s", runtime.GOOS)
+	}
+	const iterations = 50
+
+	countFDs := func() int {
+		entries, err := os.ReadDir("/proc/self/fd")
+		if err != nil {
+			t.Fatalf("read /proc/self/fd: %v", err)
+		}
+		return len(entries)
+	}
+
+	// Warm the path once so any one-shot allocations (logger init, tempdir
+	// bookkeeping) don't get counted as per-iteration growth.
+	srWarm, _ := newCaptureFDExec(t)
+	if err := srWarm.Close(nil); err != nil {
+		t.Fatalf("warm Close: %v", err)
+	}
+
+	before := countFDs()
+	for i := range iterations {
+		sr, _ := newCaptureFDExec(t)
+		if err := sr.Close(nil); err != nil {
+			t.Fatalf("iter %d Close: %v", i, err)
+		}
+	}
+	after := countFDs()
+
+	// A per-cycle leak would push delta >= iterations. Allow a small
+	// constant for test-runtime noise (goroutine-scheduler internals,
+	// transient log handles) without masking a real linear leak.
+	const noiseTolerance = 5
+	if delta := after - before; delta >= noiseTolerance {
+		t.Fatalf("fd count grew by %d over %d iterations (before=%d after=%d); expected < %d",
+			delta, iterations, before, after, noiseTolerance)
+	}
+}

--- a/internal/terminal/terminalrunner/terminal.go
+++ b/internal/terminal/terminalrunner/terminal.go
@@ -199,6 +199,9 @@ func (sr *Exec) startPty() error {
 		_ = logf.Close()
 		return errPerm
 	}
+	// Hand fd ownership to the runner; Close closes it after PTY teardown
+	// so in-flight multiOutW.Write has settled. See #229.
+	sr.captureFile = logf
 
 	if errU := sr.updateMetadata(); errU != nil {
 		return fmt.Errorf("update metadata: %w", errU)

--- a/internal/terminal/terminalrunner/terminal_runner_exec.go
+++ b/internal/terminal/terminalrunner/terminal_runner_exec.go
@@ -81,6 +81,13 @@ type Exec struct {
 
 	closePTY *sync.Once
 
+	// captureFile is the *os.File backing the always-on capture writer in
+	// multiOutW. The runner owns the fd from startPty onward; Close closes
+	// it via closeCapture so repeated New→Start→Close cycles in-process do
+	// not leak fds. See #229.
+	captureFile  *os.File
+	closeCapture *sync.Once
+
 	// initMode is captured at construction time so tests can toggle
 	// initmode.Enable before/after NewTerminalRunnerExec without surprising
 	// the already-running goroutines.
@@ -163,6 +170,7 @@ func NewTerminalRunnerExec(ctx context.Context, logger *slog.Logger, spec *api.T
 		childDoneOnce: &sync.Once{},
 		ptyPipes:      &ptyPipes{},
 		closePTY:      &sync.Once{},
+		closeCapture:  &sync.Once{},
 
 		initMode: inInit,
 		reaper:   rp,


### PR DESCRIPTION
## Summary

- `Exec.Close()` now closes the capture file fd opened in `startPty`. Pre-fix, `logf` was handed to `DynamicMultiWriter` as an opaque `io.Writer` and the runner never closed it — process-exit reclaimed the fd in production single-shot runners, but in-process recycle (tests, future server) accumulated one leaked fd per cycle.
- Implements **Option A** from the issue (narrow blast radius): `*os.File` field on `Exec`, idempotent close via `*sync.Once`. Option B (teaching `DynamicMultiWriter` about `io.Closer` writers) is deferred per the issue's "Out of scope" note.
- Close sequencing matches the issue's guidance — capture fd closes **after** `closeAllSubscribers` and ptmx teardown, so any in-flight `multiOutW.Write` from the PTY reader has settled before the fd disappears.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make sbsh-sb` + `file ./sbsh` (ELF executable confirmed)
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')`
- [x] `go test -tags=integration ./cmd/sb/get/...`
- [x] `make e2e`
- [x] `pre-commit run --files <changed>`
- [x] New regression tests in `lifecycle_capture_fd_test.go`:
  - `TestExecClose_CapturesFileFD` — direct close verification (second `*os.File.Close()` returns `os.ErrClosed`)
  - `TestExecClose_CaptureFileDoubleCloseIsHarmless` — `sync.Once` guards double-close
  - `TestExecClose_CaptureFileFDNoAccumulation` — loop 50× and assert `/proc/self/fd` delta stays under noise threshold (Linux-only; skips elsewhere)

Closes #229