### PR TITLE
refactor(cmd/sb/stop): rename Test_SendPgroupSignal_* to Test_SendPgroupKill_*

### DIFF
--- a/cmd/sb/stop/terminals.go
+++ b/cmd/sb/stop/terminals.go
@@ -267,7 +267,7 @@ func stopOneTerminal(
 		// Reap the child pgroup first: SIGKILL the controller alone
 		// leaves any pgroup member that traps SIGHUP (or ignores it via
 		// nohup) reparented to init. Pre-#252 metadata has no ChildPgid
-		// recorded; sendPgroupSignal treats zero as a no-op.
+		// recorded; sendPgroupKill treats zero as a no-op.
 		if err := sendPgroupKill(doc.Status.ChildPgid); err != nil {
 			fmt.Fprintf(stderr, "failed to SIGKILL terminal %q child pgroup: %v\n", name, err)
 			return resultFailed

--- a/cmd/sb/stop/terminals_test.go
+++ b/cmd/sb/stop/terminals_test.go
@@ -359,11 +359,11 @@ func Test_StopOneTerminal_Force_ReapsChildPgroupOnSIGHUPTrap(t *testing.T) {
 	}
 }
 
-// Test_SendPgroupSignal_ZeroPgidIsNoOp guards the critical invariant that
+// Test_SendPgroupKill_ZeroPgidIsNoOp guards the critical invariant that
 // Kill(0, sig) — which on POSIX means "signal every process in the caller's
 // own pgroup" — must never be issued. Older terminals on disk have no
 // ChildPgid recorded; the field defaults to zero.
-func Test_SendPgroupSignal_ZeroPgidIsNoOp(t *testing.T) {
+func Test_SendPgroupKill_ZeroPgidIsNoOp(t *testing.T) {
 	if err := sendPgroupKill(0); err != nil {
 		t.Fatalf("sendPgroupKill(0) = %v; want nil (no-op)", err)
 	}
@@ -372,9 +372,9 @@ func Test_SendPgroupSignal_ZeroPgidIsNoOp(t *testing.T) {
 	}
 }
 
-// Test_SendPgroupSignal_GoneGroupIsNoOp covers the ESRCH path: a pgid whose
+// Test_SendPgroupKill_GoneGroupIsNoOp covers the ESRCH path: a pgid whose
 // members have already drained must not surface as an error to the caller.
-func Test_SendPgroupSignal_GoneGroupIsNoOp(t *testing.T) {
+func Test_SendPgroupKill_GoneGroupIsNoOp(t *testing.T) {
 	probe := exec.Command("/bin/sh", "-c", `exit 0`)
 	probe.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	if err := probe.Start(); err != nil {


### PR DESCRIPTION
## Summary
- The helper is named `sendPgroupKill` (introduced in #256), but three sites in `cmd/sb/stop` still referenced the non-existent `sendPgroupSignal`. A future debugger seeing `Test_SendPgroupSignal_*` in `go test` output and grepping for the symbol would find nothing until they opened the test body.
- Renamed the two test functions (and their leading doc comments) to `Test_SendPgroupKill_ZeroPgidIsNoOp` / `Test_SendPgroupKill_GoneGroupIsNoOp` to match the helper they exercise.
- Updated the inline comment at `cmd/sb/stop/terminals.go:270` to reference `sendPgroupKill` instead of `sendPgroupSignal`.

No behavior change — symbol rename + comment edit only. `git grep -i sendpgroupsignal` returns no matches post-fix.

Note on AC line numbers: the issue body cites `terminals_test.go:323/334`, but the actual sites had drifted to `:366/:377` between issue-filing and pickup. Same symbols, same call sites — only the line offsets moved. Renames applied at the current locations.

## Test plan
- [x] `make sbsh-sb` (canonical build; `file ./sbsh` and `file ./sb` both ELF executables)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./cmd/sb/stop/... -count=1 -run 'Test_SendPgroup' -v` (both renamed tests PASS)
- [x] `make test` (full CI test target: cmd/sb, cmd/sbsh, internal/terminal, internal/client, integration get, e2e — all green)
- [x] `git grep -i sendpgroupsignal` returns no matches

Closes #257