### PR TITLE
fix(stop): reject recycled PIDs in reconcile and reconcile single-name targets

### DIFF
--- a/cmd/sb/stop/terminals.go
+++ b/cmd/sb/stop/terminals.go
@@ -224,7 +224,12 @@ func resolveTargets(
 	if doc == nil {
 		return nil, fmt.Errorf("%w: terminal %q", errdefs.ErrTerminalNotFound, opts.name)
 	}
-	return []api.TerminalDoc{*doc}, nil
+	// Persist Exited if the recorded process is gone (or its PID has been
+	// recycled to an unrelated instance). Mirrors the --all branch above so
+	// metadata stays consistent regardless of which target path was taken.
+	docs := []api.TerminalDoc{*doc}
+	discovery.ReconcileTerminals(ctx, logger, opts.runPath, docs)
+	return docs, nil
 }
 
 func stopOneTerminal(

--- a/cmd/sb/stop/terminals_test.go
+++ b/cmd/sb/stop/terminals_test.go
@@ -18,12 +18,18 @@ package stop
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
+	"log/slog"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/eminwux/sbsh/cmd/config"
+	"github.com/eminwux/sbsh/internal/defaults"
 	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/pkg/api"
 	"github.com/spf13/viper"
 )
 
@@ -134,5 +140,73 @@ func Test_ProcessIsOurs_ZeroTokenFallsBack(t *testing.T) {
 	}
 	if processIsOurs(0, 0) {
 		t.Fatal("expected processIsOurs(0, 0) to be false")
+	}
+}
+
+func writeStopTestTerminal(t *testing.T, runPath, id, name string, state api.TerminalStatusMode, pid int) {
+	t.Helper()
+	dir := filepath.Join(runPath, defaults.TerminalsRunPath, id)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	doc := api.TerminalDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindTerminal,
+		Spec:       api.TerminalSpec{ID: api.ID(id), Name: name, RunPath: runPath},
+		Status: api.TerminalStatus{
+			State:           state,
+			Pid:             pid,
+			TerminalRunPath: dir,
+		},
+	}
+	b, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if writeErr := os.WriteFile(filepath.Join(dir, "metadata.json"), b, 0o644); writeErr != nil {
+		t.Fatalf("write metadata.json: %v", writeErr)
+	}
+}
+
+func readStopTestTerminalState(t *testing.T, runPath, id string) api.TerminalStatusMode {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(runPath, defaults.TerminalsRunPath, id, "metadata.json"))
+	if err != nil {
+		t.Fatalf("read metadata: %v", err)
+	}
+	var doc api.TerminalDoc
+	if unmarshalErr := json.Unmarshal(b, &doc); unmarshalErr != nil {
+		t.Fatalf("unmarshal: %v", unmarshalErr)
+	}
+	return doc.Status.State
+}
+
+// Test_ResolveTargets_SingleName_PersistsExited covers the previously-missing
+// reconcile step on the single-target name path: a stale terminal whose
+// recorded PID is dead should be persisted as Exited after resolveTargets
+// runs, matching what the --all branch already does.
+func Test_ResolveTargets_SingleName_PersistsExited(t *testing.T) {
+	const deadPid = 0x7fffffff // very-high PID unlikely to exist
+	runPath := t.TempDir()
+	writeStopTestTerminal(t, runPath, "id-dead", "alpha", api.Ready, deadPid)
+
+	opts := stopOpts{
+		runPath: runPath,
+		name:    "alpha",
+		timeout: defaultStopTimeout,
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	docs, err := resolveTargets(context.Background(), logger, opts)
+	if err != nil {
+		t.Fatalf("resolveTargets: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 doc, got %d", len(docs))
+	}
+	if docs[0].Status.State != api.Exited {
+		t.Fatalf("in-memory: expected Exited after reconcile, got %v", docs[0].Status.State)
+	}
+	if got := readStopTestTerminalState(t, runPath, "id-dead"); got != api.Exited {
+		t.Fatalf("persisted: expected Exited after reconcile, got %v", got)
 	}
 }

--- a/internal/discovery/reconcile.go
+++ b/internal/discovery/reconcile.go
@@ -25,6 +25,7 @@ import (
 	"syscall"
 
 	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/internal/pidutil"
 	"github.com/eminwux/sbsh/internal/shared"
 	"github.com/eminwux/sbsh/pkg/api"
 )
@@ -56,6 +57,32 @@ func isProcessAlive(pid int) bool {
 	return false
 }
 
+// isInstanceAlive extends isProcessAlive with PID-reuse rejection: if a
+// start-time token was recorded, the live PID must still belong to the same
+// process instance that produced it. A zero token degrades to liveness-only,
+// matching the contract documented on pidutil.Match for legacy metadata and
+// non-Linux platforms.
+func isInstanceAlive(pid int, pidStart uint64) bool {
+	if !isProcessAlive(pid) {
+		return false
+	}
+	if pidStart == 0 {
+		return true
+	}
+	ok, err := pidutil.Match(pid, pidStart)
+	if err != nil {
+		// /proc entry vanished between the signal-0 check and the token read —
+		// treat as gone so callers persist Exited.
+		if errors.Is(err, os.ErrNotExist) {
+			return false
+		}
+		// Other read errors are inconclusive; keep prior behavior (treat as
+		// alive) rather than invent an Exited state on a transient /proc error.
+		return true
+	}
+	return ok
+}
+
 // ReconcileTerminals checks each terminal's recorded PID and, if the process
 // is gone but the metadata still claims a live state, rewrites metadata.json
 // with state=Exited. Mutates terminals in place so callers see fresh state.
@@ -79,7 +106,7 @@ func reconcileTerminal(
 	if t.Status.State == api.Exited {
 		return
 	}
-	if isProcessAlive(t.Status.Pid) {
+	if isInstanceAlive(t.Status.Pid, t.Status.PidStart) {
 		return
 	}
 	logger.InfoContext(ctx, "reconcileTerminal: marking stale terminal as Exited",
@@ -125,7 +152,7 @@ func reconcileClient(
 	if c.Status.State == api.ClientExited {
 		return
 	}
-	if isProcessAlive(c.Status.Pid) {
+	if isInstanceAlive(c.Status.Pid, c.Status.PidStart) {
 		return
 	}
 	logger.InfoContext(ctx, "reconcileClient: marking stale client as Exited",

--- a/internal/discovery/reconcile_test.go
+++ b/internal/discovery/reconcile_test.go
@@ -1,0 +1,161 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+func writeTerminalDocFull(t *testing.T, runPath, id string, state api.TerminalStatusMode, pid int, pidStart uint64) {
+	t.Helper()
+	dir := filepath.Join(runPath, defaults.TerminalsRunPath, id)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	doc := api.TerminalDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindTerminal,
+		Spec:       api.TerminalSpec{ID: api.ID(id), RunPath: runPath},
+		Status: api.TerminalStatus{
+			State:           state,
+			Pid:             pid,
+			PidStart:        pidStart,
+			TerminalRunPath: dir,
+		},
+	}
+	b, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if writeErr := os.WriteFile(filepath.Join(dir, "metadata.json"), b, 0o644); writeErr != nil {
+		t.Fatalf("write metadata.json: %v", writeErr)
+	}
+}
+
+func readTerminalState(t *testing.T, runPath, id string) api.TerminalStatusMode {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(runPath, defaults.TerminalsRunPath, id, "metadata.json"))
+	if err != nil {
+		t.Fatalf("read metadata: %v", err)
+	}
+	var doc api.TerminalDoc
+	if unmarshalErr := json.Unmarshal(b, &doc); unmarshalErr != nil {
+		t.Fatalf("unmarshal: %v", unmarshalErr)
+	}
+	return doc.Status.State
+}
+
+// TestReconcileTerminals_RejectsRecycledPid asserts a live PID with a
+// non-matching pidStart token is treated as a recycled PID and the terminal
+// is flipped to Exited. Linux-only because the pidStart token is /proc-backed
+// and zero on other platforms (where the rejection degrades to liveness-only,
+// which we cover in a separate fallback test).
+func TestReconcileTerminals_RejectsRecycledPid(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("pidStart token is only populated on Linux")
+	}
+	runPath := t.TempDir()
+	// Our own PID is alive; pidStart=1 will not match the real start-time
+	// token, so reconcile must treat this as a recycled-PID stranger.
+	writeTerminalDocFull(t, runPath, "id-1", api.Ready, os.Getpid(), 1)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	docs := []api.TerminalDoc{{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindTerminal,
+		Spec:       api.TerminalSpec{ID: api.ID("id-1"), RunPath: runPath},
+		Status: api.TerminalStatus{
+			State:           api.Ready,
+			Pid:             os.Getpid(),
+			PidStart:        1,
+			TerminalRunPath: filepath.Join(runPath, defaults.TerminalsRunPath, "id-1"),
+		},
+	}}
+	ReconcileTerminals(context.Background(), logger, runPath, docs)
+
+	if docs[0].Status.State != api.Exited {
+		t.Fatalf("in-memory doc: expected state=Exited after reconcile, got %v", docs[0].Status.State)
+	}
+	if got := readTerminalState(t, runPath, "id-1"); got != api.Exited {
+		t.Fatalf("persisted doc: expected state=Exited after reconcile, got %v", got)
+	}
+}
+
+// TestReconcileTerminals_ZeroTokenFallsBackToLiveness covers legacy metadata
+// (or non-Linux platforms) where PidStart is unset: the predicate degrades to
+// liveness-only, matching pidutil.Match's documented contract.
+func TestReconcileTerminals_ZeroTokenFallsBackToLiveness(t *testing.T) {
+	runPath := t.TempDir()
+	writeTerminalDocFull(t, runPath, "id-live", api.Ready, os.Getpid(), 0)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	docs := []api.TerminalDoc{{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindTerminal,
+		Spec:       api.TerminalSpec{ID: api.ID("id-live"), RunPath: runPath},
+		Status: api.TerminalStatus{
+			State:           api.Ready,
+			Pid:             os.Getpid(),
+			PidStart:        0,
+			TerminalRunPath: filepath.Join(runPath, defaults.TerminalsRunPath, "id-live"),
+		},
+	}}
+	ReconcileTerminals(context.Background(), logger, runPath, docs)
+
+	if docs[0].Status.State != api.Ready {
+		t.Fatalf("expected state=Ready preserved for live PID with zero token, got %v", docs[0].Status.State)
+	}
+}
+
+// TestReconcileTerminals_DeadPidIsExited covers the original reconcile
+// contract: a dead PID flips state to Exited. Regression coverage in case
+// the isInstanceAlive refactor broke the existing path.
+func TestReconcileTerminals_DeadPidIsExited(t *testing.T) {
+	runPath := t.TempDir()
+	const deadPid = 0x7fffffff // very-high PID unlikely to exist
+	writeTerminalDocFull(t, runPath, "id-dead", api.Ready, deadPid, 0)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	docs := []api.TerminalDoc{{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindTerminal,
+		Spec:       api.TerminalSpec{ID: api.ID("id-dead"), RunPath: runPath},
+		Status: api.TerminalStatus{
+			State:           api.Ready,
+			Pid:             deadPid,
+			TerminalRunPath: filepath.Join(runPath, defaults.TerminalsRunPath, "id-dead"),
+		},
+	}}
+	ReconcileTerminals(context.Background(), logger, runPath, docs)
+
+	if docs[0].Status.State != api.Exited {
+		t.Fatalf("expected state=Exited for dead PID, got %v", docs[0].Status.State)
+	}
+	if got := readTerminalState(t, runPath, "id-dead"); got != api.Exited {
+		t.Fatalf("persisted: expected state=Exited, got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

- **Closes #248**: `internal/discovery/reconcile.go:isProcessAlive` was PID-only. A recycled PID kept stale metadata stuck at the prior live state (e.g. `Ready`) — `sb get`, `sb prune`, and `sb stop --all` all saw it as live. New `isInstanceAlive` consults `pidutil.Match` when a token is recorded; zero-token metadata still falls back to liveness-only (matches `pidutil.Match`'s contract for legacy/non-Linux callers). Applied to both `reconcileTerminal` and `reconcileClient`.
- **Closes #249**: `cmd/sb/stop/terminals.go:resolveTargets` only ran reconcile on the `--all` branch. The single-target path now reconciles the singleton doc too, so metadata stays consistent (`state=Exited` persists to disk) when the recorded process is gone, matching `--all` semantics.
- **Closes #222** (audit): see the audit-report comment on the issue for the full sweep. Three further findings (RPC-retry budget, controller-grace vs `--timeout` asymmetry, `--force` orphaning child pgroup) are filed as separate `bug` follow-ups for later prioritisation; see #251 and #252.

## Notes for the reviewer

- `isInstanceAlive` lives in `internal/discovery/reconcile.go` rather than pidutil because the contract is reconcile-specific: liveness-first, token-second, with a "transient /proc error keeps prior behavior" branch that pidutil itself deliberately does not impose. The existing `processIsOurs` in `cmd/sb/stop/terminals.go` is the opposite shape (token-first, liveness-second) — leaving each surface its own semantics avoids over-coupling the stop signal path to the reconcile-side defaults. Happy to consolidate if the reviewer prefers a single helper.
- The single-name reconcile uses the existing `discovery.ReconcileTerminals` slice entry point instead of the package-private `reconcileTerminal` to avoid expanding the discovery package's surface for a one-shot caller. Cost is a one-element slice allocation per `sb stop <name>`.
- The new `internal/discovery/reconcile_test.go::TestReconcileTerminals_RejectsRecycledPid` is Linux-gated because the PidStart token is `/proc`-derived (zero on other platforms). The zero-token-fallback case is covered cross-platform by `TestReconcileTerminals_ZeroTokenFallsBackToLiveness`.

## Test plan

- [x] `make sbsh-sb` — canonical build succeeds.
- [x] `file ./sbsh` — confirms ELF 64-bit LSB executable.
- [x] `go build ./...`, `go vet ./...` — clean.
- [x] `go test ./internal/discovery/... ./cmd/sb/stop/...` — passes (new tests + existing).
- [x] `go test -count=10 -run 'Reconcile|ResolveTargets' ./internal/discovery/... ./cmd/sb/stop/...` — non-flaky over 10 runs.
- [x] `make test` — Makefile test target passes (cmd/sb..., cmd/sbsh..., internal/terminal..., internal/client..., integration get/, e2e).
- [x] `pre-commit run --files internal/discovery/reconcile.go internal/discovery/reconcile_test.go cmd/sb/stop/terminals.go cmd/sb/stop/terminals_test.go` — all hooks pass.
- [ ] `make test-race` — not run; the make `test` target above does not include `-race`, and a full `-race` sweep across `./pkg/...` is broader than the diff. Reviewer can run separately if desired.

Closes #248
Closes #249
Closes #222