### PR TITLE
fix(discovery): convert profile-walk per-entry errors into ProfileWarnings

### DIFF
--- a/pkg/discovery/profiles.go
+++ b/pkg/discovery/profiles.go
@@ -66,14 +66,16 @@ func (w ProfileWarning) String() string {
 //
 // Any problem that is scoped to a single file or document becomes a
 // ProfileWarning rather than aborting the scan:
+//   - cannot read a directory entry during the walk (unreadable subdir,
+//     broken filesystem state under a subtree),
 //   - cannot open a file,
 //   - malformed YAML,
 //   - missing required apiVersion/kind/metadata.name,
 //   - unsupported apiVersion or kind,
 //   - duplicate profile name (keeps the first and skips subsequent).
 //
-// An error is returned only for unrecoverable conditions such as a walk
-// failure on the directory itself.
+// An error is returned only for unrecoverable conditions such as the
+// initial stat on dir failing for a reason other than os.ErrNotExist.
 func LoadProfilesFromDir(
 	ctx context.Context,
 	logger *slog.Logger,
@@ -96,14 +98,14 @@ func LoadProfilesFromDir(
 		return nil, nil, fmt.Errorf("profiles path %q is not a directory", dir)
 	}
 
-	files, err := collectYAMLFiles(dir)
+	files, walkWarnings, err := collectYAMLFiles(dir)
 	if err != nil {
-		return nil, nil, err
+		return nil, walkWarnings, err
 	}
 
 	var (
 		profiles []api.TerminalProfileDoc
-		warnings []ProfileWarning
+		warnings = walkWarnings
 		// seen maps profile name -> file that first loaded that name.
 		seen = make(map[string]string)
 	)
@@ -136,12 +138,27 @@ func LoadProfilesFromDir(
 }
 
 // collectYAMLFiles returns the lexicographically sorted list of *.yaml and
-// *.yml files found under dir (recursively).
-func collectYAMLFiles(dir string) ([]string, error) {
-	var files []string
+// *.yml files found under dir (recursively). Per-entry walk failures
+// (unreadable subdirectory, broken filesystem state under a subtree) become
+// ProfileWarning entries; the walk continues so siblings still load.
+func collectYAMLFiles(dir string) ([]string, []ProfileWarning, error) {
+	var (
+		files    []string
+		warnings []ProfileWarning
+	)
 	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, e error) error {
 		if e != nil {
-			return e
+			warnings = append(warnings, ProfileWarning{
+				File:   path,
+				Reason: fmt.Sprintf("walk: %v", e),
+			})
+			// For an unreadable directory, SkipDir prevents the walker from
+			// re-reporting the same ReadDir failure; for a file or the
+			// initial-stat case (d == nil), nil lets siblings still process.
+			if d != nil && d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 		if d.IsDir() {
 			return nil
@@ -153,10 +170,10 @@ func collectYAMLFiles(dir string) ([]string, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("walk profiles dir %q: %w", dir, err)
+		return nil, warnings, fmt.Errorf("walk profiles dir %q: %w", dir, err)
 	}
 	sort.Strings(files)
-	return files, nil
+	return files, warnings, nil
 }
 
 // loadProfilesFromFile decodes every YAML document in a single file and

--- a/pkg/discovery/profiles_test.go
+++ b/pkg/discovery/profiles_test.go
@@ -289,6 +289,54 @@ spec:
 	}
 }
 
+func TestLoadProfilesFromDir_UnreadableSubdirProducesWarning(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permission bits, cannot exercise per-entry walk failure")
+	}
+	ctx := context.Background()
+	logger := testLogger()
+	dir := t.TempDir()
+
+	writeFile(t, dir, "good.yaml", `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: good
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/sh
+`)
+	bad := filepath.Join(dir, "bad")
+	if err := os.Mkdir(bad, 0o000); err != nil {
+		t.Fatalf("mkdir bad: %v", err)
+	}
+	// Restore perms so t.TempDir's cleanup can recurse into bad/.
+	t.Cleanup(func() {
+		_ = os.Chmod(bad, 0o755)
+	})
+
+	got, warnings, err := discovery.LoadProfilesFromDir(ctx, logger, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].Metadata.Name != "good" {
+		t.Fatalf("expected sibling YAML to still load, got %+v", got)
+	}
+	if len(warnings) == 0 {
+		t.Fatal("expected a warning for the unreadable subdir, got none")
+	}
+	var matched *discovery.ProfileWarning
+	for i := range warnings {
+		if strings.HasSuffix(warnings[i].File, "bad") && strings.Contains(warnings[i].Reason, "walk") {
+			matched = &warnings[i]
+			break
+		}
+	}
+	if matched == nil {
+		t.Fatalf("expected walk warning pointing at the unreadable subdir, got %v", warnings)
+	}
+}
+
 func TestLoadProfilesFromDir_UnsupportedKindProducesWarning(t *testing.T) {
 	ctx := context.Background()
 	logger := testLogger()


### PR DESCRIPTION
## Summary
- `collectYAMLFiles` no longer aborts the walk when a per-entry error surfaces (unreadable subdir, broken filesystem state under a subtree). The callback records a `ProfileWarning` for `path`, returns `filepath.SkipDir` when the entry is a directory (so the walker doesn't re-report the same `ReadDir` failure) and `nil` otherwise (including the initial-stat case where `d == nil`), so siblings still load.
- `collectYAMLFiles`'s signature is now `([]string, []ProfileWarning, error)`. The function is unexported and `LoadProfilesFromDir` is its sole caller; walk warnings are prepended to the per-file warning slice and surface through `PrintProfileWarnings` like every other loader diagnostic.
- `LoadProfilesFromDir`'s docstring lists per-entry walk failures among the warnings-not-errors cases and narrows the "error returned only when …" clause to the initial stat (the only path that still produces a hard error).

## Test plan
- [x] `go test ./pkg/discovery/... -run TestLoadProfilesFromDir -v` — new `TestLoadProfilesFromDir_UnreadableSubdirProducesWarning` passes; pre-existing cases unchanged. Test skips when `os.Geteuid() == 0` because root bypasses dir mode bits.
- [x] `make sbsh-sb` produces an ELF binary (`file ./sbsh` reports `ELF 64-bit LSB executable`).
- [x] `go build ./...`; `go vet ./...`.
- [x] CI's main suite: `go test -timeout=5m $(go list ./... | grep -v '/e2e$')`.
- [x] CI's integration build tag: `go test -tags=integration ./cmd/sb/get/...`.
- [x] `make e2e`.
- [x] `pre-commit run --files pkg/discovery/profiles.go pkg/discovery/profiles_test.go`.

Closes #260