### PR TITLE
fix(terminalrunner): tear down attacher outWriters in Close to drain goroutines

### DIFF
--- a/internal/terminal/terminalrunner/lifecycle.go
+++ b/internal/terminal/terminalrunner/lifecycle.go
@@ -236,13 +236,36 @@ func (sr *Exec) Close(reason error) error {
 
 	// close clients
 	//
+	// Snapshot multiOutW outside clientsMu: cleanupClient takes
+	// ptyPipesMu then clientsMu (via removeClient), so acquiring them in
+	// the opposite order here would invert the lock graph.
+	//
+	// Per-client teardown mirrors cleanupClient (connections.go) and the
+	// Detach RPC path: drop the attacher's bounded writer from the
+	// fan-out, Close it to wake its drain goroutine, then close the conn.
+	// Pre-fix Close only closed conn and relied on the dualcopier
+	// reader-side onClose firing detach to indirectly drain the
+	// goroutine; that path still runs (idempotently, gated by
+	// detachOnce + clear() below), but the indirect dependency is no
+	// longer load-bearing for goroutine teardown. See #230.
+	//
 	// clear() instead of `sr.clients = nil`: a concurrent addClient call
 	// can race past Close's unlock (per-conn RPC handlers outlive the
 	// accept loop's ctx-cancel exit), and writing to a nil map panics.
 	// Emptying the map keeps it addressable so the late write is a benign
 	// stale-entry no-op shape. See #225.
+	sr.ptyPipesMu.RLock()
+	multiOutW := sr.ptyPipes.multiOutW
+	sr.ptyPipesMu.RUnlock()
+
 	sr.clientsMu.Lock()
 	for _, c := range sr.clients {
+		if c.outWriter != nil {
+			if multiOutW != nil {
+				multiOutW.Remove(c.outWriter)
+			}
+			_ = c.outWriter.Close()
+		}
 		if err := c.conn.Close(); err != nil {
 			sr.logger.Warn("could not close client connection", "id", sr.id, "client", c.id, "err", err)
 		}

--- a/internal/terminal/terminalrunner/lifecycle_close_drain_test.go
+++ b/internal/terminal/terminalrunner/lifecycle_close_drain_test.go
@@ -1,0 +1,95 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrunner
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// TestExecClose_TearsDownAttacherOutWriters is the regression for #230.
+//
+// Pre-fix, Close() only called c.conn.Close() per client and left each
+// attacher's subscriberWriter registered in multiOutW with its drain
+// goroutine parked on cond.Wait. The drain only exited indirectly, via the
+// dualcopier reader-side onClose firing detach → cleanupClient → aw.Close.
+// In this test there is no dualcopier wired up, so the indirect path is
+// inert — pre-fix, the N drain goroutines would never exit and the
+// post-Close goroutine count would not return to baseline.
+//
+// Post-fix, Close calls multiOutW.Remove + aw.Close inline per client,
+// waking each drain so it can flush, run its onDetach (a no-op here), and
+// exit via the defer that closes the conn.
+func TestExecClose_TearsDownAttacherOutWriters(t *testing.T) {
+	const attacherCount = 5
+
+	sr := newCloseRaceExec(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Real multiOutW so the inline Remove + Close pairing has something to
+	// remove from. newCloseRaceExec leaves ptyPipes empty.
+	sr.ptyPipesMu.Lock()
+	sr.ptyPipes.multiOutW = NewDynamicMultiWriter(logger)
+	sr.ptyPipesMu.Unlock()
+
+	baseline := runtime.NumGoroutine()
+
+	for i := range attacherCount {
+		id := api.ID(fmt.Sprintf("client-%d", i))
+		// net.Pipe gives us two connected in-memory conns. We retain only
+		// the runner-side half; the peer is GC'd, which is fine because
+		// the drain goroutine's defer closes its end.
+		c, _ := net.Pipe()
+		aw := newSubscriberWriter(c, defaultSubscriberBufferBytes, nil, logger)
+		sr.ptyPipes.multiOutW.Add(aw)
+		sr.clients[id] = &ioClient{id: &id, conn: c, outWriter: aw}
+		go aw.Run()
+	}
+
+	// Let each drain goroutine reach cond.Wait before Close — otherwise a
+	// fast Close could win the race and the test would not be probing the
+	// "drain is parked and must be woken" failure mode the fix targets.
+	time.Sleep(20 * time.Millisecond)
+
+	if err := sr.Close(nil); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+
+	// Poll for goroutine count to return to baseline. The fix is a wakeup
+	// not a join, so we allow a bounded grace period for the drains to
+	// observe Close and exit. The slack of +1 absorbs unrelated goroutine
+	// fluctuations from the runtime/test harness.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		got := runtime.NumGoroutine()
+		if got <= baseline+1 {
+			return
+		}
+		if !time.Now().Before(deadline) {
+			t.Fatalf("drain goroutines did not exit within 2s after Close; "+
+				"baseline=%d, got=%d (regression of #230)", baseline, got)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
## Summary

- `Close()` (`internal/terminal/terminalrunner/lifecycle.go`) previously closed only `c.conn` per client and left each attacher's `subscriberWriter` registered in `multiOutW` with its drain goroutine parked on `cond.Wait`. The drain only exited indirectly via the dualcopier reader-side `onClose` → `detach` → `cleanupClient` → `aw.Close` path. If a future refactor changed that indirection's semantics, drains would silently leak with no test to flag it.
- Fix makes Close's teardown symmetric with `cleanupClient` and the `Detach` RPC path: drop the attacher's bounded writer from the fan-out, `Close()` it to wake the drain, then close the conn.
- `multiOutW` is snapshotted under `ptyPipesMu.RLock()` *outside* `clientsMu` because `cleanupClient` takes `ptyPipesMu` then `clientsMu` (via `removeClient`); acquiring them in the opposite order in `Close` would invert the lock graph.
- The `clear(sr.clients)` from #225 is preserved.

## Notes for reviewer

- **AC #4 ("Metadata writes from `cleanupClient` and `Close` don't race-clobber each other").** The fix does not introduce a new metadata write per client. The drain goroutine's `defer onDetach()` still runs `cleanupClient` post-Close — same as today's indirect path — and is gated by the existing `detachOnce`; the second `Remove`/`Close` calls are no-ops, `removeClient` finds the map already cleared, and `updateTerminalAttachers` fires exactly once per client (same as pre-fix). The race exists in main and is unchanged by this PR; out of scope here.
- The fix follows the issue's literal Proposal block. The bundled-with-#225-panic option mentioned in the issue is already in main, so this PR only adds the symmetric teardown.

## Test plan

- [x] `make test` (passes; includes the new `TestExecClose_TearsDownAttacherOutWriters`)
- [x] `go test -race ./internal/terminal/terminalrunner/...`
- [x] `make sbsh-sb` + `file ./sbsh` → ELF executable
- [x] `go build ./...`, `go vet ./...`
- [x] `make e2e` (passes)
- [x] Regression verified: temporarily reverted the `lifecycle.go` change and re-ran the new test — fails with `baseline=2, got=7` (5 leaked drain goroutines). Restored, test passes.
- [x] `pre-commit run --files <changed>` — all hooks pass

Closes #230