### PR TITLE
fix(sb stop): --force reaps child shell pgroup before SIGKILL'ing controller

### DIFF
--- a/cmd/sb/stop/terminals.go
+++ b/cmd/sb/stop/terminals.go
@@ -70,6 +70,10 @@ is unreachable, falls back to SIGTERM on the recorded PID. After signalling,
 waits up to --timeout for the process to exit. With --force, sends SIGKILL
 immediately. With --kill-after, escalates to SIGKILL when the timeout elapses.
 
+Both --force and the --kill-after escalation reap the child shell's entire
+process group (SIGKILL on the recorded child pgid) before SIGKILL'ing the
+controller, so a shell that traps or ignores SIGHUP is taken down too.
+
 Metadata is left in place so 'sb prune terminals' can clean it up.`,
 		SilenceUsage:      true,
 		Args:              cobra.MaximumNArgs(1),
@@ -101,7 +105,7 @@ func setupStopTerminalsCmd(c *cobra.Command) {
 	c.Flags().Bool("all", false, "Stop every active terminal")
 	_ = viper.BindPFlag(config.SB_STOP_ALL.ViperKey, c.Flags().Lookup("all"))
 
-	c.Flags().Bool("force", false, "Send SIGKILL immediately instead of a graceful stop")
+	c.Flags().Bool("force", false, "Send SIGKILL immediately (reaps the entire child pgroup, not just the controller)")
 	_ = viper.BindPFlag(config.SB_STOP_FORCE.ViperKey, c.Flags().Lookup("force"))
 
 	c.Flags().Duration("timeout", defaultStopTimeout, "How long to wait for the terminal to exit")
@@ -260,6 +264,14 @@ func stopOneTerminal(
 	}
 
 	if opts.force {
+		// Reap the child pgroup first: SIGKILL the controller alone
+		// leaves any pgroup member that traps SIGHUP (or ignores it via
+		// nohup) reparented to init. Pre-#252 metadata has no ChildPgid
+		// recorded; sendPgroupSignal treats zero as a no-op.
+		if err := sendPgroupKill(doc.Status.ChildPgid); err != nil {
+			fmt.Fprintf(stderr, "failed to SIGKILL terminal %q child pgroup: %v\n", name, err)
+			return resultFailed
+		}
 		if err := sendSignal(doc.Status.Pid, doc.Status.PidStart, syscall.SIGKILL); err != nil {
 			fmt.Fprintf(stderr, "failed to SIGKILL terminal %q: %v\n", name, err)
 			return resultFailed
@@ -295,6 +307,12 @@ func stopOneTerminal(
 	}
 
 	fmt.Fprintf(stdout, "terminal %q did not exit within %s; escalating to SIGKILL\n", name, opts.timeout)
+	// Mirror the --force branch: reap the child pgroup before SIGKILL'ing
+	// the controller so SIGHUP-trapping members don't survive.
+	if err := sendPgroupKill(doc.Status.ChildPgid); err != nil {
+		fmt.Fprintf(stderr, "failed to SIGKILL terminal %q child pgroup: %v\n", name, err)
+		return resultFailed
+	}
 	if err := sendSignal(doc.Status.Pid, doc.Status.PidStart, syscall.SIGKILL); err != nil {
 		fmt.Fprintf(stderr, "failed to SIGKILL terminal %q: %v\n", name, err)
 		return resultFailed
@@ -331,6 +349,25 @@ func stopViaRPC(
 	defer func() { _ = rc.Close() }()
 
 	return rc.Stop(rpcCtx, &api.StopArgs{Reason: "sb stop"})
+}
+
+// sendPgroupKill SIGKILLs the process group led by pgid via
+// syscall.Kill(-pgid, SIGKILL). It is intentionally permissive about ESRCH
+// (pgroup already drained) and about pgid <= 0: a zero pgid means the
+// terminal metadata predates ChildPgid (#252), and Kill(0, SIGKILL) would
+// signal the caller's own pgroup — a destructive surprise we refuse.
+// There is no PidStart-style recycle protection on the pgid here: the
+// caller has already verified the controller is alive (processIsOurs on
+// doc.Status.Pid) and the runner exits when the child does, so a stale
+// ChildPgid implies a dead controller, which the caller filters out.
+func sendPgroupKill(pgid int) error {
+	if pgid <= 0 {
+		return nil
+	}
+	if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return fmt.Errorf("%w: %w", errdefs.ErrSignalProcess, err)
+	}
+	return nil
 }
 
 // sendSignal delivers sig to pid, but only after confirming pid still maps

--- a/cmd/sb/stop/terminals_test.go
+++ b/cmd/sb/stop/terminals_test.go
@@ -17,6 +17,7 @@
 package stop
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -24,13 +25,16 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/eminwux/sbsh/cmd/config"
 	"github.com/eminwux/sbsh/internal/defaults"
 	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/internal/pidutil"
 	"github.com/eminwux/sbsh/pkg/api"
 	"github.com/spf13/viper"
 )
@@ -252,5 +256,139 @@ func Test_StopViaRPC_StaleSocket_RespectsTimeout(t *testing.T) {
 	// (~600ms) and orders of magnitude below the pre-fix 9.6s ceiling.
 	if elapsed > 500*time.Millisecond {
 		t.Fatalf("stopViaRPC took %v with timeout=%v; expected <500ms (pre-fix: 0.6s-9.6s)", elapsed, timeout)
+	}
+}
+
+// startBackgroundProc spawns cmd, fires a one-shot goroutine that Wait()s
+// on it so the test process reaps the zombie, and registers a Cleanup that
+// SIGKILLs the whole pgroup as a safety net. The returned channel closes
+// once Wait() returns, letting the test assert "process is gone" without
+// racing zombie state.
+func startBackgroundProc(t *testing.T, cmd *exec.Cmd) <-chan struct{} {
+	t.Helper()
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start %v: %v", cmd.Args, err)
+	}
+	done := make(chan struct{})
+	go func() {
+		_, _ = cmd.Process.Wait()
+		close(done)
+	}()
+	t.Cleanup(func() {
+		// Best-effort pgroup kill in case the test fails before our
+		// signal lands. ESRCH (group already drained) is fine.
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		_ = cmd.Process.Kill()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+		}
+	})
+	return done
+}
+
+// Test_StopOneTerminal_Force_ReapsChildPgroupOnSIGHUPTrap covers #252:
+// `sb stop --force` must SIGKILL the recorded child pgroup before SIGKILL'ing
+// the controller, otherwise a shell that traps or ignores SIGHUP (the
+// PTY-master-close fallback) survives reparented to init.
+//
+// We approximate the runner's two-process layout without spinning up a real
+// controller/PTY: a long-sleeping "controller" stand-in, plus a SIGHUP-and-
+// SIGTERM-trapping child shell in its own session (Setsid → pgid == pid).
+// Pre-fix, --force only SIGKILLs the controller and the child shell stays
+// alive past sigkillGrace; post-fix the pgroup-kill takes it down.
+func Test_StopOneTerminal_Force_ReapsChildPgroupOnSIGHUPTrap(t *testing.T) {
+	// Child shell: trap HUP and TERM so only SIGKILL takes it (and the
+	// backgrounded sleep) down. Setsid puts it in its own pgroup, mirroring
+	// the runner's prepareTerminalCommand.
+	child := exec.Command("/bin/sh", "-c", `trap '' HUP TERM; sleep 60 & wait`)
+	child.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	childDone := startBackgroundProc(t, child)
+
+	// Controller stand-in: a plain sleep we can SIGKILL by PID.
+	parent := exec.Command("/bin/sh", "-c", `sleep 60`)
+	parentDone := startBackgroundProc(t, parent)
+
+	// Give the child shell time to install the trap before we signal —
+	// without this, SIGKILL on the pgroup can win the race before `trap`
+	// runs, which trivially passes the test for the wrong reason.
+
+	time.Sleep(100 * time.Millisecond)
+
+	parentPidStart, err := pidutil.StartTime(parent.Process.Pid)
+	if err != nil {
+		t.Fatalf("StartTime(parent=%d): %v", parent.Process.Pid, err)
+	}
+
+	doc := &api.TerminalDoc{
+		Spec: api.TerminalSpec{Name: "trap-hup"},
+		Status: api.TerminalStatus{
+			State:     api.Ready,
+			Pid:       parent.Process.Pid,
+			PidStart:  parentPidStart,
+			ChildPgid: child.Process.Pid, // Setsid → pgid == child.Pid
+		},
+	}
+	opts := stopOpts{force: true, timeout: defaultStopTimeout}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	var stdout, stderr bytes.Buffer
+
+	start := time.Now()
+	res := stopOneTerminal(context.Background(), logger, &stdout, &stderr, doc, opts)
+	elapsed := time.Since(start)
+
+	if res != resultStopped {
+		t.Fatalf("expected resultStopped, got %v\nstdout=%q\nstderr=%q", res, stdout.String(), stderr.String())
+	}
+	if elapsed > sigkillGrace {
+		t.Fatalf("stopOneTerminal --force took %v; expected <= sigkillGrace (%v)", elapsed, sigkillGrace)
+	}
+
+	// Controller is reaped by SIGKILL on doc.Status.Pid.
+	select {
+	case <-parentDone:
+	case <-time.After(sigkillGrace):
+		t.Fatalf("controller stand-in still alive after sigkillGrace=%v", sigkillGrace)
+	}
+	// Load-bearing assertion for #252: the trap-HUP child must be reaped
+	// by the pgroup-kill, not survive past sigkillGrace.
+	select {
+	case <-childDone:
+	case <-time.After(sigkillGrace):
+		t.Fatalf("child shell pgroup still alive after sigkillGrace=%v; --force only reaped controller", sigkillGrace)
+	}
+}
+
+// Test_SendPgroupSignal_ZeroPgidIsNoOp guards the critical invariant that
+// Kill(0, sig) — which on POSIX means "signal every process in the caller's
+// own pgroup" — must never be issued. Older terminals on disk have no
+// ChildPgid recorded; the field defaults to zero.
+func Test_SendPgroupSignal_ZeroPgidIsNoOp(t *testing.T) {
+	if err := sendPgroupKill(0); err != nil {
+		t.Fatalf("sendPgroupKill(0) = %v; want nil (no-op)", err)
+	}
+	if err := sendPgroupKill(-1); err != nil {
+		t.Fatalf("sendPgroupKill(-1) = %v; want nil (no-op)", err)
+	}
+}
+
+// Test_SendPgroupSignal_GoneGroupIsNoOp covers the ESRCH path: a pgid whose
+// members have already drained must not surface as an error to the caller.
+func Test_SendPgroupSignal_GoneGroupIsNoOp(t *testing.T) {
+	probe := exec.Command("/bin/sh", "-c", `exit 0`)
+	probe.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := probe.Start(); err != nil {
+		t.Fatalf("start probe: %v", err)
+	}
+	pgid := probe.Process.Pid
+	if _, err := probe.Process.Wait(); err != nil {
+		t.Fatalf("wait probe: %v", err)
+	}
+	// Brief settle so the pgroup is fully drained — exit(0) on the
+	// leader can race ahead of pgroup teardown on slow CI.
+
+	time.Sleep(50 * time.Millisecond)
+	if err := sendPgroupKill(pgid); err != nil {
+		t.Fatalf("sendPgroupKill(drained pgid=%d) = %v; want nil (ESRCH suppressed)", pgid, err)
 	}
 }

--- a/internal/terminal/terminalrunner/terminal.go
+++ b/internal/terminal/terminalrunner/terminal.go
@@ -166,9 +166,14 @@ func (sr *Exec) startPty() error {
 		return fmt.Errorf("error setting initial pty size: %w", errS)
 	}
 
-	// Set tty device in status metadata
+	// Set tty device in status metadata. Capture ChildPgid here too:
+	// cmd.Process.Pid is the child shell's PID, and because we set
+	// Setsid: true in prepareTerminalCommand, the child is its own
+	// session leader, so pgid == pid. Consumers (e.g. `sb stop --force`)
+	// signal -ChildPgid to reap the whole child pgroup.
 	sr.metadataMu.Lock()
 	sr.metadata.Status.Tty = sr.pts.Name()
+	sr.metadata.Status.ChildPgid = sr.cmd.Process.Pid
 	sr.metadataMu.Unlock()
 
 	if sr.initMode && sr.reaper != nil {

--- a/pkg/api/terminal.go
+++ b/pkg/api/terminal.go
@@ -112,7 +112,17 @@ type TerminalStatus struct {
 	// write time so callers that later signal Pid can reject a recycled
 	// PID. Zero means "no token recorded" and consumers should treat the
 	// PID as unverifiable. See internal/pidutil.
-	PidStart        uint64             `json:"pidStart,omitempty"`
+	PidStart uint64 `json:"pidStart,omitempty"`
+	// ChildPgid is the child shell's process-group id, captured at PTY
+	// start. The child is spawned with Setsid: true, so the pgid equals
+	// the child's PID and lives in a different session from the
+	// controller. `sb stop --force` (and the --kill-after escalation)
+	// signal -ChildPgid before SIGKILL'ing the controller so the entire
+	// child pgroup is reaped even when the shell traps SIGHUP. Zero
+	// means "metadata predates this field" — callers must skip the
+	// pgroup-kill rather than risk Kill(0, sig) hitting the caller's
+	// own process group.
+	ChildPgid       int                `json:"childPgid,omitempty"`
 	Tty             string             `json:"tty"`
 	State           TerminalStatusMode `json:"state"`
 	SocketFile      string             `json:"socketCtrl"`


### PR DESCRIPTION
## Summary

- Closes #252. `sb stop --force` (and the `--kill-after` SIGKILL escalation) now `syscall.Kill(-ChildPgid, SIGKILL)` the recorded child pgroup **before** SIGKILL'ing the controller, so a shell that traps SIGHUP (or ignores it via `nohup`) is taken down with the controller rather than reparented to init. Before this fix, only the controller PID was signaled — SIGKILL is uncatchable so its deferred `shutdownChild` never ran, and the child shell's separate session meant the SIGKILL didn't propagate.
- Adds `ChildPgid int` to `api.TerminalStatus` (omitempty for back-compat with on-disk metadata written by older controllers). The runner captures `cmd.Process.Pid` after PTY start — with `Setsid: true`, `pgid == pid`.
- New helper `sendPgroupKill(pgid int)` in `cmd/sb/stop/terminals.go`: refuses `pgid <= 0` (since `Kill(0, SIGKILL)` would signal the caller's own pgroup — a destructive surprise for terminals whose metadata predates this field), and suppresses ESRCH (already-drained pgroup) so a child that died between metadata-write and stop doesn't surface as an error.

## Notes for the reviewer

- **No PidStart-style recycle protection on `ChildPgid`.** The caller has already filtered with `processIsOurs(doc.Status.Pid, doc.Status.PidStart)` on the controller; per `watchChildExit`, the controller exits when the child does, so a live controller implies the child PID we recorded is still our child. Adding a per-pgid start-time token would have been new scope the issue didn't ask for. Happy to add one if the reviewer disagrees.
- **Back-compat with older metadata.** Terminals started by a controller built before this change have `ChildPgid == 0` on disk. `sendPgroupKill(0)` is a deliberate no-op (skipping the pgroup-kill silently rather than risking `Kill(0, ...)`). Those terminals lose the new protection until restarted — surfacing this only in `--help` and the field comment felt cleaner than synthesizing a fallback that could be wrong.
- **Ordering.** Pgroup-kill fires first, controller-kill second. The issue specifies this order; the rationale is to hit the pgroup while still well-formed (controller alive, PTY chain intact) and avoid any state where the controller is dead but the child group is in transition.
- **Help text.** Updated the `Long` description and the `--force` short help to mention pgroup reaping so operators reading `sb stop --help` see the new behavior.
- **Regression-check.** I temporarily commented out the `sendPgroupKill` call and re-ran `Test_StopOneTerminal_Force_ReapsChildPgroupOnSIGHUPTrap`; it failed with \`child shell pgroup still alive after sigkillGrace=2s; --force only reaped controller\` (the load-bearing assertion) — confirming the test catches the bug it's meant to catch. Then I restored the fix and re-ran clean.

## Test plan

- [x] \`make sbsh-sb\` — canonical build succeeds; \`file ./sbsh\` confirms ELF 64-bit LSB executable and \`./sb\` hardlink.
- [x] \`go build ./...\`, \`go vet ./...\` — clean.
- [x] \`go test -run 'Test_StopOneTerminal_Force|Test_SendPgroupSignal' -count=10 ./cmd/sb/stop/...\` — new tests non-flaky over 10 runs.
- [x] \`make test\` — full Makefile test target passes (\`./cmd/sb...\`, \`./cmd/sbsh...\`, \`./internal/terminal...\`, \`./internal/client...\`, integration \`./cmd/sb/get/...\`, \`./e2e\`).
- [x] \`pre-commit run --files cmd/sb/stop/terminals.go cmd/sb/stop/terminals_test.go internal/terminal/terminalrunner/terminal.go pkg/api/terminal.go\` — all hooks pass.
- [x] Mutation check: temporarily disabled the new \`sendPgroupKill\` call in the \`--force\` branch and confirmed the new test fails with the load-bearing assertion (\`child shell pgroup still alive after sigkillGrace=2s; --force only reaped controller\`); restored the fix and re-verified.
- [ ] \`make test-race\` — not run; the Makefile \`test\` target above doesn't include \`-race\`, and a tree-wide \`-race\` sweep is broader than this diff. Reviewer can run separately if desired.

Closes #252