### PR TITLE
fix(terminalrunner): guard close(closedCh) with sync.Once so repeat Close is idempotent

### DIFF
--- a/internal/terminal/terminalrunner/control_server_graceful_test.go
+++ b/internal/terminal/terminalrunner/control_server_graceful_test.go
@@ -57,6 +57,7 @@ func newStartServerTestExec(t *testing.T, logger *slog.Logger) (*Exec, func()) {
 		childDoneOnce: &sync.Once{},
 		ptyPipes:      &ptyPipes{},
 		closePTY:      &sync.Once{},
+		closeClosedCh: &sync.Once{},
 	}
 	cleanup := func() {
 		cancel()

--- a/internal/terminal/terminalrunner/lifecycle.go
+++ b/internal/terminal/terminalrunner/lifecycle.go
@@ -321,7 +321,13 @@ func (sr *Exec) Close(reason error) error {
 		}
 	}
 
-	close(sr.closedCh)
+	// Guard close(closedCh) so a repeat Close on the same runner does not
+	// panic on an already-closed channel. The other once-only steps in this
+	// function (closePTY, closeCapture, childDoneOnce) follow the same
+	// per-resource sync.Once pattern. See #242.
+	sr.closeClosedCh.Do(func() {
+		close(sr.closedCh)
+	})
 	return nil
 }
 

--- a/internal/terminal/terminalrunner/lifecycle_capture_fd_test.go
+++ b/internal/terminal/terminalrunner/lifecycle_capture_fd_test.go
@@ -64,6 +64,7 @@ func newCaptureFDExec(t *testing.T) (*Exec, *os.File) {
 		ptyPipes:      &ptyPipes{},
 		closePTY:      &sync.Once{},
 		closeCapture:  &sync.Once{},
+		closeClosedCh: &sync.Once{},
 		captureFile:   logf,
 	}
 	return sr, logf
@@ -85,9 +86,10 @@ func TestExecClose_CapturesFileFD(t *testing.T) {
 }
 
 // TestExecClose_CaptureFileDoubleCloseIsHarmless is the regression for #229's
-// idempotency AC. closeCapture is a sync.Once, so a second Close on the
-// runner must not double-close the underlying fd (which would error and log
-// a warning), and must not panic.
+// idempotency AC plus the closedCh follow-up in #242. closeCapture and
+// closeClosedCh are sync.Once, so a second Close on the runner must not
+// double-close the underlying fd (which would error and log a warning), must
+// not panic on `close of closed channel`, and must return nil.
 func TestExecClose_CaptureFileDoubleCloseIsHarmless(t *testing.T) {
 	sr, _ := newCaptureFDExec(t)
 
@@ -99,11 +101,6 @@ func TestExecClose_CaptureFileDoubleCloseIsHarmless(t *testing.T) {
 			t.Fatalf("second Close panicked: %v", r)
 		}
 	}()
-	// Reset closedCh so the second Close's `close(sr.closedCh)` does not
-	// panic on a closed channel — that's an orthogonal Close-idempotency
-	// concern, not what this test is asserting. The sync.Once on
-	// closeCapture is what protects the capture fd from a double-close.
-	sr.closedCh = make(chan struct{})
 	if err := sr.Close(nil); err != nil {
 		t.Fatalf("second Close returned error: %v", err)
 	}

--- a/internal/terminal/terminalrunner/lifecycle_close_clients_race_test.go
+++ b/internal/terminal/terminalrunner/lifecycle_close_clients_race_test.go
@@ -67,6 +67,7 @@ func newCloseRaceExec(t *testing.T) *Exec {
 		childDoneOnce: &sync.Once{},
 		ptyPipes:      &ptyPipes{},
 		closePTY:      &sync.Once{},
+		closeClosedCh: &sync.Once{},
 	}
 }
 

--- a/internal/terminal/terminalrunner/sockets_test.go
+++ b/internal/terminal/terminalrunner/sockets_test.go
@@ -64,6 +64,7 @@ func newOpenSocketCtrlExec(t *testing.T, socketFile string) *Exec {
 		childDoneOnce: &sync.Once{},
 		ptyPipes:      &ptyPipes{},
 		closePTY:      &sync.Once{},
+		closeClosedCh: &sync.Once{},
 	}
 }
 

--- a/internal/terminal/terminalrunner/subscribe_close_race_test.go
+++ b/internal/terminal/terminalrunner/subscribe_close_race_test.go
@@ -71,6 +71,7 @@ func newSubscribeRaceExec(t *testing.T) *Exec {
 		childDoneOnce: &sync.Once{},
 		ptyPipes:      &ptyPipes{multiOutW: NewDynamicMultiWriter(logger)},
 		closePTY:      &sync.Once{},
+		closeClosedCh: &sync.Once{},
 	}
 }
 

--- a/internal/terminal/terminalrunner/terminal_runner_exec.go
+++ b/internal/terminal/terminalrunner/terminal_runner_exec.go
@@ -88,6 +88,11 @@ type Exec struct {
 	captureFile  *os.File
 	closeCapture *sync.Once
 
+	// closeClosedCh guards close(closedCh) so a second Close call does not
+	// panic on a channel that is already closed. Matches the per-resource
+	// once pattern used for closePTY/closeCapture. See #242.
+	closeClosedCh *sync.Once
+
 	// initMode is captured at construction time so tests can toggle
 	// initmode.Enable before/after NewTerminalRunnerExec without surprising
 	// the already-running goroutines.
@@ -171,6 +176,7 @@ func NewTerminalRunnerExec(ctx context.Context, logger *slog.Logger, spec *api.T
 		ptyPipes:      &ptyPipes{},
 		closePTY:      &sync.Once{},
 		closeCapture:  &sync.Once{},
+		closeClosedCh: &sync.Once{},
 
 		initMode: inInit,
 		reaper:   rp,


### PR DESCRIPTION
## Summary
- `Exec.Close` called `close(sr.closedCh)` unguarded as its last step, so a real second call panicked with `close of closed channel`. PR #240's regression test acknowledged this and worked around it by resetting `sr.closedCh = make(chan struct{})` between the two `Close` calls; the workaround stayed in place so the capture-fd idempotency assertion remained clean.
- Issue #242 offered a choice: wrap the whole `Close` body in `sync.Once`, **or** guard `close(sr.closedCh)` the same way `closeCapture`/`closePTY` are guarded. This PR takes the second option — adds a per-resource `closeClosedCh *sync.Once` to `Exec` (matching the surrounding pattern of `closePTY`, `closeCapture`, `childDoneOnce`) and wraps `close(sr.closedCh)` in `sr.closeClosedCh.Do(...)`. Lower blast radius than the whole-body wrap, doesn't change `Close`'s return-value semantics across repeated calls, and the other steps inside `Close` are already individually safe to re-invoke (or guarded by their own once / nil-out).
- Test helpers in `lifecycle_capture_fd_test.go`, `subscribe_close_race_test.go`, `lifecycle_close_clients_race_test.go`, `control_server_graceful_test.go`, and `sockets_test.go` initialize `closeClosedCh: &sync.Once{}` so the `Exec{}` literal stays valid alongside the existing once fields (no nil-guard fallback in `Close`, mirroring how `closePTY`/`closeCapture` are dereferenced unconditionally).
- `TestExecClose_CaptureFileDoubleCloseIsHarmless` loses the `sr.closedCh = make(chan struct{})` workaround and its explanatory comment — the second `Close` now exercises the production idempotency path directly. Test name and assertion shape stay the same; the doc-comment is updated to credit both #229 (capture fd) and #242 (closedCh) idempotency.

## Test plan
- [x] `make sbsh-sb` and `file ./sbsh` (`ELF 64-bit LSB executable`)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/terminal/terminalrunner/...`
- [x] `go test -race ./internal/terminal/terminalrunner/...`
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` (full unit-test target — the CI parity run)
- [x] `go test -tags=integration ./cmd/sb/get/...`
- [x] `E2E_BIN_DIR=$(pwd) go test ./e2e`
- [x] `pre-commit run --files <changed>` (go fmt, go-mod-tidy, golangci-lint, addlicense — all passed)

Closes #242