### PR TITLE
fix(sb stop): bound Stop RPC budget by --timeout

### DIFF
--- a/cmd/sb/stop/terminals.go
+++ b/cmd/sb/stop/terminals.go
@@ -274,7 +274,7 @@ func stopOneTerminal(
 	}
 
 	// Graceful path: try RPC first, fall back to SIGTERM.
-	if err := stopViaRPC(ctx, logger, doc); err != nil {
+	if err := stopViaRPC(ctx, logger, doc, opts.timeout); err != nil {
 		logger.DebugContext(ctx, "Stop RPC failed, falling back to SIGTERM",
 			"name", name, "error", err)
 		if errSig := sendSignal(doc.Status.Pid, doc.Status.PidStart, syscall.SIGTERM); errSig != nil {
@@ -312,16 +312,25 @@ func stopViaRPC(
 	ctx context.Context,
 	logger *slog.Logger,
 	doc *api.TerminalDoc,
+	timeout time.Duration,
 ) error {
 	socket := doc.Status.SocketFile
 	if socket == "" {
 		return errors.New("terminal metadata has no control socket recorded")
 	}
 
+	// Bound the whole RPC budget (dial retries + call) to the user's --timeout
+	// so a stale or wedged controller socket can't burn ~9.6s of retries before
+	// the SIGTERM fallback. The post-signal waitForExit gets its own --timeout
+	// budget; the user's stop wall-clock is bounded by ~2*timeout in the worst
+	// case, never by the retry loop's hardcoded ~9.6s.
+	rpcCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
 	rc := rpcterminal.NewUnix(socket, logger, rpcterminal.WithDialTimeout(stopRPCDialTimeout))
 	defer func() { _ = rc.Close() }()
 
-	return rc.Stop(ctx, &api.StopArgs{Reason: "sb stop"})
+	return rc.Stop(rpcCtx, &api.StopArgs{Reason: "sb stop"})
 }
 
 // sendSignal delivers sig to pid, but only after confirming pid still maps

--- a/cmd/sb/stop/terminals_test.go
+++ b/cmd/sb/stop/terminals_test.go
@@ -22,9 +22,11 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/eminwux/sbsh/cmd/config"
 	"github.com/eminwux/sbsh/internal/defaults"
@@ -208,5 +210,47 @@ func Test_ResolveTargets_SingleName_PersistsExited(t *testing.T) {
 	}
 	if got := readStopTestTerminalState(t, runPath, "id-dead"); got != api.Exited {
 		t.Fatalf("persisted: expected Exited after reconcile, got %v", got)
+	}
+}
+
+func Test_StopViaRPC_StaleSocket_RespectsTimeout(t *testing.T) {
+	tmpDir := t.TempDir()
+	sockPath := filepath.Join(tmpDir, "controller.sock")
+
+	// Fake a stale controller socket: bind a Unix listener, prevent the
+	// default unlink-on-close so the socket file survives, then close the
+	// listener. Subsequent dial() returns ECONNREFUSED quickly; without a
+	// bounded ctx the retry loop burns ~600ms of inter-attempt delays
+	// (and up to ~9.6s if dial itself stalls — see #251).
+	addr := &net.UnixAddr{Name: sockPath, Net: "unix"}
+	l, err := net.ListenUnix("unix", addr)
+	if err != nil {
+		t.Fatalf("ListenUnix: %v", err)
+	}
+	l.SetUnlinkOnClose(false)
+	if closeErr := l.Close(); closeErr != nil {
+		t.Fatalf("Close listener: %v", closeErr)
+	}
+	if _, statErr := os.Stat(sockPath); statErr != nil {
+		t.Fatalf("expected stale socket file at %s, stat: %v", sockPath, statErr)
+	}
+
+	doc := &api.TerminalDoc{
+		Spec:   api.TerminalSpec{Name: "stale"},
+		Status: api.TerminalStatus{SocketFile: sockPath},
+	}
+
+	timeout := 100 * time.Millisecond
+	start := time.Now()
+	rpcErr := stopViaRPC(context.Background(), slog.Default(), doc, timeout)
+	elapsed := time.Since(start)
+
+	if rpcErr == nil {
+		t.Fatal("stopViaRPC against a stale socket: expected error, got nil")
+	}
+	// Generous slack for CI variance but well below the retry-delay budget
+	// (~600ms) and orders of magnitude below the pre-fix 9.6s ceiling.
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("stopViaRPC took %v with timeout=%v; expected <500ms (pre-fix: 0.6s-9.6s)", elapsed, timeout)
 	}
 }


### PR DESCRIPTION
## Summary

- Closes #251. `stopViaRPC` (`cmd/sb/stop/terminals.go`) now wraps its parent ctx with `context.WithTimeout(ctx, opts.timeout)` so the JSON-RPC retry loop in `pkg/rpcclient/terminal/rpc_session.go` (3 attempts × 3s dial + 0/200/400ms inter-attempt waits, ~9.6s worst case) is bounded by the user's `--timeout` rather than the retry budget. Stale-socket and wedged-controller stops now fall through to SIGTERM inside the user's timeout window instead of after ~10s of wasted retries.
- Picked option (1) from the issue ("lower-risk: per-call ctx with deadline = opts.timeout") because it's local to `stopViaRPC` and leaves the shared `callWithCodec` retry loop untouched — preserving the existing retry behaviour for `io.go` / `write` / `read` callers per the issue's second AC. Options (2) and (3) (per-client `WithMaxAttempts(1)` or a pre-RPC `os.Stat`/`syscall.Connect` probe) are larger surfaces; (1) wins on blast radius.

## Notes for the reviewer

- The timeout bounds the RPC budget (dial retries + the in-flight `rpc.Call`), not the post-signal `waitForExit`. The post-signal wait keeps its own `opts.timeout` budget — same as today — so the worst-case `sb stop --timeout T` wall-clock is now ~2T (RPC budget + waitForExit) instead of `min(9.6s, ∞) + T`. The issue's AC ("`sb stop --timeout 1s` returns within ~2s") matches this 2T shape.
- I considered a smaller dedicated dial budget (the AC's parenthetical alternative). I went with `opts.timeout` directly because (a) it matches the user's mental model that `--timeout` bounds the whole stop, (b) the issue's "returns within ~2s" target lines up with `opts.timeout` not a smaller constant, and (c) introducing a second tunable adds a flag dev would have to plumb just to scope this one call site. Happy to switch to a dedicated `stopRPCTimeout = min(opts.timeout, X)` if the reviewer prefers a hard ceiling.
- `stopRPCDialTimeout = 3 * time.Second` is left in place. With the new ctx deadline, `net.Dialer.DialContext` uses `min(dialer.Timeout, ctx-deadline)`, so the 3s cap only fires when `opts.timeout > 3s`; for shorter timeouts the ctx wins. Removing it would change behaviour for the long-`--timeout` case (each dial could then take the full remaining ctx budget), which is out of scope for this fix.
- The new test (`Test_StopViaRPC_StaleSocket_RespectsTimeout`) fakes a stale socket the way the AC describes: bind a `net.UnixListener` with `SetUnlinkOnClose(false)`, close it, leave the file. The dial then returns `ECONNREFUSED` quickly; without the ctx bound the retry loop's inter-attempt waits (~600ms) dominate, so the 500ms assertion catches the pre-fix wall-clock. A pre-fix run hits `~600ms` minimum and fails the assertion; a post-fix run completes in `~100ms` (the test's timeout). A wedged-listener variant (listener accepts but never responds) would more directly exercise the in-flight-call timeout path, but the AC asks for the stale-socket scenario specifically; one test is enough.

## Test plan

- [x] `make sbsh-sb` — canonical build succeeds.
- [x] `file ./sbsh` — confirms ELF 64-bit LSB executable (and `./sb` hardlink).
- [x] `go build ./...`, `go vet ./...` — clean.
- [x] `go test ./cmd/sb/stop/...` — passes (new test + existing).
- [x] `go test -count=10 -run 'StopViaRPC' ./cmd/sb/stop/...` — non-flaky over 10 runs.
- [x] `make test` — full Makefile test target passes (`./cmd/sb...`, `./cmd/sbsh...`, `./internal/terminal...`, `./internal/client...`, integration `./cmd/sb/get/...`, `./e2e`).
- [x] `pre-commit run --files cmd/sb/stop/terminals.go cmd/sb/stop/terminals_test.go` — all hooks pass.
- [ ] `make test-race` — not run; the make `test` target above does not include `-race`, and a full `-race` sweep across `./pkg/...` is broader than the diff. Reviewer can run separately if desired.

Closes #251