### PR TITLE
feat(builder): suppress terminals/<id>/ subdir when all artifact paths are explicit

### DIFF
--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -219,7 +219,14 @@ type BuildTerminalSpecParams struct {
 	LogFileMode string
 	// LogFileGID is the numeric GID flag value for the log file, or nil
 	// to fall through to the profile / leave the group unchanged.
-	LogFileGID       *int
+	LogFileGID *int
+	// MetadataDir, when non-empty, overrides where the runner writes
+	// metadata.json — bypassing the legacy runPath/terminals/<id>/
+	// subdir. applyParamDefaults derives it (from LogFile.dirname) when
+	// all three of LogFile, CaptureFile, and SocketFile are
+	// caller-supplied; an embedder that pre-allocates the per-terminal
+	// directory layout (e.g. kukeon) can also set it explicitly.
+	MetadataDir      string
 	EnvVars          []string
 	DisableSetPrompt bool
 	ShutdownGrace    time.Duration
@@ -276,6 +283,13 @@ func applyParamDefaults(input *BuildTerminalSpecParams) {
 		input.TerminalCmd = "/bin/bash"
 		input.TerminalCmdArgs = []string{"-i"}
 	}
+	// Capture "all three artifact paths are caller-supplied" before the
+	// defaulting block fires, so the runner can place metadata.json next
+	// to the caller-owned files instead of injecting a terminals/<id>/
+	// subdir under runPath. See pkg/api.TerminalSpec.MetadataDir.
+	explicitArtifactPaths := input.LogFile != "" &&
+		input.CaptureFile != "" &&
+		input.SocketFile != ""
 	if input.LogFile == "" {
 		input.LogFile = filepath.Join(
 			input.RunPath,
@@ -302,6 +316,9 @@ func applyParamDefaults(input *BuildTerminalSpecParams) {
 			input.TerminalID,
 			"socket",
 		)
+	}
+	if explicitArtifactPaths && input.MetadataDir == "" {
+		input.MetadataDir = filepath.Dir(input.LogFile)
 	}
 }
 
@@ -496,6 +513,7 @@ func addInputValuesToTerminal(terminalSpec *api.TerminalSpec, input *BuildTermin
 	terminalSpec.LogFile = input.LogFile
 	terminalSpec.LogLevel = input.LogLevel
 	terminalSpec.SocketFile = input.SocketFile
+	terminalSpec.MetadataDir = input.MetadataDir
 	if input.Cwd != "" {
 		terminalSpec.Cwd = input.Cwd
 	}

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -22,9 +22,11 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/eminwux/sbsh/internal/defaults"
 	"github.com/eminwux/sbsh/internal/errdefs"
 	"github.com/eminwux/sbsh/pkg/api"
 )
@@ -304,6 +306,110 @@ func TestApplyOnePermOverride_ExplicitGIDReplacesPrior(t *testing.T) {
 	}
 	if gid == nil || *gid != 7 {
 		t.Fatalf("gid: want 7, got %v", gid)
+	}
+}
+
+// applyParamDefaults: when LogFile, CaptureFile, and SocketFile are all
+// caller-supplied the helper sets MetadataDir to LogFile.dirname so the
+// runner places metadata.json next to the caller-owned files instead of
+// injecting runPath/terminals/<id>/. This is the embedder-opt-out path
+// for the per-terminal subdir convention. See issue #273.
+func TestApplyParamDefaults_AllExplicitArtifactPaths_SetsMetadataDir(t *testing.T) {
+	customDir := "/run/embedder/tty"
+	p := &BuildTerminalSpecParams{
+		RunPath:     "/run/sbsh",
+		LogFile:     filepath.Join(customDir, "log"),
+		CaptureFile: filepath.Join(customDir, "capture"),
+		SocketFile:  filepath.Join(customDir, "socket"),
+	}
+	applyParamDefaults(p)
+	if p.MetadataDir != customDir {
+		t.Fatalf("MetadataDir: want %q, got %q", customDir, p.MetadataDir)
+	}
+}
+
+// applyParamDefaults: if any one artifact path is left empty the legacy
+// default fires (paths derived under runPath/terminals/<id>/) and
+// MetadataDir stays empty so the runner uses the legacy directory. The
+// existing CLI lane must not regress — pkg/discovery.ScanTerminals still
+// finds metadata.json at the legacy location.
+func TestApplyParamDefaults_PartialOrEmptyArtifactPaths_LeavesMetadataDirEmpty(t *testing.T) {
+	customDir := "/run/embedder/tty"
+	tests := []struct {
+		name string
+		in   *BuildTerminalSpecParams
+	}{
+		{
+			name: "all empty",
+			in:   &BuildTerminalSpecParams{RunPath: "/run/sbsh"},
+		},
+		{
+			name: "log only",
+			in: &BuildTerminalSpecParams{
+				RunPath: "/run/sbsh",
+				LogFile: filepath.Join(customDir, "log"),
+			},
+		},
+		{
+			name: "log + capture, no socket",
+			in: &BuildTerminalSpecParams{
+				RunPath:     "/run/sbsh",
+				LogFile:     filepath.Join(customDir, "log"),
+				CaptureFile: filepath.Join(customDir, "capture"),
+			},
+		},
+		{
+			name: "log + socket, no capture",
+			in: &BuildTerminalSpecParams{
+				RunPath:    "/run/sbsh",
+				LogFile:    filepath.Join(customDir, "log"),
+				SocketFile: filepath.Join(customDir, "socket"),
+			},
+		},
+		{
+			name: "capture + socket, no log",
+			in: &BuildTerminalSpecParams{
+				RunPath:     "/run/sbsh",
+				CaptureFile: filepath.Join(customDir, "capture"),
+				SocketFile:  filepath.Join(customDir, "socket"),
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			applyParamDefaults(tc.in)
+			if tc.in.MetadataDir != "" {
+				t.Fatalf("MetadataDir: want empty, got %q", tc.in.MetadataDir)
+			}
+			// And the defaulted artifact paths must still live under the
+			// legacy runPath/terminals/<id>/ subdir so ScanTerminals keeps
+			// working for any artifact the caller did not provide.
+			legacyDir := filepath.Join(tc.in.RunPath, defaults.TerminalsRunPath, tc.in.TerminalID)
+			for _, p := range []string{tc.in.LogFile, tc.in.CaptureFile, tc.in.SocketFile} {
+				if filepath.Dir(p) != legacyDir && filepath.Dir(p) != customDir {
+					t.Fatalf("unexpected artifact dir: %q (want legacy %q or custom %q)",
+						filepath.Dir(p), legacyDir, customDir)
+				}
+			}
+		})
+	}
+}
+
+// applyParamDefaults: a caller that already populated MetadataDir (e.g.
+// kukeon's wrapper that pre-resolves the metadata location) must not have
+// its choice overwritten by the LogFile.dirname fallback.
+func TestApplyParamDefaults_PreSetMetadataDir_NotOverwritten(t *testing.T) {
+	preset := "/run/embedder/tty"
+	p := &BuildTerminalSpecParams{
+		RunPath:     "/run/sbsh",
+		LogFile:     "/some/other/place/log",
+		CaptureFile: "/some/other/place/capture",
+		SocketFile:  "/some/other/place/socket",
+		MetadataDir: preset,
+	}
+	applyParamDefaults(p)
+	if p.MetadataDir != preset {
+		t.Fatalf("MetadataDir: want preserved %q, got %q", preset, p.MetadataDir)
 	}
 }
 

--- a/internal/terminal/terminalrunner/metadata.go
+++ b/internal/terminal/terminalrunner/metadata.go
@@ -31,13 +31,27 @@ import (
 func (sr *Exec) CreateMetadata() error {
 	sr.metadataMu.Lock()
 	runPath := sr.metadata.Spec.RunPath
-	dir := filepath.Join(runPath, defaults.TerminalsRunPath, string(sr.id))
+	metadataDirOverride := sr.metadata.Spec.MetadataDir
 	sr.metadataMu.Unlock()
 
-	sr.logger.Debug("CreateMetadata: creating terminal directory", "dir", dir)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		sr.logger.Error("CreateMetadata: failed to create terminal dir", "dir", dir, "error", err)
-		return fmt.Errorf("mkdir terminal dir: %w", err)
+	dir, embedderOwnsDir := resolveMetadataDir(runPath, metadataDirOverride, sr.id)
+
+	if embedderOwnsDir {
+		// MetadataDir is set: the embedder pre-allocated this directory
+		// (e.g. via a bind mount) and owns its contents. Do not MkdirAll —
+		// avoid silently creating a parent the embedder didn't intend, and
+		// avoid puncturing the embedder's "this dir is fully mine" contract
+		// with sbsh-injected subdirs. See pkg/api.TerminalSpec.MetadataDir.
+		sr.logger.Debug(
+			"CreateMetadata: using embedder-owned metadata directory",
+			"dir", dir,
+		)
+	} else {
+		sr.logger.Debug("CreateMetadata: creating terminal directory", "dir", dir)
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			sr.logger.Error("CreateMetadata: failed to create terminal dir", "dir", dir, "error", err)
+			return fmt.Errorf("mkdir terminal dir: %w", err)
+		}
 	}
 
 	pid := os.Getpid()
@@ -74,15 +88,30 @@ func (sr *Exec) CreateMetadata() error {
 func (sr *Exec) getTerminalDir() string {
 	sr.metadataMu.RLock()
 	defer sr.metadataMu.RUnlock()
-	return filepath.Join(sr.metadata.Spec.RunPath, defaults.TerminalsRunPath, string(sr.id))
+	dir, _ := resolveMetadataDir(sr.metadata.Spec.RunPath, sr.metadata.Spec.MetadataDir, sr.id)
+	return dir
 }
 
 func (sr *Exec) updateMetadata() error {
 	sr.metadataMu.RLock()
 	metadataCopy := sr.metadata
-	dir := filepath.Join(sr.metadata.Spec.RunPath, defaults.TerminalsRunPath, string(sr.id))
+	dir, _ := resolveMetadataDir(sr.metadata.Spec.RunPath, sr.metadata.Spec.MetadataDir, sr.id)
 	sr.metadataMu.RUnlock()
 	return shared.WriteMetadata(sr.ctx, metadataCopy, dir)
+}
+
+// resolveMetadataDir picks the directory where metadata.json is written.
+// When metadataDirOverride is non-empty the embedder owns that directory
+// (e.g. kukeon bind-mounts /run/kukeon/tty into the container) and the
+// runner places metadata.json there without creating any sbsh-injected
+// subdir; the second return is true on that branch so callers can skip
+// MkdirAll. Empty preserves the legacy runPath/terminals/<id>/ layout
+// scanned by pkg/discovery.ScanTerminals.
+func resolveMetadataDir(runPath, metadataDirOverride string, id api.ID) (string, bool) {
+	if metadataDirOverride != "" {
+		return metadataDirOverride, true
+	}
+	return filepath.Join(runPath, defaults.TerminalsRunPath, string(id)), false
 }
 
 func (sr *Exec) updateTerminalState(status api.TerminalStatusMode) error {

--- a/internal/terminal/terminalrunner/metadata_test.go
+++ b/internal/terminal/terminalrunner/metadata_test.go
@@ -1,0 +1,61 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrunner
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// resolveMetadataDir is the runner-side switch for option A (issue #273).
+// An empty override falls through to the legacy
+// runPath/terminals/<id>/ layout that pkg/discovery.ScanTerminals scans;
+// the second return is false so CreateMetadata MkdirAlls the path.
+func TestResolveMetadataDir_NoOverrideUsesLegacyLayout(t *testing.T) {
+	runPath := "/run/sbsh"
+	id := api.ID("term-id")
+
+	dir, embedderOwns := resolveMetadataDir(runPath, "", id)
+
+	want := filepath.Join(runPath, defaults.TerminalsRunPath, string(id))
+	if dir != want {
+		t.Fatalf("dir: want %q, got %q", want, dir)
+	}
+	if embedderOwns {
+		t.Fatal("embedderOwns: want false on legacy path so CreateMetadata MkdirAlls")
+	}
+}
+
+// resolveMetadataDir: a non-empty override is used verbatim, and the
+// second return is true so CreateMetadata skips MkdirAll — the embedder
+// pre-allocated this directory (e.g. via a bind mount) and owns its
+// contents.
+func TestResolveMetadataDir_OverrideUsedVerbatim(t *testing.T) {
+	override := "/run/kukeon/tty"
+
+	dir, embedderOwns := resolveMetadataDir("/run/sbsh", override, api.ID("term-id"))
+
+	if dir != override {
+		t.Fatalf("dir: want %q, got %q", override, dir)
+	}
+	if !embedderOwns {
+		t.Fatal("embedderOwns: want true so CreateMetadata skips MkdirAll")
+	}
+}

--- a/pkg/api/terminal.go
+++ b/pkg/api/terminal.go
@@ -73,6 +73,17 @@ type TerminalSpec struct {
 	LogLevel    string `json:"logLevel"`
 	SocketFile  string `json:"socketIO"`
 
+	// MetadataDir overrides where the runner writes metadata.json. When
+	// non-empty, the runner uses this directory verbatim and does NOT
+	// create the legacy runPath/terminals/<id>/ subdir. The builder sets
+	// this when all three of LogFile, CaptureFile, and SocketFile are
+	// caller-supplied via With* options — the signal that the embedder
+	// already owns the per-terminal directory layout and does not want
+	// sbsh-injected subdirs under runPath. Empty preserves the legacy
+	// behavior (and the discoverability of metadata.json via
+	// pkg/discovery.ScanTerminals).
+	MetadataDir string `json:"metadataDir,omitempty"`
+
 	// SocketMode is the chmod applied to the control socket after Listen.
 	// Zero means "use the runner default" (0600), preserving owner-only
 	// behavior for callers that never set the field.

--- a/pkg/builder/terminal_test.go
+++ b/pkg/builder/terminal_test.go
@@ -546,6 +546,54 @@ func TestBuildTerminalSpec_WithLogFileGID(t *testing.T) {
 	}
 }
 
+// Option A (issue #273): when an embedder passes all three of
+// WithLogFile, WithCaptureFile, and WithSocketFile, the resulting spec
+// carries a non-empty MetadataDir = LogFile.dirname. The runner uses
+// that to place metadata.json next to the embedder-owned files instead
+// of injecting runPath/terminals/<id>/.
+func TestBuildTerminalSpec_AllExplicitArtifactPaths_SetsMetadataDir(t *testing.T) {
+	runPath := t.TempDir()
+	embedderDir := filepath.Join(t.TempDir(), "tty")
+	spec, err := builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		builder.WithLogFile(filepath.Join(embedderDir, "kuketty.log")),
+		builder.WithCaptureFile(filepath.Join(embedderDir, "capture")),
+		builder.WithSocketFile(filepath.Join(embedderDir, "socket")),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.MetadataDir != embedderDir {
+		t.Fatalf("MetadataDir: want %q, got %q", embedderDir, spec.MetadataDir)
+	}
+}
+
+// Option A (issue #273): an embedder that supplies only some of the
+// artifact paths still triggers the legacy runPath/terminals/<id>/
+// layout for the unset paths, so MetadataDir stays empty and
+// pkg/discovery.ScanTerminals continues to find metadata.json under
+// the legacy directory. Covers the no-regression half of the AC.
+func TestBuildTerminalSpec_PartialExplicitArtifactPaths_LeavesMetadataDirEmpty(t *testing.T) {
+	runPath := t.TempDir()
+	embedderDir := filepath.Join(t.TempDir(), "tty")
+	spec, err := builder.BuildTerminalSpec(
+		context.Background(),
+		testLogger(),
+		runPath,
+		// Two of three explicit — not enough to opt out.
+		builder.WithLogFile(filepath.Join(embedderDir, "kuketty.log")),
+		builder.WithCaptureFile(filepath.Join(embedderDir, "capture")),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.MetadataDir != "" {
+		t.Fatalf("MetadataDir: want empty, got %q", spec.MetadataDir)
+	}
+}
+
 // WithCommand with empty argv (or empty argv[0]) is a no-op.
 func TestBuildTerminalSpec_WithCommandEmpty(t *testing.T) {
 	runPath := t.TempDir()


### PR DESCRIPTION
## Summary

Implements option A from #273. When an embedder supplies all three of `WithLogFile`, `WithCaptureFile`, and `WithSocketFile`, the builder now sets a new `TerminalSpec.MetadataDir` field to `LogFile.dirname` and the runner places `metadata.json` there directly — skipping the unconditional `runPath/terminals/<id>/` `MkdirAll` that previously punctured the embedder's "this directory is fully mine" contract (e.g. kukeon's per-cell `/run/kukeon/tty/` bind mount).

The opt-out is fully implicit and backwards-compatible:
- Callers that leave any one of `LogFile` / `CaptureFile` / `SocketFile` empty (the sb CLI lane and every existing embedder) keep the legacy layout — `applyParamDefaults` still derives the empties under `runPath/terminals/<id>/`, `MetadataDir` stays empty, and `pkg/discovery.ScanTerminals` continues to find `metadata.json` at the legacy location.
- On the opt-out path the runner skips `MkdirAll` (the embedder owns the directory and pre-allocated it); `Status.TerminalRunPath` records the override dir, so any future cleanup path (currently dead — `deleteTerminalsDir = false`) targets the embedder's dir rather than a non-existent subdir.

The issue author confirmed option A in the issue comment (https://github.com/eminwux/sbsh/issues/273#issuecomment-4486966700):

> Implement option A

No new builder option is introduced — per the issue, option A's intent is to *extend the existing conditionality* of `applyParamDefaults` (which already only defaults paths the caller left empty) into the metadata-directory decision in the runner.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make sbsh-sb` + `file ./sbsh` reports ELF executable
- [x] `pre-commit run --files <changed>` (golangci-lint, gofmt, go-mod-tidy, addlicense — all pass)
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` — full unit-test sweep passes (including the new `TestApplyParamDefaults_*`, `TestBuildTerminalSpec_*ArtifactPaths_*`, `TestResolveMetadataDir_*`)
- [x] `go test -tags=integration ./cmd/sb/get/...` — integration tests pass
- [x] `make e2e` — e2e suite passes

## Acceptance criteria

- [x] An embedder that supplies all three of `WithLogFile`, `WithCaptureFile`, `WithSocketFile` can run a terminal without `runPath/terminals/<id>/` being created on disk — covered by `TestBuildTerminalSpec_AllExplicitArtifactPaths_SetsMetadataDir` and `TestResolveMetadataDir_OverrideUsedVerbatim` (asserts the runner skips `MkdirAll`).
- [x] `metadata.json` continues to be discoverable for `pkg/discovery.ScanTerminals` callers that use the legacy layout — covered by `TestApplyParamDefaults_PartialOrEmptyArtifactPaths_LeavesMetadataDirEmpty` (asserts every defaulted artifact path lands under `runPath/terminals/<id>/`) and `TestResolveMetadataDir_NoOverrideUsesLegacyLayout`.

Closes #273