### PR TITLE
fix(terminal/controller): check Close return on rpcDoneCh failure path

### DIFF
--- a/internal/terminal/controller.go
+++ b/internal/terminal/controller.go
@@ -225,7 +225,7 @@ func (c *Controller) Run(spec *api.TerminalSpec) error {
 				return errdefs.ErrRPCServerExited
 			}
 			c.logger.ErrorContext(c.ctx, "rpc server has failed", "err", err)
-			if errC := c.Close(err); err != nil {
+			if errC := c.Close(err); errC != nil {
 				c.logger.ErrorContext(c.ctx, "error during Close after rpc server failure", "err", errC)
 				err = fmt.Errorf("%w: %w: %w", err, errdefs.ErrOnClose, errC)
 			}


### PR DESCRIPTION
## Summary
- Fixes a typo at `internal/terminal/controller.go:228` — the conditional `if errC := c.Close(err); err != nil` assigned to `errC` but gated on `err`. Changed the gate to `errC != nil` so the Close return is actually inspected and wrapped into the returned error chain.
- Today the practical bug from the issue body ("graceful rpcDoneCh + Close failure silently drops `errC`") doesn't fire — a graceful early-return now sits above this branch at lines 218-226 (added after the issue was filed), so the typo path is only reached when `err != nil`. There the code "works by accident" because the gate is always true on this path, but the intent is to check `errC` (Close's return) not `err` (the rpcDoneCh value), and the surrounding sibling sites in this file (lines 200 `ContextDone` ladder) and `internal/client/controller.go` already use the correct shape. Fixing the typo aligns the failure path with intent and removes the latent footgun if the graceful early-return is ever refactored away.

## Test plan
- [x] `make sbsh-sb` — produces an ELF binary (verified with `file ./sbsh`)
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `make test` — full project test target green, including `./internal/terminal/...`, `./internal/client/...`, integration `./cmd/sb/get/...`, and `./e2e`

## Notes for reviewer
- Issue body cited lines 218-224 and described the practical impact as "graceful rpcDoneCh + Close failure loses the Close error entirely." Code has evolved since the file: the graceful path now early-returns at lines 218-226 and the typo lives at line 228 on the failure path only, so the practical symptom no longer fires today. The typo itself is still real and the proposed one-line fix from the issue still applies verbatim. Flagging this divergence per dev CLAUDE.md's rotted-premise guidance — the underlying intent is intact and reinterpretation is mechanical.

Closes #232