### PR TITLE
test(terminalrunner): assert subscribeErrCount surfaces empty race window

### DIFF
--- a/internal/terminal/terminalrunner/subscribe_close_race_test.go
+++ b/internal/terminal/terminalrunner/subscribe_close_race_test.go
@@ -128,8 +128,8 @@ func TestSubscribe_NoOrphanDrainOnConcurrentClose(t *testing.T) {
 				// Post-Close rejection is the expected outcome for the
 				// late-arriving half; the cliFD was already closed by
 				// Subscribe's error path. Count the rejection so the
-				// test surfaces if every single subscriber was rejected
-				// (would indicate the race window never opened).
+				// post-wg.Wait() assertion can fail if every single
+				// subscriber was rejected (race window never opened).
 				if !errors.Is(err, errTerminalClosing) {
 					t.Errorf("subscribe (idx=%d): unexpected error: %v", idx, err)
 				}
@@ -151,6 +151,13 @@ func TestSubscribe_NoOrphanDrainOnConcurrentClose(t *testing.T) {
 		t.Fatalf("Close returned error: %v", err)
 	}
 	wg.Wait()
+
+	// If every subscriber took the early-rejection path the race window the
+	// test exists to cover never opened — a future change to Subscribe that
+	// fires the ctx-check more aggressively would silently still pass.
+	if subscribeErrCount.Load() == concurrentSubscribers {
+		t.Fatal("race window never opened — every subscriber was early-rejected")
+	}
 
 	// Invariant 1 (eventually): every registered subscriber was detached.
 	// The drain goroutine runs onDetach in its defer, so the registry


### PR DESCRIPTION
## Summary
- Adds the assertion the existing comment at `subscribe_close_race_test.go:130-134` already advertised: if every concurrent subscriber takes the early-rejection path, the race window the test exists to cover never opened. Pre-change `subscribeErrCount` was incremented but never read, so a future change to `Subscribe` that fired the ctx-check more aggressively would silently still pass.
- Picked option 1 from the issue (add the assertion) over option 2 (drop the var). Option 1 is strictly more test coverage and aligns the code with the existing comment's intent; the diff is a 3-line `if` plus a comment refresh at the increment site.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -run 'TestSubscribe_NoOrphanDrainOnConcurrentClose|TestSubscribe_PostCloseRejectsCleanly' -count=5 ./internal/terminal/terminalrunner/`
- [x] `make sbsh-sb` (ELF verified for `sbsh` and `sb`)
- [x] `make test` (full CI test target — all packages green incl. e2e)

Closes #238