### PR TITLE
docs(terminalstore): document scope, lifetime, and concurrency model

### DIFF
--- a/internal/client/terminalstore/doc.go
+++ b/internal/client/terminalstore/doc.go
@@ -1,0 +1,62 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package terminalstore is the client-side, in-memory registry of
+// terminals known to a single sbsh client process.
+//
+// # Scope and lifetime
+//
+// A TerminalStore is created fresh inside client.Controller.Run (see
+// internal/client/controller.go) and dies with the controller goroutine
+// when the client process exits or its context is cancelled. The store
+// holds *api.AttachedTerminal values keyed by api.ID; it is not
+// persisted to disk.
+//
+// The authoritative inventory of terminals across the host lives on
+// disk under <runPath>/terminals/<id>/. That directory tree is the
+// source of truth — owned by the per-terminal supervisor process and
+// read by package internal/discovery. Stale-entry reconciliation for
+// terminals whose supervisor crashed without a graceful stop happens
+// there (discovery.ReconcileTerminals + internal/pidutil for
+// PID-reuse safety), not in this package. Likewise, name-collision
+// rejection on terminal creation lives in
+// discovery.VerifyTerminalNameAvailable (issue #114, PR #182). This
+// package never touches the filesystem and never inspects PIDs.
+//
+// # Concurrency
+//
+// All TerminalStore operations on the production Exec implementation
+// are guarded by a single sync.RWMutex. Read methods (Get, ListLive,
+// Current) take the read lock; mutators (Add, Remove, SetCurrent)
+// take the write lock. Each compound check-then-write sequence —
+// Add's "exists? then insert (and maybe set current)" and
+// SetCurrent's "exists? then assign" — runs under one write-lock
+// acquisition, so they are atomic with respect to concurrent callers.
+// There is no internal TOCTOU window.
+//
+// The store is keyed by api.ID exclusively. There is no name-keyed
+// lookup, and no callers route from a store entry to a kill(2)
+// target — the PID-reuse-safe signal path lives in
+// internal/pidutil.Match, gated by the start-time token persisted in
+// TerminalStatus.PidStart (issue #109 tracks the pidfd_open
+// alternative). A TOCTOU between "find by name" and "send signal"
+// cannot arise through this store.
+//
+// # Test double
+//
+// session_store_fake.go provides Test, a function-stub fake intended
+// for unit tests of code that depends on the TerminalStore interface.
+package terminalstore


### PR DESCRIPTION
## Summary

- Issue #223 asked for an audit of `internal/client/terminalstore/session_store.go` for concurrency, stale-entry, and TOCTOU concerns. The audit's primary verdict is **no defects in the store itself**; this PR delivers that verdict as a `doc.go` so the next reader doesn't have to re-derive it. A separate dead-API observation is filed as a follow-up (#250) rather than bundled here.
- The new `doc.go` documents: scope (in-memory, per-client-process registry keyed by `api.ID`, not persisted to disk), lifetime (created in `client.Controller.Run`, dies with the process), concurrency model (single `sync.RWMutex`, mutators take write lock, readers take read lock, `Add`/`SetCurrent` compound-atomic), the source-of-truth boundary (on-disk inventory under `<runPath>/terminals/*` owned by `internal/discovery`), and the TOCTOU non-concern (keyed by `api.ID` only — there is no name→signal path through this store; PID-reuse safety lives in `internal/pidutil`).
- Branch prefixed `docs/` per repo convention. Trivial-edit shortcut (`ready-to-merge`) applies — no executable code, test, or behavior changes; only a new file containing a Go package comment.

## Audit findings for #223

Acceptance criteria from #223:

- [x] **`session_store.go` read end-to-end with the bug lens** — done. The file is 112 lines: an interface (`Add`/`Get`/`ListLive`/`Remove`/`Current`/`SetCurrent`) and a single `Exec` implementation backing it with `map[api.ID]*api.AttachedTerminal` + `current api.ID` under `sync.RWMutex`.
- [x] **Concurrent-access invariants verified.** All mutators (`Add`, `Remove`, `SetCurrent`) take the write lock; all readers (`Get`, `ListLive`, `Current`) take the read lock. Each compound check-then-write (Add's "exists? then insert; if first, set current" and SetCurrent's "exists? then assign") runs under a single write-lock acquisition, so no internal TOCTOU window exists. `ListLive` correctly pre-sizes the output slice with `make([]api.ID, 0, len(m.terminals))` while holding the read lock — no concurrent-map iteration hazard.
- [x] **Crash-recovery / stale-entry handling verified.** Not at this layer. The store is in-memory and per-process — it dies with the client. The authoritative inventory of terminals across the host lives on disk under `<runPath>/terminals/*` and is reconciled by `internal/discovery.ReconcileTerminals` (the same flow that PR #182 / issue #114 hardened for name-collision rejection). PID-liveness checks during reconciliation are PID-reuse-safe via the start-time token persisted in `TerminalStatus.PidStart` (see #109 for the pidfd_open consideration). `terminalstore` never touches the filesystem and never inspects PIDs, so it has no stale-entry surface of its own.
- [x] **Each finding filed as a separate `bug` issue linked here.** Zero new `bug` issues. One `chore:` follow-up filed — #250 — for the dead public surface area observation below. That observation is a quality concern, not a defect, so it is not labelled `bug`.
- [ ] **This issue closed with either a fix PR or an audit-report comment.** This PR carries the audit-report content (this section + the new `doc.go`) and `Closes #223`, but the role rule blocks dev from closing issues it didn't author — the PR-driven auto-close on merge handles the closure cleanly without a manual `gh issue close`.

## Cross-cutting observations (informational, not bugs)

While performing the audit I noticed two related surface-area issues that don't qualify as bugs but are worth raising. Both are filed in #250 (a `chore:` follow-up with `enhancement` + `priority:C`), not bundled here:

1. **Five of the six `TerminalStore` interface methods are dead in production.** Only `Add` is called (three sites — `controller.go:334`, `:368`, `:392`). `Get`, `ListLive`, `Remove`, `Current`, `SetCurrent` are unused outside tests; the test stubs provide them solely to match the interface shape.
2. **`internal/client/clientrunner/client_runner_exec.go:54` `Mgr *terminalstore.Exec` is never read or written.** A grep of `\.Mgr\b` across `*.go` returns zero hits.

The audit-relevant point: code that doesn't run cannot race, but it can mislead the next reader into reasoning about properties (current-terminal lifecycle, list-live semantics, ID→signal routing through this store) that are not actually load-bearing. The new `doc.go` documents the actual shape; the follow-up #250 proposes trimming the surface to match.

## Test plan

- [x] `make sbsh-sb` — canonical build succeeds (`./sbsh` is ELF 64-bit LSB executable, `./sb` hardlinked).
- [x] `file ./sbsh` — confirms ELF.
- [x] `go build ./...` / `go vet ./...` — clean.
- [x] `go test -timeout=300s $(go list ./... | grep -v '/e2e$')` — full unit suite green.
- [x] `go test -timeout=120s -tags=integration ./cmd/sb/get/...` — integration step green.
- [x] `stdbuf -oL -eL make e2e </dev/null` — full e2e suite green (3.10s).
- [x] `pre-commit run --files internal/client/terminalstore/doc.go` — all hooks pass (`go fmt`, `golangci-lint`, `addlicense`, etc.).

Closes #223