### PR TITLE
refactor(terminalstore): trim TerminalStore to Add-only and drop dead Mgr field

### DIFF
--- a/internal/client/clientrunner/client_runner_exec.go
+++ b/internal/client/clientrunner/client_runner_exec.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"sync"
 
-	"github.com/eminwux/sbsh/internal/client/terminalstore"
 	"github.com/eminwux/sbsh/pkg/api"
 	"github.com/eminwux/sbsh/pkg/rpcclient/terminal"
 	"golang.org/x/term"
@@ -51,7 +50,6 @@ type Exec struct {
 
 	events   chan<- Event
 	terminal *api.AttachedTerminal
-	Mgr      *terminalstore.Exec
 
 	lnCtrl net.Listener
 

--- a/internal/client/controller_test.go
+++ b/internal/client/controller_test.go
@@ -220,28 +220,6 @@ func Test_ErrAttach(t *testing.T) {
 			AddFunc: func(_ *api.AttachedTerminal) error {
 				return nil
 			},
-			GetFunc: func(_ api.ID) (*api.AttachedTerminal, bool) {
-				return &api.AttachedTerminal{
-					Spec: &api.TerminalSpec{
-						ID:   "term-1",
-						Name: "terminal-1",
-					},
-				}, true
-			},
-			ListLiveFunc: func() []api.ID {
-				return []api.ID{}
-			},
-			RemoveFunc: func(_ api.ID) {
-			},
-			CurrentFunc: func() api.ID {
-				return "sess-1"
-			},
-			SetCurrentFunc: func(id api.ID) error {
-				if id == "" {
-					return errors.New("empty id not allowed")
-				}
-				return nil
-			},
 		}
 	}
 
@@ -321,23 +299,6 @@ func Test_ErrContextDone(t *testing.T) {
 	sc.NewTerminalStore = func() terminalstore.TerminalStore {
 		return &terminalstore.Test{
 			AddFunc: func(_ *api.AttachedTerminal) error {
-				return nil
-			},
-			GetFunc: func(_ api.ID) (*api.AttachedTerminal, bool) {
-				return nil, false
-			},
-			ListLiveFunc: func() []api.ID {
-				return []api.ID{}
-			},
-			RemoveFunc: func(_ api.ID) {
-			},
-			CurrentFunc: func() api.ID {
-				return "sess-1"
-			},
-			SetCurrentFunc: func(id api.ID) error {
-				if id == "" {
-					return errors.New("empty id not allowed")
-				}
 				return nil
 			},
 		}
@@ -486,23 +447,6 @@ func Test_ErrRPCServerExited(t *testing.T) {
 			AddFunc: func(_ *api.AttachedTerminal) error {
 				return nil
 			},
-			GetFunc: func(_ api.ID) (*api.AttachedTerminal, bool) {
-				return nil, false
-			},
-			ListLiveFunc: func() []api.ID {
-				return []api.ID{}
-			},
-			RemoveFunc: func(_ api.ID) {
-			},
-			CurrentFunc: func() api.ID {
-				return "sess-1"
-			},
-			SetCurrentFunc: func(id api.ID) error {
-				if id == "" {
-					return errors.New("empty id not allowed")
-				}
-				return nil
-			},
 		}
 	}
 
@@ -581,23 +525,6 @@ func Test_ErrCloseReq(t *testing.T) {
 	sc.NewTerminalStore = func() terminalstore.TerminalStore {
 		return &terminalstore.Test{
 			AddFunc: func(_ *api.AttachedTerminal) error {
-				return nil
-			},
-			GetFunc: func(_ api.ID) (*api.AttachedTerminal, bool) {
-				return nil, false
-			},
-			ListLiveFunc: func() []api.ID {
-				return []api.ID{}
-			},
-			RemoveFunc: func(_ api.ID) {
-			},
-			CurrentFunc: func() api.ID {
-				return "sess-1"
-			},
-			SetCurrentFunc: func(id api.ID) error {
-				if id == "" {
-					return errors.New("empty id not allowed")
-				}
 				return nil
 			},
 		}
@@ -681,23 +608,6 @@ func Test_ErrStartCmd(t *testing.T) {
 			AddFunc: func(_ *api.AttachedTerminal) error {
 				return nil
 			},
-			GetFunc: func(_ api.ID) (*api.AttachedTerminal, bool) {
-				return nil, false
-			},
-			ListLiveFunc: func() []api.ID {
-				return []api.ID{}
-			},
-			RemoveFunc: func(_ api.ID) {
-			},
-			CurrentFunc: func() api.ID {
-				return "sess-1"
-			},
-			SetCurrentFunc: func(id api.ID) error {
-				if id == "" {
-					return errors.New("empty id not allowed")
-				}
-				return nil
-			},
 		}
 	}
 
@@ -773,23 +683,6 @@ func Test_ErrTerminalStore(t *testing.T) {
 		return &terminalstore.Test{
 			AddFunc: func(_ *api.AttachedTerminal) error {
 				return errors.New("force add fail")
-			},
-			GetFunc: func(_ api.ID) (*api.AttachedTerminal, bool) {
-				return nil, false
-			},
-			ListLiveFunc: func() []api.ID {
-				return []api.ID{}
-			},
-			RemoveFunc: func(_ api.ID) {
-			},
-			CurrentFunc: func() api.ID {
-				return "sess-1"
-			},
-			SetCurrentFunc: func(id api.ID) error {
-				if id == "" {
-					return errors.New("empty id not allowed")
-				}
-				return nil
 			},
 		}
 	}
@@ -902,22 +795,6 @@ func Test_ErrNoTerminalSpec(t *testing.T) {
 			AddFunc: func(_ *api.AttachedTerminal) error {
 				return nil
 			},
-			GetFunc: func(_ api.ID) (*api.AttachedTerminal, bool) {
-				return nil, false
-			},
-			ListLiveFunc: func() []api.ID {
-				return []api.ID{}
-			},
-			RemoveFunc: func(_ api.ID) {},
-			CurrentFunc: func() api.ID {
-				return "sess-1"
-			},
-			SetCurrentFunc: func(id api.ID) error {
-				if id == "" {
-					return errors.New("empty id not allowed")
-				}
-				return nil
-			},
 		}
 	}
 
@@ -978,22 +855,6 @@ func Test_ErrTerminalExists(t *testing.T) {
 		return &terminalstore.Test{
 			AddFunc: func(_ *api.AttachedTerminal) error {
 				return errdefs.ErrTerminalExists
-			},
-			GetFunc: func(_ api.ID) (*api.AttachedTerminal, bool) {
-				return nil, false
-			},
-			ListLiveFunc: func() []api.ID {
-				return []api.ID{}
-			},
-			RemoveFunc: func(_ api.ID) {},
-			CurrentFunc: func() api.ID {
-				return "sess-1"
-			},
-			SetCurrentFunc: func(id api.ID) error {
-				if id == "" {
-					return errors.New("empty id not allowed")
-				}
-				return nil
 			},
 		}
 	}
@@ -1208,22 +1069,6 @@ func Test_EventCmdExited(t *testing.T) {
 			AddFunc: func(_ *api.AttachedTerminal) error {
 				return nil
 			},
-			GetFunc: func(_ api.ID) (*api.AttachedTerminal, bool) {
-				return nil, false
-			},
-			ListLiveFunc: func() []api.ID {
-				return []api.ID{}
-			},
-			RemoveFunc: func(_ api.ID) {},
-			CurrentFunc: func() api.ID {
-				return "sess-1"
-			},
-			SetCurrentFunc: func(id api.ID) error {
-				if id == "" {
-					return errors.New("empty id not allowed")
-				}
-				return nil
-			},
 		}
 	}
 
@@ -1315,22 +1160,6 @@ func Test_EventError(t *testing.T) {
 	sc.NewTerminalStore = func() terminalstore.TerminalStore {
 		return &terminalstore.Test{
 			AddFunc: func(_ *api.AttachedTerminal) error {
-				return nil
-			},
-			GetFunc: func(_ api.ID) (*api.AttachedTerminal, bool) {
-				return nil, false
-			},
-			ListLiveFunc: func() []api.ID {
-				return []api.ID{}
-			},
-			RemoveFunc: func(_ api.ID) {},
-			CurrentFunc: func() api.ID {
-				return "sess-1"
-			},
-			SetCurrentFunc: func(id api.ID) error {
-				if id == "" {
-					return errors.New("empty id not allowed")
-				}
 				return nil
 			},
 		}
@@ -1427,22 +1256,6 @@ func Test_EventDetach(t *testing.T) {
 			AddFunc: func(_ *api.AttachedTerminal) error {
 				return nil
 			},
-			GetFunc: func(_ api.ID) (*api.AttachedTerminal, bool) {
-				return nil, false
-			},
-			ListLiveFunc: func() []api.ID {
-				return []api.ID{}
-			},
-			RemoveFunc: func(_ api.ID) {},
-			CurrentFunc: func() api.ID {
-				return "sess-1"
-			},
-			SetCurrentFunc: func(id api.ID) error {
-				if id == "" {
-					return errors.New("empty id not allowed")
-				}
-				return nil
-			},
 		}
 	}
 
@@ -1537,22 +1350,6 @@ func Test_EventDetachFailure(t *testing.T) {
 			AddFunc: func(_ *api.AttachedTerminal) error {
 				return nil
 			},
-			GetFunc: func(_ api.ID) (*api.AttachedTerminal, bool) {
-				return nil, false
-			},
-			ListLiveFunc: func() []api.ID {
-				return []api.ID{}
-			},
-			RemoveFunc: func(_ api.ID) {},
-			CurrentFunc: func() api.ID {
-				return "sess-1"
-			},
-			SetCurrentFunc: func(id api.ID) error {
-				if id == "" {
-					return errors.New("empty id not allowed")
-				}
-				return nil
-			},
 		}
 	}
 
@@ -1638,12 +1435,7 @@ func Test_EventError_PeerClosed(t *testing.T) {
 
 	sc.NewTerminalStore = func() terminalstore.TerminalStore {
 		return &terminalstore.Test{
-			AddFunc:        func(_ *api.AttachedTerminal) error { return nil },
-			GetFunc:        func(_ api.ID) (*api.AttachedTerminal, bool) { return nil, false },
-			ListLiveFunc:   func() []api.ID { return []api.ID{} },
-			RemoveFunc:     func(_ api.ID) {},
-			CurrentFunc:    func() api.ID { return "sess-1" },
-			SetCurrentFunc: func(_ api.ID) error { return nil },
+			AddFunc: func(_ *api.AttachedTerminal) error { return nil },
 		}
 	}
 
@@ -1734,12 +1526,7 @@ func Test_EventDetachThenError_ClientDetached(t *testing.T) {
 
 	sc.NewTerminalStore = func() terminalstore.TerminalStore {
 		return &terminalstore.Test{
-			AddFunc:        func(_ *api.AttachedTerminal) error { return nil },
-			GetFunc:        func(_ api.ID) (*api.AttachedTerminal, bool) { return nil, false },
-			ListLiveFunc:   func() []api.ID { return []api.ID{} },
-			RemoveFunc:     func(_ api.ID) {},
-			CurrentFunc:    func() api.ID { return "sess-1" },
-			SetCurrentFunc: func(_ api.ID) error { return nil },
+			AddFunc: func(_ *api.AttachedTerminal) error { return nil },
 		}
 	}
 
@@ -1836,22 +1623,6 @@ func Test_EventUnknown(_ *testing.T) {
 	sc.NewTerminalStore = func() terminalstore.TerminalStore {
 		return &terminalstore.Test{
 			AddFunc: func(_ *api.AttachedTerminal) error {
-				return nil
-			},
-			GetFunc: func(_ api.ID) (*api.AttachedTerminal, bool) {
-				return nil, false
-			},
-			ListLiveFunc: func() []api.ID {
-				return []api.ID{}
-			},
-			RemoveFunc: func(_ api.ID) {},
-			CurrentFunc: func() api.ID {
-				return "sess-1"
-			},
-			SetCurrentFunc: func(id api.ID) error {
-				if id == "" {
-					return errors.New("empty id not allowed")
-				}
 				return nil
 			},
 		}
@@ -2093,22 +1864,6 @@ func Test_RunNewTerminalSuccess(t *testing.T) {
 			AddFunc: func(_ *api.AttachedTerminal) error {
 				return nil
 			},
-			GetFunc: func(_ api.ID) (*api.AttachedTerminal, bool) {
-				return nil, false
-			},
-			ListLiveFunc: func() []api.ID {
-				return []api.ID{}
-			},
-			RemoveFunc: func(_ api.ID) {},
-			CurrentFunc: func() api.ID {
-				return "sess-1"
-			},
-			SetCurrentFunc: func(id api.ID) error {
-				if id == "" {
-					return errors.New("empty id not allowed")
-				}
-				return nil
-			},
 		}
 	}
 
@@ -2239,19 +1994,6 @@ func Test_ClientAttach_WaitForStartingOrReady(t *testing.T) {
 			AddFunc: func(_ *api.AttachedTerminal) error {
 				return nil
 			},
-			GetFunc: func(_ api.ID) (*api.AttachedTerminal, bool) {
-				return nil, false
-			},
-			ListLiveFunc: func() []api.ID {
-				return []api.ID{}
-			},
-			RemoveFunc: func(_ api.ID) {},
-			CurrentFunc: func() api.ID {
-				return "term-1"
-			},
-			SetCurrentFunc: func(_ api.ID) error {
-				return nil
-			},
 		}
 	}
 
@@ -2374,19 +2116,6 @@ func Test_ClientAttach_StateTransition(t *testing.T) {
 	sc.NewTerminalStore = func() terminalstore.TerminalStore {
 		return &terminalstore.Test{
 			AddFunc: func(_ *api.AttachedTerminal) error {
-				return nil
-			},
-			GetFunc: func(_ api.ID) (*api.AttachedTerminal, bool) {
-				return nil, false
-			},
-			ListLiveFunc: func() []api.ID {
-				return []api.ID{}
-			},
-			RemoveFunc: func(_ api.ID) {},
-			CurrentFunc: func() api.ID {
-				return "term-1"
-			},
-			SetCurrentFunc: func(_ api.ID) error {
 				return nil
 			},
 		}

--- a/internal/client/terminalstore/doc.go
+++ b/internal/client/terminalstore/doc.go
@@ -14,8 +14,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package terminalstore is the client-side, in-memory registry of
-// terminals known to a single sbsh client process.
+// Package terminalstore is a client-side, in-memory fail-fast guard
+// against duplicate terminal IDs inside a single sbsh client process.
 //
 // # Scope and lifetime
 //
@@ -23,7 +23,8 @@
 // internal/client/controller.go) and dies with the controller goroutine
 // when the client process exits or its context is cancelled. The store
 // holds *api.AttachedTerminal values keyed by api.ID; it is not
-// persisted to disk.
+// persisted to disk and exposes only Add — there is no lifecycle
+// tracking, no listing, and no current-terminal pointer here.
 //
 // The authoritative inventory of terminals across the host lives on
 // disk under <runPath>/terminals/<id>/. That directory tree is the
@@ -38,14 +39,10 @@
 //
 // # Concurrency
 //
-// All TerminalStore operations on the production Exec implementation
-// are guarded by a single sync.RWMutex. Read methods (Get, ListLive,
-// Current) take the read lock; mutators (Add, Remove, SetCurrent)
-// take the write lock. Each compound check-then-write sequence —
-// Add's "exists? then insert (and maybe set current)" and
-// SetCurrent's "exists? then assign" — runs under one write-lock
-// acquisition, so they are atomic with respect to concurrent callers.
-// There is no internal TOCTOU window.
+// Add is guarded by a sync.Mutex. The check-then-insert sequence —
+// "exists? then insert" — runs under one lock acquisition, so it is
+// atomic with respect to concurrent callers. There is no internal
+// TOCTOU window.
 //
 // The store is keyed by api.ID exclusively. There is no name-keyed
 // lookup, and no callers route from a store entry to a kill(2)

--- a/internal/client/terminalstore/session_store.go
+++ b/internal/client/terminalstore/session_store.go
@@ -17,7 +17,6 @@
 package terminalstore
 
 import (
-	"errors"
 	"sync"
 
 	"github.com/eminwux/sbsh/internal/errdefs"
@@ -26,17 +25,11 @@ import (
 
 type TerminalStore interface {
 	Add(s *api.AttachedTerminal) error
-	Get(id api.ID) (*api.AttachedTerminal, bool)
-	ListLive() []api.ID
-	Remove(id api.ID)
-	Current() api.ID
-	SetCurrent(id api.ID) error
 }
 
 type Exec struct {
-	mu        sync.RWMutex
+	mu        sync.Mutex
 	terminals map[api.ID]*api.AttachedTerminal
-	current   api.ID
 }
 
 func NewTerminalStoreExec() TerminalStore {
@@ -53,8 +46,6 @@ func NewSupervisedTerminal(spec *api.TerminalSpec) *api.AttachedTerminal {
 	}
 }
 
-/* Basic ops */
-
 func (m *Exec) Add(s *api.AttachedTerminal) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -62,50 +53,5 @@ func (m *Exec) Add(s *api.AttachedTerminal) error {
 		return errdefs.ErrTerminalExists
 	}
 	m.terminals[s.Spec.ID] = s
-	if m.current == "" {
-		m.current = s.Spec.ID
-	}
-	return nil
-}
-
-func (m *Exec) Get(id api.ID) (*api.AttachedTerminal, bool) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	s, ok := m.terminals[id]
-	return s, ok
-}
-
-func (m *Exec) ListLive() []api.ID {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	out := make([]api.ID, 0, len(m.terminals))
-	for id := range m.terminals {
-		out = append(out, id)
-	}
-	return out
-}
-
-func (m *Exec) Remove(id api.ID) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	delete(m.terminals, id)
-	if m.current == id {
-		m.current = "" // caller can SetCurrent to another live terminal
-	}
-}
-
-func (m *Exec) Current() api.ID {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	return m.current
-}
-
-func (m *Exec) SetCurrent(id api.ID) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if _, ok := m.terminals[id]; !ok {
-		return errors.New("unknown terminal id")
-	}
-	m.current = id
 	return nil
 }

--- a/internal/client/terminalstore/session_store_fake.go
+++ b/internal/client/terminalstore/session_store_fake.go
@@ -24,22 +24,9 @@ import (
 )
 
 type Test struct {
-	// Last-call trackers (useful for assertions)
-	LastAdded        *api.AttachedTerminal
-	LastGetID        api.ID
-	LastRemovedID    api.ID
-	LastSetCurrentID api.ID
+	LastAdded *api.AttachedTerminal
 
-	// Optional: store a value to be returned by Current() when CurrentFunc is nil
-	CurrentID api.ID
-
-	// Stub functions (set these in tests to control behavior)
-	AddFunc        func(s *api.AttachedTerminal) error
-	GetFunc        func(id api.ID) (*api.AttachedTerminal, bool)
-	ListLiveFunc   func() []api.ID
-	RemoveFunc     func(id api.ID)
-	CurrentFunc    func() api.ID
-	SetCurrentFunc func(id api.ID) error
+	AddFunc func(s *api.AttachedTerminal) error
 }
 
 func NewTerminalStoreTest() *Test {
@@ -50,27 +37,6 @@ func NewTerminalStoreTest() *Test {
 			}
 			return nil
 		},
-		GetFunc: func(id api.ID) (*api.AttachedTerminal, bool) {
-			if id == "" {
-				return nil, false
-			}
-			return &api.AttachedTerminal{}, true
-		},
-		ListLiveFunc: func() []api.ID {
-			return []api.ID{"sess-1", "sess-2"}
-		},
-		RemoveFunc: func(_ api.ID) {
-			// no-op, LastRemovedID is tracked automatically
-		},
-		CurrentFunc: func() api.ID {
-			return "sess-1"
-		},
-		SetCurrentFunc: func(id api.ID) error {
-			if id == "" {
-				return errors.New("cannot set empty id")
-			}
-			return nil
-		},
 	}
 }
 
@@ -78,43 +44,6 @@ func (t *Test) Add(s *api.AttachedTerminal) error {
 	t.LastAdded = s
 	if t.AddFunc != nil {
 		return t.AddFunc(s)
-	}
-	return errdefs.ErrFuncNotSet
-}
-
-func (t *Test) Get(id api.ID) (*api.AttachedTerminal, bool) {
-	t.LastGetID = id
-	if t.GetFunc != nil {
-		return t.GetFunc(id)
-	}
-	return nil, false
-}
-
-func (t *Test) ListLive() []api.ID {
-	if t.ListLiveFunc != nil {
-		return t.ListLiveFunc()
-	}
-	return nil
-}
-
-func (t *Test) Remove(id api.ID) {
-	t.LastRemovedID = id
-	if t.RemoveFunc != nil {
-		t.RemoveFunc(id)
-	}
-}
-
-func (t *Test) Current() api.ID {
-	if t.CurrentFunc != nil {
-		return t.CurrentFunc()
-	}
-	return t.CurrentID
-}
-
-func (t *Test) SetCurrent(id api.ID) error {
-	t.LastSetCurrentID = id
-	if t.SetCurrentFunc != nil {
-		return t.SetCurrentFunc(id)
 	}
 	return errdefs.ErrFuncNotSet
 }


### PR DESCRIPTION
## Summary
- `terminalstore.TerminalStore` had six methods (`Add`, `Get`, `ListLive`, `Remove`, `Current`, `SetCurrent`); production code only ever calls `Add` from three sites in `internal/client/controller.go`. The other five were dead surface, with the `current api.ID` tracking field they implied. Pruning them and the orphan `LastGetID` / `LastRemovedID` / `LastSetCurrentID` / `CurrentID` trackers on the test fake keeps the package's contract aligned with its single production caller, per #250 / parent audit #223.
- `clientrunner.Exec.Mgr *terminalstore.Exec` was an exported field that no caller ever read or wrote; the audit confirmed it was a leaky concrete-type placeholder. Removing it also drops the now-unused `terminalstore` import from `client_runner_exec.go`.
- `session_store.go`'s mutex is now a plain `sync.Mutex` (no readers remain). `doc.go`'s package preamble is rewritten to describe the Add-only fail-fast guard the package actually is — including a corrected "Concurrency" section that no longer references read methods or `SetCurrent`'s check-then-assign.

## Test plan
- [x] `make sbsh-sb` — canonical build produces an ELF `sbsh` (verified via `file`)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — full unit suite + integration + e2e (`./e2e` ran green, including the controller tests whose ~90 stub blocks were rewritten)
- [x] pre-commit hooks (gofmt, golangci-lint, addlicense) green

Closes #250