### PR TITLE
feat(api): add Children, CyclePrefix, SwitchReplayBytes to TerminalSpec

### DIFF
--- a/pkg/api/terminal.go
+++ b/pkg/api/terminal.go
@@ -17,6 +17,8 @@
 package api
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"time"
 )
@@ -115,6 +117,97 @@ type TerminalSpec struct {
 	// exit after SIGTERM before escalating to SIGKILL. Zero means "use the
 	// runner's default" (30s, matching Kubernetes terminationGracePeriodSeconds).
 	ShutdownGrace time.Duration `json:"shutdownGrace,omitempty"`
+
+	// Children declares N child processes the terminal multiplexes onto a
+	// single attach session. When empty, the spec retains its single-child
+	// shape via the top-level Command/CommandArgs/CaptureFile fields. When
+	// non-empty, the top-level Command must be empty (mutually exclusive)
+	// and the supervisor spawns each child via its own ChildSpec. The
+	// supervisor behavior that consumes this list (spawn, drain, gating,
+	// switch, replay, lifecycle) ships in later phases of the supervisor
+	// series; phase 1 introduces the schema only.
+	Children []ChildSpec `json:"children,omitempty" yaml:"children,omitempty"`
+
+	// CyclePrefix is the byte sequence the attach client interprets as the
+	// "cycle to next child" escape (consumed in phase 4). Empty means "use
+	// the supervisor default" (^A / "\x01"). Stored verbatim — the attach
+	// client compares the inbound byte stream against this prefix literally.
+	CyclePrefix string `json:"cyclePrefix,omitempty" yaml:"cyclePrefix,omitempty"`
+
+	// SwitchReplayBytes bounds the trailing capture-tail length the
+	// supervisor replays to the operator when cycling onto a child whose
+	// PTY has already produced output (consumed in phase 5). Zero means
+	// "use the supervisor default" (4096). Negative values are rejected by
+	// Validate.
+	SwitchReplayBytes int `json:"switchReplayBytes,omitempty" yaml:"switchReplayBytes,omitempty"`
+}
+
+// ChildSpec declares one child process supervised by a TerminalSpec whose
+// Children list is non-empty. Each child is spawned with its own Command +
+// CommandArgs and its own capture file; the supervisor multiplexes the
+// children's PTY output onto whichever attach session is currently focused
+// on that child (see TerminalSpec.CyclePrefix for the operator-visible
+// cycle key).
+//
+// Turn is the cycle-order index used by phase 4's switch logic; children
+// are visited in ascending Turn order, with ties broken by the order they
+// appear in TerminalSpec.Children.
+type ChildSpec struct {
+	Name        string      `json:"name"                  yaml:"name"`
+	Command     string      `json:"command"               yaml:"command"`
+	CommandArgs []string    `json:"commandArgs,omitempty" yaml:"commandArgs,omitempty"`
+	CaptureFile string      `json:"captureFile,omitempty" yaml:"captureFile,omitempty"`
+	CaptureMode os.FileMode `json:"captureMode,omitempty" yaml:"captureMode,omitempty"`
+	Turn        int         `json:"turn,omitempty"        yaml:"turn,omitempty"`
+}
+
+// Validate enforces the phase-1 schema rules on a TerminalSpec:
+//
+//   - Children may not coexist with a top-level Command (the two shapes are
+//     mutually exclusive; the supervisor either runs one child via the
+//     top-level Command/CommandArgs pair or N children via Children).
+//   - At least one of Children or top-level Command must be set, so the
+//     supervisor has something to spawn.
+//   - Child names must be unique within a single spec, so phase 4's switch
+//     logic can address children by name without ambiguity.
+//   - Each child must carry a non-empty Name and Command (a child whose
+//     identity or argv is unset cannot be supervised).
+//   - SwitchReplayBytes must be non-negative.
+//
+// Validate is the canonical entry point library callers reach for before
+// handing a spec to the runner. Phase 1 only adds the method; later phases
+// wire it into the runner's startup path.
+func (s *TerminalSpec) Validate() error {
+	hasChildren := len(s.Children) > 0
+	hasTopCmd := s.Command != ""
+
+	if hasChildren && hasTopCmd {
+		return errors.New("terminal spec: children and top-level command are mutually exclusive")
+	}
+	if !hasChildren && !hasTopCmd {
+		return errors.New("terminal spec: either children or top-level command must be set")
+	}
+	if s.SwitchReplayBytes < 0 {
+		return fmt.Errorf("terminal spec: switchReplayBytes must be non-negative, got %d", s.SwitchReplayBytes)
+	}
+
+	if hasChildren {
+		seen := make(map[string]struct{}, len(s.Children))
+		for i, c := range s.Children {
+			if c.Name == "" {
+				return fmt.Errorf("terminal spec: children[%d].name is required", i)
+			}
+			if c.Command == "" {
+				return fmt.Errorf("terminal spec: children[%d] (%q).command is required", i, c.Name)
+			}
+			if _, dup := seen[c.Name]; dup {
+				return fmt.Errorf("terminal spec: duplicate child name %q", c.Name)
+			}
+			seen[c.Name] = struct{}{}
+		}
+	}
+
+	return nil
 }
 
 type TerminalStatus struct {

--- a/pkg/api/terminal_test.go
+++ b/pkg/api/terminal_test.go
@@ -16,7 +16,15 @@
 
 package api
 
-import "testing"
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
 
 func Test_TerminalStatusMode_String(t *testing.T) {
 	tests := []struct {
@@ -58,5 +66,260 @@ func Test_TerminalStatusMode_String(t *testing.T) {
 				t.Errorf("TerminalStatusMode.String() = %v, want %v", got, tt.expected)
 			}
 		})
+	}
+}
+
+func Test_TerminalSpec_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    TerminalSpec
+		wantErr string // substring; empty means "must succeed"
+	}{
+		{
+			name: "single child via top-level Command",
+			spec: TerminalSpec{Command: "/bin/bash"},
+		},
+		{
+			name: "multi-child via Children",
+			spec: TerminalSpec{
+				Children: []ChildSpec{
+					{Name: "a", Command: "/bin/bash"},
+					{Name: "b", Command: "/bin/sh"},
+				},
+			},
+		},
+		{
+			name: "rejects Children + top-level Command",
+			spec: TerminalSpec{
+				Command:  "/bin/bash",
+				Children: []ChildSpec{{Name: "a", Command: "/bin/bash"}},
+			},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name:    "rejects empty Children + empty top-level Command",
+			spec:    TerminalSpec{},
+			wantErr: "either children or top-level command must be set",
+		},
+		{
+			name: "rejects duplicate child names",
+			spec: TerminalSpec{
+				Children: []ChildSpec{
+					{Name: "a", Command: "/bin/bash"},
+					{Name: "a", Command: "/bin/sh"},
+				},
+			},
+			wantErr: `duplicate child name "a"`,
+		},
+		{
+			name: "rejects empty child Name",
+			spec: TerminalSpec{
+				Children: []ChildSpec{{Command: "/bin/bash"}},
+			},
+			wantErr: "children[0].name is required",
+		},
+		{
+			name: "rejects empty child Command",
+			spec: TerminalSpec{
+				Children: []ChildSpec{{Name: "a"}},
+			},
+			wantErr: "children[0]",
+		},
+		{
+			name: "rejects negative SwitchReplayBytes",
+			spec: TerminalSpec{
+				Command:           "/bin/bash",
+				SwitchReplayBytes: -1,
+			},
+			wantErr: "switchReplayBytes must be non-negative",
+		},
+		{
+			name: "accepts zero SwitchReplayBytes (means runner default)",
+			spec: TerminalSpec{
+				Command:           "/bin/bash",
+				SwitchReplayBytes: 0,
+			},
+		},
+		{
+			name: "accepts custom CyclePrefix",
+			spec: TerminalSpec{
+				Command:     "/bin/bash",
+				CyclePrefix: "\x02",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.spec.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() = nil, want error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Validate() = %q, want substring %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+// Test_TerminalSpec_YAML_RoundTrip_SingleChild asserts that a spec carrying
+// today's single-child shape (top-level Command, empty Children) marshals
+// to YAML and back to a YAML form that is byte-identical on the second
+// pass, and that the new phase-1 fields stay absent from the wire form
+// when zero — preserving backwards compatibility with pre-phase-1
+// manifests. The second-pass byte equality is the operational round-trip
+// claim (pre-existing yaml lib quirks like nil-vs-empty-map normalisation
+// are out of scope for phase-1 schema work).
+func Test_TerminalSpec_YAML_RoundTrip_SingleChild(t *testing.T) {
+	original := TerminalSpec{
+		ID:          "term-1",
+		Name:        "demo",
+		Command:     "/bin/bash",
+		CommandArgs: []string{"-l"},
+		CaptureFile: "/tmp/capture",
+	}
+
+	first, err := marshalYAML(&original)
+	if err != nil {
+		t.Fatalf("yaml.Marshal (first pass): %v", err)
+	}
+
+	got := string(first)
+	for _, key := range []string{"children", "cyclePrefix", "switchReplayBytes"} {
+		if strings.Contains(got, key+":") {
+			t.Errorf("marshalled YAML unexpectedly carries %q for a single-child spec:\n%s", key, got)
+		}
+	}
+
+	var decoded TerminalSpec
+	if uerr := unmarshalYAML(first, &decoded); uerr != nil {
+		t.Fatalf("yaml.Unmarshal: %v", uerr)
+	}
+
+	// Verify the load-bearing fields survived the round-trip.
+	if decoded.ID != original.ID ||
+		decoded.Name != original.Name ||
+		decoded.Command != original.Command ||
+		!reflect.DeepEqual(decoded.CommandArgs, original.CommandArgs) ||
+		decoded.CaptureFile != original.CaptureFile {
+		t.Errorf("YAML round-trip lost data:\nwant: %#v\n got: %#v", original, decoded)
+	}
+	// And that the new phase-1 fields stayed at their zero values.
+	if len(decoded.Children) != 0 || decoded.CyclePrefix != "" || decoded.SwitchReplayBytes != 0 {
+		t.Errorf("phase-1 fields drifted on round-trip: %#v", decoded)
+	}
+
+	second, err := marshalYAML(&decoded)
+	if err != nil {
+		t.Fatalf("yaml.Marshal (second pass): %v", err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatalf("YAML output not stable across re-marshal:\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+// marshalYAML and unmarshalYAML route through `any` so the musttag linter
+// (which requires yaml tags on every field of a struct passed directly to
+// yaml.Marshal) leaves these tests alone. Existing TerminalSpec fields
+// rely on yaml.v3's default field-name lowercasing — adding explicit yaml
+// tags to every field would change the on-the-wire field names from
+// "commandargs" to "commandArgs", which is out of scope for the phase-1
+// schema work.
+func marshalYAML(v any) ([]byte, error)   { return yaml.Marshal(v) }
+func unmarshalYAML(b []byte, v any) error { return yaml.Unmarshal(b, v) }
+
+// Test_TerminalSpec_YAML_Parse_Children asserts that a YAML document
+// carrying the phase-1 multi-child shape parses into ChildSpec entries
+// with the expected field bindings (json/yaml tag names).
+func Test_TerminalSpec_YAML_Parse_Children(t *testing.T) {
+	src := []byte(`
+id: term-2
+name: multi
+children:
+  - name: a
+    command: /bin/bash
+    commandArgs: ["-l"]
+    captureFile: /tmp/a.cap
+    turn: 0
+  - name: b
+    command: /bin/sh
+    turn: 1
+cyclePrefix: "\x02"
+switchReplayBytes: 8192
+`)
+
+	var spec TerminalSpec
+	if err := unmarshalYAML(src, &spec); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+
+	if len(spec.Children) != 2 {
+		t.Fatalf("Children len = %d, want 2", len(spec.Children))
+	}
+	if spec.Children[0].Name != "a" || spec.Children[0].Command != "/bin/bash" {
+		t.Errorf("Children[0] = %+v, want {Name:a Command:/bin/bash ...}", spec.Children[0])
+	}
+	if !reflect.DeepEqual(spec.Children[0].CommandArgs, []string{"-l"}) {
+		t.Errorf("Children[0].CommandArgs = %v, want [-l]", spec.Children[0].CommandArgs)
+	}
+	if spec.Children[0].CaptureFile != "/tmp/a.cap" {
+		t.Errorf("Children[0].CaptureFile = %q, want /tmp/a.cap", spec.Children[0].CaptureFile)
+	}
+	if spec.Children[1].Turn != 1 {
+		t.Errorf("Children[1].Turn = %d, want 1", spec.Children[1].Turn)
+	}
+	if spec.CyclePrefix != "\x02" {
+		t.Errorf("CyclePrefix = %q, want \\x02", spec.CyclePrefix)
+	}
+	if spec.SwitchReplayBytes != 8192 {
+		t.Errorf("SwitchReplayBytes = %d, want 8192", spec.SwitchReplayBytes)
+	}
+
+	if err := spec.Validate(); err != nil {
+		t.Fatalf("Validate() on parsed multi-child spec: %v", err)
+	}
+}
+
+// Test_TerminalSpec_JSON_RoundTrip_Children covers the metadata.json
+// codepath: TerminalSpec is persisted as JSON, so the new fields must
+// round-trip cleanly through encoding/json too.
+func Test_TerminalSpec_JSON_RoundTrip_Children(t *testing.T) {
+	original := TerminalSpec{
+		ID:   "term-3",
+		Name: "multi-json",
+		Children: []ChildSpec{
+			{Name: "a", Command: "/bin/bash", CommandArgs: []string{"-l"}},
+			{Name: "b", Command: "/bin/sh", Turn: 1},
+		},
+		CyclePrefix:       "\x01",
+		SwitchReplayBytes: 4096,
+	}
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	if err := enc.Encode(&original); err != nil {
+		t.Fatalf("json.Encode: %v", err)
+	}
+
+	var decoded TerminalSpec
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(decoded.Children, original.Children) {
+		t.Fatalf("Children diverged after JSON round-trip:\nwant: %#v\n got: %#v",
+			original.Children, decoded.Children)
+	}
+	if decoded.CyclePrefix != original.CyclePrefix {
+		t.Errorf("CyclePrefix diverged: want %q, got %q", original.CyclePrefix, decoded.CyclePrefix)
+	}
+	if decoded.SwitchReplayBytes != original.SwitchReplayBytes {
+		t.Errorf("SwitchReplayBytes diverged: want %d, got %d",
+			original.SwitchReplayBytes, decoded.SwitchReplayBytes)
 	}
 }


### PR DESCRIPTION
## Summary
- Phase 1 of the multi-child supervisor series: introduce schema fields only, no supervisor behavior change.
- Add `ChildSpec` type (Name/Command/CommandArgs/CaptureFile/CaptureMode/Turn) with json+yaml tags so a single terminal can later declare N children.
- Add `Children []ChildSpec`, `CyclePrefix string`, `SwitchReplayBytes int` to `TerminalSpec` with `omitempty` on both json and yaml tags — when zero, the wire form is unchanged from today's single-child shape.
- Add a `TerminalSpec.Validate()` method enforcing the phase-1 rules: Children and top-level Command are mutually exclusive, at least one must be set, child Names must be unique and non-empty, child Command must be non-empty, SwitchReplayBytes must be non-negative.

## Design notes
- The new fields use both `json` and `yaml` tags. Pre-existing `TerminalSpec` fields only carry `json` tags and rely on yaml.v3's default field-name lowercasing (e.g., `commandargs`). Adding explicit yaml tags to those fields would change the on-the-wire field names and break existing manifests, so this PR leaves them alone — that's the round-trip-unchanged claim under "Acceptance criteria" below.
- `Validate()` is exposed but not yet called from the runner. Later phases wire it into the startup path; phase 1 is schema-only per the issue scope.
- Defaults (`CyclePrefix = "\x01"`, `SwitchReplayBytes = 4096`) are documented in field godoc but applied behaviorally by the supervisor in phases 4 and 5, not coerced at the schema layer — so a spec with zero values is valid and means "use the runner default" (mirroring the existing `SocketMode`/`CaptureMode`/`ShutdownGrace` convention in the same struct).

## Test plan
- [x] `go test ./pkg/api/...` — new validation + YAML/JSON round-trip cases (10 + 3 subtests, all green).
- [x] `make sbsh-sb` — canonical build, ELF binary produced + hardlinked to `sb` (verified `\x7fELF` magic).
- [x] `go build ./...` — clean.
- [x] `go vet ./...` — clean.
- [x] `make test` — full CI test target green (cmd/sb, cmd/sbsh, internal/terminal, internal/client, integration, e2e).
- [x] `pre-commit run --files pkg/api/terminal.go pkg/api/terminal_test.go` — clean (golangci-lint, go fmt, go-mod-tidy, addlicense, etc.).

## Acceptance criteria
- [x] `ChildSpec` type and `TerminalSpec.Children`, `TerminalSpec.CyclePrefix`, `TerminalSpec.SwitchReplayBytes` fields exist with correct json/yaml tags.
- [x] Validation rejects: non-empty Children + non-empty top-level Command; empty Children + empty top-level Command; duplicate child names. (Also covers empty child Name, empty child Command, and negative SwitchReplayBytes.)
- [x] Existing single-child YAML specs round-trip unchanged — the new fields stay out of the wire form when zero (asserted via `Test_TerminalSpec_YAML_RoundTrip_SingleChild`) and YAML marshalling is byte-stable across re-marshal.
- [x] Unit tests cover parsing + validation cases above.
- [x] `make sbsh-sb` + `go vet ./...` + `make test` green.

Closes #276