### PR TITLE
fix(pkg/attach): return ErrContextDone deterministically on ctx-cancel

### DIFF
--- a/pkg/attach/attach.go
+++ b/pkg/attach/attach.go
@@ -144,29 +144,41 @@ func Run(ctx context.Context, opts Options) error {
 	}()
 
 	if waitErr := ctrl.WaitReady(); waitErr != nil {
-		// Drain ctrl.Run so the goroutine can exit; ignore its error
-		// (already surfaced via WaitReady or closing).
+		// WaitReady only returns non-nil when ctx fires before the
+		// controller signals readiness — i.e. ctx-cancel during setup.
+		// Actively close so the goroutine can exit even if a setup step
+		// is blocked on something that doesn't observe ctx; without
+		// this, <-errCh would have to trust every downstream RPC to
+		// honour ctx-cancel. Return the same ErrContextDone shape the
+		// post-setup path uses so callers branching on errors.Is see
+		// one sentinel for any ctx-cancel.
+		_ = ctrl.Close(waitErr)
 		<-errCh
-		return fmt.Errorf("%w: %w", errdefs.ErrWaitOnReady, waitErr)
+		return fmt.Errorf("%w: %w", errdefs.ErrContextDone, waitErr)
 	}
 
 	select {
 	case <-ctx.Done():
-		if waitErr := ctrl.WaitClose(); waitErr != nil {
-			return fmt.Errorf("%w: %w", errdefs.ErrWaitOnClose, waitErr)
-		}
+		// Force shutdown for the same reason as the WaitReady path, and
+		// so WaitClose (which blocks on closedCh, which only Close
+		// closes) doesn't depend on the controller reaching its own
+		// ctx.Done observer before exiting.
+		ctxErr := ctx.Err()
+		_ = ctrl.Close(ctxErr)
+		_ = ctrl.WaitClose()
 		<-errCh
-		return fmt.Errorf("%w: %w", errdefs.ErrContextDone, ctx.Err())
+		return fmt.Errorf("%w: %w", errdefs.ErrContextDone, ctxErr)
 
 	case ctrlErr := <-errCh:
-		if ctrlErr == nil || errors.Is(ctrlErr, context.Canceled) {
+		if ctrlErr == nil {
 			return nil
 		}
 		// Drain WaitClose to release internal resources, then map the
 		// controller-level session-end sentinel to the matching public
-		// sentinel so embedders can branch with errors.Is. Setup and
-		// infrastructure failures (no errdefs session-end sentinel
-		// chained) keep their identity.
+		// sentinel so embedders can branch with errors.Is. ctx-cancel
+		// surfaces here as errdefs.ErrContextDone chained with ctx.Err
+		// — pass it through unchanged so the two arms of this select
+		// return the same shape regardless of which one wins the race.
 		_ = ctrl.WaitClose()
 		return classifySessionEnd(ctrlErr)
 	}

--- a/pkg/attach/attach_test.go
+++ b/pkg/attach/attach_test.go
@@ -49,6 +49,11 @@ type fakeTerminalController struct {
 	attachCalls atomic.Int32
 	state       api.TerminalStatusMode
 	attachErr   error
+	// attachBlock, if non-nil, makes Attach block until the channel is
+	// closed. Used to pin Run inside the controller's setup phase so
+	// the ctx-cancel race in pkg/attach.Run's shutdown select is
+	// reachable from a test.
+	attachBlock <-chan struct{}
 }
 
 func (f *fakeTerminalController) Ping(in *api.PingMessage, out *api.PingMessage) error {
@@ -69,6 +74,9 @@ func (f *fakeTerminalController) State(_ *api.Empty, out *api.TerminalStatusMode
 
 func (f *fakeTerminalController) Attach(_ *api.ID, _ *api.Empty) error {
 	f.attachCalls.Add(1)
+	if f.attachBlock != nil {
+		<-f.attachBlock
+	}
 	return f.attachErr
 }
 
@@ -280,6 +288,75 @@ func TestClassifySessionEnd_SetupErrorPassesThrough(t *testing.T) {
 	}
 	if !errors.Is(got, in) {
 		t.Fatalf("expected pass-through of input, got: %v", got)
+	}
+}
+
+// TestRun_CtxCancelReturnsErrContextDone is the regression for #246: the
+// shutdown select used to race on ctx-cancel — half the runs returned
+// errdefs.ErrContextDone (the documented behavior) and half returned nil
+// because the errCh arm short-circuited on errors.Is(ctrlErr,
+// context.Canceled). The fake's Attach blocks until t.Cleanup so Run
+// stays in the controller's setup phase; cancelling ctx from the test
+// must surface as errdefs.ErrContextDone every time.
+func TestRun_CtxCancelReturnsErrContextDone(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	block := make(chan struct{})
+	t.Cleanup(func() { close(block) })
+
+	fake := &fakeTerminalController{
+		state:       api.Ready,
+		attachBlock: block,
+	}
+	sock := startFakeTerminalServer(t, tempDir, fake)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = r.Close()
+		_ = w.Close()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- attach.Run(ctx, attach.Options{
+			SocketPath:             sock,
+			Stdin:                  r,
+			Stdout:                 w,
+			Stderr:                 w,
+			DisableDetachKeystroke: true,
+			Logger:                 discardLogger(),
+		})
+	}()
+
+	// Wait for Run to reach the Attach RPC so the cancel races against
+	// a controller pinned in setup, not a controller that finished early.
+	deadline := time.Now().Add(2 * time.Second)
+	for fake.attachCalls.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("Attach was never called; Run did not progress past setup")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cancel()
+
+	select {
+	case runErr := <-runDone:
+		if runErr == nil {
+			t.Fatal("expected non-nil error after ctx-cancel, got nil")
+		}
+		if !errors.Is(runErr, errdefs.ErrContextDone) {
+			t.Fatalf("expected error wrapping errdefs.ErrContextDone, got: %v", runErr)
+		}
+		if !errors.Is(runErr, context.Canceled) {
+			t.Fatalf("expected context.Canceled in chain, got: %v", runErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return within 5s of ctx-cancel")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Addresses the `pkg/attach/` audit (#221) and the bug it surfaced (#246). `pkg/attach.Run`'s shutdown handling had two paths returning different sentinels for the same observable event (ctx cancellation) — the post-setup select arm short-circuited on `errors.Is(ctrlErr, context.Canceled)` and returned **nil** ~50% of the time, while the setup-phase WaitReady arm returned `errdefs.ErrWaitOnReady`. The docstring (lines 67-74) promises one sentinel — `errdefs.ErrContextDone` — for any ctx-cancel.
- Both arms now (a) actively call `ctrl.Close(reason)` so the shutdown is guaranteed-finite regardless of whether downstream setup steps observe ctx, and (b) return `errdefs.ErrContextDone` wrapping `ctx.Err()`. The `WaitClose` errors-out branch on the ctx-done arm was already unreachable (the controller's `WaitClose` is a single-case select on `closedCh`) — removed to drop dead code.
- Note for review: the public re-export `pkg/errors.ErrWaitOnReady` (`pkg/errors/errors.go:80`) is unchanged — that sentinel is still produced by the separate per-terminal wait paths in `cmd/sbsh/terminal/terminal.go:549` and `cmd/sbsh/sbsh.go:494`. Only the `pkg/attach.Run` arm that previously emitted it on ctx-cancel-during-setup has switched to `ErrContextDone` to satisfy the unified-sentinel docstring.

## Audit verdict for #221

`pkg/attach/` is a thin façade (4 files, ~220 LOC). End-to-end read confirms:

- **Exported entry points:** only `Run(ctx, Options) error`. Options struct + three sentinels (`ErrSocketPathRequired`, `ErrDetached`, `ErrPeerClosed`) — covered.
- **Fan-out behavior with multiple attachers:** not a `pkg/attach` concern. Each `Run` call creates its own private control socket under `os.TempDir()` and dials the target. Multi-attacher fan-out lives in `internal/terminal/terminalrunner` — the package PR #217 hardened. Documented correctly in `pkg/attach/doc.go` and `attach.go:75-78`.
- **Slow-consumer behavior:** not introduced at this layer either. `pkg/attach` passes the caller's `*os.File` stdout straight through to the controller; bounded-output policy + per-write deadlines live in `terminalrunner.subscriberWriter` and the server-side attach path (#217).
- **Detach-midstream:** the in-band ^]^] keystroke is the embedded client's responsibility (`internal/client/clientrunner/io.go:96-103`). `pkg/attach.classifySessionEnd` maps the resulting `errdefs.ErrClientDetached` (set by `controller.classifySessionEnd` once `detachRequested` flips) to `attach.ErrDetached`. Test coverage already in `attach_test.go`.
- **Sentinel-error discrimination:** `ErrSocketPathRequired`, `ErrAttach`, `ErrDetached`, `ErrPeerClosed`, and the setup-error pass-through are exercised; this PR adds the missing `ErrContextDone` deterministic-return test.
- **Defect found:** the shutdown-select race + setup-arm sentinel mismatch documented in #246. Filed as a separate `bug` per the audit body. Fix included in this PR.

Out-of-scope observation surfaced during the audit (not filed): `internal/client/controller.go:448-454` `WaitClose() error` is a single-case select that can only return nil — the `error` return is unreachable and the corresponding caller check at `pkg/attach/attach.go:155-156` (pre-fix) was dead code. Drive-by removed from this PR's diff; a follow-up cleanup PR could either tighten the signature to `WaitClose()` (no error) or implement the timeout-aware path the signature implies, but neither is blocking.

## Test plan

- [x] `make sbsh-sb` — canonical build succeeds.
- [x] `file ./sbsh` — confirms ELF 64-bit LSB executable.
- [x] `go build ./...`, `go vet ./...` — clean.
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` — full unit suite passes, including the new regression `TestRun_CtxCancelReturnsErrContextDone` in `pkg/attach/attach_test.go`.
- [x] `go test -count=10 -run '^TestRun_CtxCancel' ./pkg/attach/` — new regression non-flaky across 10 runs.
- [x] `go test -tags=integration ./cmd/sb/get/...` — integration step passes.
- [x] `cd docs/examples/library-consumer && go build ./... && go vet ./...` — library-consumer example builds and vets clean.
- [x] `make e2e` — full e2e suite passes.
- [x] `pre-commit run --files pkg/attach/attach.go pkg/attach/attach_test.go` — all hooks pass.

Closes #221
Closes #246