### PR TITLE
fix(terminalrunner): close capture fd on startPty error paths after assignment

### DIFF
--- a/internal/terminal/terminalrunner/terminal.go
+++ b/internal/terminal/terminalrunner/terminal.go
@@ -205,10 +205,13 @@ func (sr *Exec) startPty() error {
 		return errPerm
 	}
 	// Hand fd ownership to the runner; Close closes it after PTY teardown
-	// so in-flight multiOutW.Write has settled. See #229.
+	// so in-flight multiOutW.Write has settled. See #229. Error returns
+	// after this assignment must close the fd via closeCapture so the
+	// idempotency contract holds whether Close runs or not (see #241).
 	sr.captureFile = logf
 
 	if errU := sr.updateMetadata(); errU != nil {
+		sr.closeCapture.Do(func() { _ = sr.captureFile.Close() })
 		return fmt.Errorf("update metadata: %w", errU)
 	}
 
@@ -217,6 +220,7 @@ func (sr *Exec) startPty() error {
 	// conn writes to pipeInW
 	pipeInR, pipeInW, err := os.Pipe()
 	if err != nil {
+		sr.closeCapture.Do(func() { _ = sr.captureFile.Close() })
 		sr.logger.Error("error opening IN pipe", "err", err)
 		return fmt.Errorf("error opening IN pipe: %w", err)
 	}


### PR DESCRIPTION
## Summary
- After `sr.captureFile = logf` in `startPty`, the two subsequent error returns (`updateMetadata` failure and `os.Pipe` failure) returned without closing the now-struct-owned capture fd. The caller in those paths never reaches `Exec.Close`, so the fd leaked per failed start.
- Close via `sr.closeCapture.Do(func() { _ = sr.captureFile.Close() })` on each post-assignment error return, matching the idiom already used by `Close` in `lifecycle.go:293-299`. The `sync.Once` keeps the contract idempotent: if the error path closes the fd and `Close` is also called later, the second invocation is a no-op.
- The pre-assignment error path at `terminal.go:203-206` (applyArtifactPerms failure) keeps the inline `_ = logf.Close()` — the fd is not yet struct-owned there, so the local handle is the only reference and a direct close is correct.

No new test added: the existing `TestExecClose_CaptureFileDoubleCloseIsHarmless` already proves the `sync.Once` contract this fix relies on (a second `closeCapture.Do(...)` invocation is harmless after the first). Exercising the literal `startPty` error paths in a unit test would require a real PTY + child process plus a way to inject `os.Pipe()` / `updateMetadata` failures, which is disproportionate for a nit; the contract underlying the fix is already covered.

## Test plan
- [x] `make sbsh-sb` (canonical build produces ELF binary)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (full suite: cmd/sb, cmd/sbsh, internal/terminal, internal/client, integration get, e2e — all green)

Closes #241