### PR TITLE
fix(discovery): scanMetadataFiles logs and skips per-file failures instead of aborting

### DIFF
--- a/pkg/discovery/clients_test.go
+++ b/pkg/discovery/clients_test.go
@@ -95,9 +95,39 @@ func TestScanClients_InvalidJSON(t *testing.T) {
 	runPath := t.TempDir()
 	writeInvalidClientJSON(t, runPath, "bad")
 
-	_, err := discovery.ScanClients(ctx, logger, runPath)
-	if err == nil {
-		t.Fatal("expected decode error, got nil")
+	got, err := discovery.ScanClients(ctx, logger, runPath)
+	if err != nil {
+		t.Fatalf("expected no error on invalid JSON (per-file failures are skipped), got: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 clients (only the corrupt one was present), got %d", len(got))
+	}
+}
+
+// TestScanClients_InvalidJSON_SiblingsStillLoad verifies the core contract
+// from #258: one corrupt metadata.json must not mask every other live
+// client from discovery.
+func TestScanClients_InvalidJSON_SiblingsStillLoad(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	runPath := t.TempDir()
+
+	writeClientDoc(t, runPath, "c-good-1", "alpha")
+	writeInvalidClientJSON(t, runPath, "c-bad")
+	writeClientDoc(t, runPath, "c-good-2", "beta")
+
+	got, err := discovery.ScanClients(ctx, logger, runPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantIDs := []string{"c-good-1", "c-good-2"}
+	if len(got) != len(wantIDs) {
+		t.Fatalf("want %d clients, got %d (%+v)", len(wantIDs), len(got), got)
+	}
+	for i, w := range wantIDs {
+		if string(got[i].Spec.ID) != w {
+			t.Fatalf("mismatch at %d: want %q, got %q", i, w, got[i].Spec.ID)
+		}
 	}
 }
 

--- a/pkg/discovery/scan.go
+++ b/pkg/discovery/scan.go
@@ -36,6 +36,11 @@ import (
 
 // scanMetadataFiles reads all metadata.json files matching the pattern and unmarshals them.
 // It returns a slice of unmarshaled metadata structs of type T.
+//
+// Per-file read or decode failures are logged at Warn and skipped — one
+// corrupt or unreadable metadata.json must not mask every other live
+// terminal/client from discovery. An error is returned only for
+// unrecoverable conditions (glob itself failing, ctx cancellation).
 func scanMetadataFiles[T any](
 	ctx context.Context,
 	logger *slog.Logger,
@@ -54,6 +59,7 @@ func scanMetadataFiles[T any](
 	}
 
 	out := make([]T, 0, len(paths))
+	skipped := 0
 	for _, p := range paths {
 		select {
 		case <-ctx.Done():
@@ -63,20 +69,25 @@ func scanMetadataFiles[T any](
 		}
 		b, errRead := os.ReadFile(p)
 		if errRead != nil {
-			logger.ErrorContext(ctx, fmt.Sprintf("%s: failed to read file", logPrefix), "file", p, "error", errRead)
-			return nil, fmt.Errorf("read %s: %w", p, errRead)
+			logger.WarnContext(
+				ctx,
+				fmt.Sprintf("%s: failed to read file, skipping", logPrefix),
+				"file", p,
+				"error", errRead,
+			)
+			skipped++
+			continue
 		}
 		var s T
 		if errUnmarshal := json.Unmarshal(b, &s); errUnmarshal != nil {
-			logger.ErrorContext(
+			logger.WarnContext(
 				ctx,
-				fmt.Sprintf("%s: failed to decode file", logPrefix),
-				"file",
-				p,
-				"error",
-				errUnmarshal,
+				fmt.Sprintf("%s: failed to decode file, skipping", logPrefix),
+				"file", p,
+				"error", errUnmarshal,
 			)
-			return nil, fmt.Errorf("decode %s: %w", p, errUnmarshal)
+			skipped++
+			continue
 		}
 		logger.DebugContext(
 			ctx,
@@ -89,7 +100,12 @@ func scanMetadataFiles[T any](
 		out = append(out, s)
 	}
 
-	logger.InfoContext(ctx, fmt.Sprintf("%s: finished scanning", logPrefix), "count", len(out))
+	logger.InfoContext(
+		ctx,
+		fmt.Sprintf("%s: finished scanning", logPrefix),
+		"count", len(out),
+		"skipped", skipped,
+	)
 	return out, nil
 }
 

--- a/pkg/discovery/terminals_test.go
+++ b/pkg/discovery/terminals_test.go
@@ -101,12 +101,59 @@ func TestScanTerminals_InvalidJSON(t *testing.T) {
 	runPath := t.TempDir()
 	writeInvalidTerminalJSON(t, runPath, "bad-id")
 
-	_, err := discovery.ScanTerminals(ctx, logger, runPath)
-	if err == nil {
-		t.Fatal("expected error on invalid JSON, got nil")
+	got, err := discovery.ScanTerminals(ctx, logger, runPath)
+	if err != nil {
+		t.Fatalf("expected no error on invalid JSON (per-file failures are skipped), got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "decode") {
-		t.Fatalf("expected decode error, got: %v", err)
+	if len(got) != 0 {
+		t.Fatalf("expected 0 terminals (only the corrupt one was present), got %d", len(got))
+	}
+}
+
+// TestScanTerminals_InvalidJSON_SiblingsStillLoad verifies the core contract
+// from #258: one corrupt metadata.json must not mask every other live
+// terminal from discovery.
+func TestScanTerminals_InvalidJSON_SiblingsStillLoad(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	runPath := t.TempDir()
+
+	writeTerminalDoc(t, runPath, "id-good-1", "alpha")
+	writeInvalidTerminalJSON(t, runPath, "id-bad")
+	writeTerminalDoc(t, runPath, "id-good-2", "beta")
+
+	got, err := discovery.ScanTerminals(ctx, logger, runPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantIDs := []string{"id-good-1", "id-good-2"}
+	if len(got) != len(wantIDs) {
+		t.Fatalf("want %d terminals, got %d (%+v)", len(wantIDs), len(got), got)
+	}
+	for i, w := range wantIDs {
+		if string(got[i].Spec.ID) != w {
+			t.Fatalf("mismatch at %d: want %q, got %q", i, w, got[i].Spec.ID)
+		}
+	}
+}
+
+// TestFindTerminalByID_SkipsCorruptSibling verifies that `sb attach <id>`
+// (which routes through FindTerminalByID) succeeds when an unrelated
+// terminal's metadata.json is corrupt — AC bullet 3 of #258.
+func TestFindTerminalByID_SkipsCorruptSibling(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	runPath := t.TempDir()
+
+	writeTerminalDoc(t, runPath, "id-good", "good")
+	writeInvalidTerminalJSON(t, runPath, "id-bad")
+
+	got, err := discovery.FindTerminalByID(ctx, logger, runPath, "id-good")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || string(got.Spec.ID) != "id-good" {
+		t.Fatalf("want id-good, got %+v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- One corrupt or unreadable `metadata.json` no longer aborts the whole discovery scan and masks every other live terminal/client from `sb ls`, `sb attach`, `sb stop`, `sb prune`.
- Per-file read or decode failures are logged at `Warn` (with file + error) and skipped; the scan continues. The unrecoverable `glob` failure and `ctx.Err()` paths still return an error.
- Docstring on `scanMetadataFiles` codifies the new warnings-not-errors contract.

## Implementation choice

The issue body offered two equivalent shapes:

1. Return `([]T, []DiscoveryWarning, nil)` mirroring `LoadProfilesFromDir`.
2. Keep the `([]T, error)` shape, route per-file failures to a `logger.Warn`, reserve `error` for the unrecoverable glob-itself failure.

I went with **shape 2**: it satisfies the AC's core goal verbatim ("one corrupt directory must not mask every other live terminal") with a far smaller blast radius — the existing `([]api.TerminalDoc, error)` / `([]api.ClientDoc, error)` signatures are preserved across every caller (`internal/discovery`, `cmd/sb/get`, `cmd/sb/stop`, `cmd/config/autocomplete.go`, `pkg/discovery` `Find*` helpers) without forcing a multi-package signature change. Both `_InvalidJSON` tests now assert the no-error/skip contract per AC bullet 4. Reviewer can push back if the structured-warning shape was actually preferred — that would be a straightforward follow-up.

## Test plan

- [x] `make sbsh-sb` + `file ./sbsh` (ELF binary verified)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -timeout=5m \$(go list ./... | grep -v '/e2e\$')` — all green
- [x] `go test -tags=integration ./cmd/sb/get/...` — green
- [x] `make e2e` — green
- [x] `docs/examples/library-consumer` build + vet — green
- [x] `pre-commit run --files pkg/discovery/scan.go pkg/discovery/clients_test.go pkg/discovery/terminals_test.go` — all hooks pass
- [x] New test `TestScanTerminals_InvalidJSON_SiblingsStillLoad` — sibling good docs load when a third is corrupt (AC bullet 2)
- [x] New test `TestFindTerminalByID_SkipsCorruptSibling` — `sb attach <other-id>` path returns the live doc even when an unrelated metadata is corrupt (AC bullet 3)
- [x] New test `TestScanClients_InvalidJSON_SiblingsStillLoad` — mirror for clients

## Acceptance criteria

- [x] `scanMetadataFiles` no longer returns early on a single read/decode failure
- [x] `sb ls` shows other terminals when one terminal's `metadata.json` is corrupt (covered by the new sibling tests at the discovery layer; `sb ls` routes through `ScanAndPrintTerminals` → `ScanTerminals` → `scanMetadataFiles`)
- [x] `sb attach <other-id>` succeeds when an unrelated terminal's `metadata.json` is corrupt (covered by `TestFindTerminalByID_SkipsCorruptSibling`)
- [x] `TestScanClients_InvalidJSON` and `TestScanTerminals_InvalidJSON` updated to assert the warnings/skip contract
- [x] Existing happy-path tests still pass

Closes #258