### PR TITLE
fix(terminalrunner): probe socket for live peer before unlinking in OpenSocketCtrl

### DIFF
--- a/internal/terminal/terminalrunner/sockets.go
+++ b/internal/terminal/terminalrunner/sockets.go
@@ -20,10 +20,18 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"time"
 
 	"github.com/eminwux/sbsh/pkg/api"
 	"golang.org/x/sys/unix"
 )
+
+// liveSocketProbeTimeout bounds the DialTimeout used by OpenSocketCtrl to
+// decide whether a peer is already serving the control socket path before
+// unlinking it. A successful dial inside this window means the inode is
+// live and the bind must refuse; any dial failure (ENOENT, ECONNREFUSED,
+// timeout) means no peer is accepting and the path is safe to unlink.
+const liveSocketProbeTimeout = 100 * time.Millisecond
 
 // defaultSocketMode is the legacy owner-only mode applied when the spec
 // leaves SocketMode at its zero value. Group/world access is opt-in via
@@ -131,6 +139,23 @@ func (sr *Exec) OpenSocketCtrl() error {
 	if errMetadata != nil {
 		sr.logger.Error("OpenSocketCtrl: failed to update metadata", "error", errMetadata)
 		return fmt.Errorf("update metadata: %w", errMetadata)
+	}
+
+	// Probe before unlinking: a successful dial means a live peer is
+	// serving this path (operator passed the same --id / --socket-file
+	// twice, two starts raced, an old process is still draining a slow
+	// client). Refusing the bind keeps the victim's socket intact and
+	// surfaces a clear diagnostic instead of silently breaking attach
+	// against the older terminal. A dial failure (ENOENT, ECONNREFUSED,
+	// timeout) means no peer is accepting; the path is safe to unlink.
+	probeDialer := net.Dialer{Timeout: liveSocketProbeTimeout}
+	if conn, errDial := probeDialer.DialContext(sr.ctx, "unix", socketFile); errDial == nil {
+		_ = conn.Close()
+		sr.logger.Error(
+			"OpenSocketCtrl: socket already in use by live peer",
+			"socket", socketFile,
+		)
+		return fmt.Errorf("socket already in use by live peer: %s", socketFile)
 	}
 
 	// Remove sockets if they already exist

--- a/internal/terminal/terminalrunner/sockets_test.go
+++ b/internal/terminal/terminalrunner/sockets_test.go
@@ -1,0 +1,169 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrunner
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// newOpenSocketCtrlExec builds a minimal Exec wired with the fields
+// OpenSocketCtrl touches: ctx, logger, id, and a metadata block whose
+// Spec.RunPath points at a writable temp dir so updateMetadata can
+// persist the terminal doc without a real terminal directory layout.
+// Tests pass socketFile through metadata.Spec.SocketFile.
+func newOpenSocketCtrlExec(t *testing.T, socketFile string) *Exec {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	runPath := t.TempDir()
+	id := api.ID("opensocketctrl-test")
+	if err := os.MkdirAll(filepath.Join(runPath, "terminals", string(id)), 0o700); err != nil {
+		t.Fatalf("mkdir terminal dir: %v", err)
+	}
+	return &Exec{
+		ctx:       ctx,
+		ctxCancel: cancel,
+		logger:    logger,
+		id:        id,
+		metadata: api.TerminalDoc{
+			Spec: api.TerminalSpec{
+				RunPath:    runPath,
+				SocketFile: socketFile,
+			},
+		},
+		clients:       make(map[api.ID]*ioClient),
+		subscribers:   make(map[*subscriberWriter]struct{}),
+		closeReqCh:    make(chan error, 1),
+		closedCh:      make(chan struct{}),
+		childDoneCh:   make(chan struct{}),
+		childDoneOnce: &sync.Once{},
+		ptyPipes:      &ptyPipes{},
+		closePTY:      &sync.Once{},
+	}
+}
+
+// TestOpenSocketCtrl_RefusesBindOnLivePeer is the first AC for #261.
+//
+// Pre-fix, OpenSocketCtrl unconditionally `os.Remove`s the socket path
+// before binding. If a live peer is already listening on that path
+// (operator passed the same --id / --socket-file twice, two starts raced),
+// the live inode is silently unlinked: the victim's listener still accepts
+// on the inode it holds, but new clients hit ENOENT on dial and attach
+// against the older terminal mysteriously breaks.
+//
+// Post-fix, OpenSocketCtrl probes the path with a short DialTimeout. A
+// successful dial means a peer is serving; the bind must refuse with an
+// error and the pre-bound listener must remain serviceable.
+func TestOpenSocketCtrl_RefusesBindOnLivePeer(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "ctrl.sock")
+
+	peer, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("pre-bind peer listener: %v", err)
+	}
+	defer peer.Close()
+
+	acceptedCh := make(chan net.Conn, 1)
+	go func() {
+		c, _ := peer.Accept()
+		if c != nil {
+			acceptedCh <- c
+		}
+	}()
+
+	sr := newOpenSocketCtrlExec(t, sockPath)
+
+	err = sr.OpenSocketCtrl()
+	if err == nil {
+		t.Fatalf("OpenSocketCtrl returned nil; want error refusing bind on live peer")
+	}
+
+	// Pre-bound peer must still serve new clients — the bind refusal means
+	// the original inode survives, so DialTimeout below succeeds and
+	// peer.Accept returns the connection.
+	conn, dialErr := net.DialTimeout("unix", sockPath, time.Second)
+	if dialErr != nil {
+		t.Fatalf("pre-bound peer no longer accepts after OpenSocketCtrl refusal: %v", dialErr)
+	}
+	defer conn.Close()
+
+	select {
+	case accepted := <-acceptedCh:
+		_ = accepted.Close()
+	case <-time.After(time.Second):
+		t.Fatal("pre-bound peer did not accept the probe connection within 1s")
+	}
+}
+
+// TestOpenSocketCtrl_CleansUpStaleSocket is the second AC for #261.
+//
+// A stale socket file (an inode left by a prior process that has since
+// exited — no peer is accepting) must still be cleaned up and the bind
+// must proceed. The probe's DialTimeout returns ECONNREFUSED for a stale
+// socket file, which the implementation treats as "no peer; safe to
+// unlink".
+func TestOpenSocketCtrl_CleansUpStaleSocket(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "ctrl.sock")
+
+	// Create a stale socket file: bind a listener, then close it without
+	// removing the inode (simulates a prior process that didn't clean up).
+	stale, errListen := net.Listen("unix", sockPath)
+	if errListen != nil {
+		t.Fatalf("create stale listener: %v", errListen)
+	}
+	if unixLn, ok := stale.(*net.UnixListener); ok {
+		unixLn.SetUnlinkOnClose(false)
+	}
+	if errClose := stale.Close(); errClose != nil {
+		t.Fatalf("close stale listener: %v", errClose)
+	}
+	if _, errStat := os.Stat(sockPath); errStat != nil {
+		t.Fatalf("stale socket inode missing before OpenSocketCtrl: %v", errStat)
+	}
+
+	sr := newOpenSocketCtrlExec(t, sockPath)
+	t.Cleanup(func() {
+		if sr.lnCtrl != nil {
+			_ = sr.lnCtrl.Close()
+		}
+	})
+
+	if errOpen := sr.OpenSocketCtrl(); errOpen != nil {
+		t.Fatalf("OpenSocketCtrl returned error on stale-socket cleanup path: %v", errOpen)
+	}
+	if sr.lnCtrl == nil {
+		t.Fatal("OpenSocketCtrl succeeded but lnCtrl is nil; expected bound listener")
+	}
+
+	// Listener must actually be serving the path now — dial it.
+	conn, dialErr := net.DialTimeout("unix", sockPath, time.Second)
+	if dialErr != nil {
+		t.Fatalf("new listener does not accept dials after stale cleanup: %v", dialErr)
+	}
+	_ = conn.Close()
+}


### PR DESCRIPTION
## Summary
- `OpenSocketCtrl` now probes the control-socket path with a 100ms `DialContext` before `os.Remove`. A successful dial (live peer accepting on the inode) refuses the bind with `socket already in use by live peer: <path>`; any dial failure (ENOENT, ECONNREFUSED, timeout) means no peer and the existing unlink+listen path runs as before.
- Closes the silent-destroy failure mode flagged by #224's cross-instance-collisions lens: an operator passing the same `--id` / `--socket-file` twice, two starts racing, or an old process still draining a slow client would unlink the live peer's inode and break new client dials with ENOENT.
- Probe uses `(*net.Dialer).DialContext` with `sr.ctx` (satisfies the repo's `noctx` lint; the runner ctx already gates the bind path) and a 100ms `Timeout`. No behavior change on the clean-start path (`os.Remove` still warns on non-ENOENT errors as before).

## Test plan
- [x] `go test ./internal/terminal/terminalrunner/ -run TestOpenSocketCtrl -v` — both new cases pass
- [x] `make test` — full suite green (cmd, internal/terminal, internal/client, integration, e2e)
- [x] `make sbsh-sb` — canonical build produces ELF binary; `file ./sbsh` confirms `ELF 64-bit LSB executable`
- [x] `go vet ./...` clean
- [x] `pre-commit run --files <touched>` — all hooks pass (golangci-lint, go fmt, addlicense)

### New unit tests
- `TestOpenSocketCtrl_RefusesBindOnLivePeer` — pre-binds a real `net.Listen("unix", ...)` peer on a temp socket, calls `OpenSocketCtrl` with the same path, asserts error returned **and** that the pre-bound peer still accepts a fresh dial (proves the live inode was not unlinked).
- `TestOpenSocketCtrl_CleansUpStaleSocket` — creates a stale socket inode via `SetUnlinkOnClose(false)` + `Close`, asserts `OpenSocketCtrl` succeeds, `lnCtrl` is bound, and a dial against the path is now served by the new listener.

Closes #261