### PR TITLE
fix(terminalrpc): consume params on nil-body to prevent cross-talk

### DIFF
--- a/internal/terminal/terminalrpc/codec.go
+++ b/internal/terminal/terminalrpc/codec.go
@@ -88,13 +88,14 @@ func (c *unixJSONServerCodec) ReadRequestHeader(r *rpc.Request) error {
 
 // ReadRequestBody unmarshals the first element of the params array into body (like std jsonrpc).
 func (c *unixJSONServerCodec) ReadRequestBody(body interface{}) error {
-	if body == nil {
-		return nil
-	}
 	// We don't get seq here, so we rely on json.Decoder’s sequencing; net/rpc calls
 	// ReadRequestBody immediately after ReadRequestHeader on the same goroutine,
 	// so the most recent seq is r.Seq. To keep this simple, we pop the smallest seq
-	// that still has params (the one we just set).
+	// that still has params (the one we just set). We must consume the entry even
+	// when body is nil — net/rpc passes nil to discard the body of an unknown
+	// method, and leaving the entry behind would both leak the buffer for the
+	// connection's lifetime and cause cross-talk on the next call (smallest-seq
+	// pick would return the stale prior-request params).
 	c.seqMu.Lock()
 	var chosenSeq uint64
 	for s := range c.paramsBySeq {
@@ -105,6 +106,10 @@ func (c *unixJSONServerCodec) ReadRequestBody(body interface{}) error {
 	params := c.paramsBySeq[chosenSeq]
 	delete(c.paramsBySeq, chosenSeq)
 	c.seqMu.Unlock()
+
+	if body == nil {
+		return nil
+	}
 
 	if len(params) == 0 || string(params) == "null" {
 		return nil

--- a/internal/terminal/terminalrpc/codec_test.go
+++ b/internal/terminal/terminalrpc/codec_test.go
@@ -1,0 +1,132 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrpc
+
+import (
+	"io"
+	"log/slog"
+	"net"
+	"net/rpc"
+	"os"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestReadRequestBody_NilDoesNotCrossTalk drives the codec through the same
+// header/body sequence net/rpc uses when it sees an unknown method: read the
+// header, then ReadRequestBody(nil) to discard the body. If the codec leaves
+// the prior request's params in paramsBySeq, the next ReadRequestBody picks
+// the smallest-seq entry — the stale one — and the wrong handler gets the
+// wrong params. Reproduction asserts the second request's body matches its
+// own wire params.
+func TestReadRequestBody_NilDoesNotCrossTalk(t *testing.T) {
+	cli, srv := mustSocketpair(t)
+	defer cli.Close()
+	defer srv.Close()
+
+	codec := NewUnixJSONServerCodec(srv, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	// Request 1: unknown method, distinctive params. net/rpc will discard via
+	// ReadRequestBody(nil) on this one.
+	mustWriteJSON(t, cli, `{"id":1,"method":"Unknown.Method","params":[{"x":111}]}`)
+	// Request 2: known shape, different distinctive params. Whatever the
+	// handler receives should be {"x":222}, never {"x":111}.
+	mustWriteJSON(t, cli, `{"id":2,"method":"Known.Method","params":[{"x":222}]}`)
+
+	var r1 rpc.Request
+	if err := codec.ReadRequestHeader(&r1); err != nil {
+		t.Fatalf("ReadRequestHeader #1: %v", err)
+	}
+	if err := codec.ReadRequestBody(nil); err != nil {
+		t.Fatalf("ReadRequestBody(nil) #1: %v", err)
+	}
+
+	var r2 rpc.Request
+	if err := codec.ReadRequestHeader(&r2); err != nil {
+		t.Fatalf("ReadRequestHeader #2: %v", err)
+	}
+	var body struct {
+		X int `json:"x"`
+	}
+	if err := codec.ReadRequestBody(&body); err != nil {
+		t.Fatalf("ReadRequestBody #2: %v", err)
+	}
+	if body.X != 222 {
+		t.Fatalf("body.X = %d; want 222 (got cross-talk from request 1's params)", body.X)
+	}
+}
+
+// TestReadRequestBody_NilDrainsPendingParams asserts paramsBySeq is empty
+// after a ReadRequestBody(nil): the buffer must not survive the connection's
+// lifetime for every unknown-method call.
+func TestReadRequestBody_NilDrainsPendingParams(t *testing.T) {
+	cli, srv := mustSocketpair(t)
+	defer cli.Close()
+	defer srv.Close()
+
+	codec := NewUnixJSONServerCodec(srv, slog.New(slog.NewTextHandler(io.Discard, nil))).(*unixJSONServerCodec)
+
+	mustWriteJSON(t, cli, `{"id":1,"method":"Unknown.Method","params":[{"x":1}]}`)
+
+	var r rpc.Request
+	if err := codec.ReadRequestHeader(&r); err != nil {
+		t.Fatalf("ReadRequestHeader: %v", err)
+	}
+	if err := codec.ReadRequestBody(nil); err != nil {
+		t.Fatalf("ReadRequestBody(nil): %v", err)
+	}
+
+	codec.seqMu.Lock()
+	n := len(codec.paramsBySeq)
+	codec.seqMu.Unlock()
+	if n != 0 {
+		t.Fatalf("paramsBySeq has %d leaked entries after ReadRequestBody(nil); want 0", n)
+	}
+}
+
+func mustSocketpair(t *testing.T) (*net.UnixConn, *net.UnixConn) {
+	t.Helper()
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatalf("socketpair: %v", err)
+	}
+	return fdToUnixConn(t, fds[0], "a"), fdToUnixConn(t, fds[1], "b")
+}
+
+func fdToUnixConn(t *testing.T, fd int, name string) *net.UnixConn {
+	t.Helper()
+	f := os.NewFile(uintptr(fd), name)
+	c, err := net.FileConn(f)
+	_ = f.Close()
+	if err != nil {
+		t.Fatalf("FileConn: %v", err)
+	}
+	uc, ok := c.(*net.UnixConn)
+	if !ok {
+		_ = c.Close()
+		t.Fatalf("FileConn did not return *net.UnixConn (got %T)", c)
+	}
+	return uc
+}
+
+func mustWriteJSON(t *testing.T, c *net.UnixConn, payload string) {
+	t.Helper()
+	if _, err := c.Write([]byte(payload)); err != nil {
+		t.Fatalf("write %q: %v", payload, err)
+	}
+}


### PR DESCRIPTION
## Summary

Audit of `internal/terminal/terminalrpc/` for the SCM_RIGHTS fd-leak pattern that landed in #213, plus a small obvious fix for the one defect found.

- **The SCM_RIGHTS send site (only one) is sound.** `codec.go`'s `WriteResponse` defer-closes the local fds on every exit path (success, marshal error, `WriteMsgUnix` error) and nils out `r.FDs` for idempotency. `UnixRights` does not consume fds, so no leak there. There are no SCM_RIGHTS recv sites in the package (server-side codec only reads JSON; client-side recv lives in `pkg/rpcclient/terminal/`, out of scope for this issue).
- **`rpc_server.go` is pure delegation** — no fd handling, no shared state, no concurrency primitives. Concurrent-request handling is owned by `net/rpc`'s per-call goroutine dispatch.
- **The codec carries an unrelated defect** unrelated to SCM_RIGHTS but in the "codec edge cases" scope of #220: `ReadRequestBody(nil)` returned without consuming the entry queued in `paramsBySeq` by the matching `ReadRequestHeader`. `net/rpc` calls `ReadRequestBody(nil)` to discard the body of an unknown method, so every unknown-method call with non-empty params (a) leaked one buffer for the connection's lifetime and (b) caused **cross-talk** on the next call: `ReadRequestBody` picks the smallest-seq entry, which would be the stale prior-request one, so a later legitimate request's handler would receive the prior request's params. In practice clients and servers know the same method set so this is rarely triggered, but the leak/cross-talk is real on any version skew or malicious client.

Fix: move the `paramsBySeq` consume block above the `body == nil` check so the entry is always drained.

Regression test: `internal/terminal/terminalrpc/codec_test.go` drives two requests through the codec, the first an "unknown" method with `ReadRequestBody(nil)`, the second a known method with distinct params; asserts the second handler receives its own params (verified to fail with `body.X = 111; want 222` and `paramsBySeq has 1 leaked entries; want 0` when the fix is reverted).

## Test plan

- [x] `make sbsh-sb` (canonical build produces ELF for both `sbsh` and `sb`)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (full project test target — cmd, internal, e2e)
- [x] `go test ./internal/terminal/terminalrpc/...` (includes the two new regression tests)
- [x] Regression tests verified to fail with the codec fix reverted (cross-talk on test 1, leak on test 2)
- [x] `pre-commit run --files` on changed files

Closes #220