### PR TITLE
feat(terminalrunner): active-process gating and Switch RPC (phase 3)

### DIFF
--- a/internal/terminal/controller.go
+++ b/internal/terminal/controller.go
@@ -386,6 +386,16 @@ func (c *Controller) Subscribe(req *api.SubscribeRequest, response *api.Response
 	return sr.Subscribe(req, response)
 }
 
+func (c *Controller) Switch(name api.ProcessName) error {
+	c.srMu.RLock()
+	sr := c.sr
+	c.srMu.RUnlock()
+	if sr == nil {
+		return errors.New("terminal runner not initialized")
+	}
+	return sr.Switch(name)
+}
+
 func (c *Controller) State() (*api.TerminalStatusMode, error) {
 	c.srMu.RLock()
 	sr := c.sr

--- a/internal/terminal/controller_fake.go
+++ b/internal/terminal/controller_fake.go
@@ -39,6 +39,7 @@ type ControllerTest struct {
 	StopFunc      func(args *api.StopArgs) error
 	WriteFunc     func(req *api.WriteRequest) error
 	SubscribeFunc func(req *api.SubscribeRequest, response *api.ResponseWithFD) error
+	SwitchFunc    func(name api.ProcessName) error
 }
 
 func (f *ControllerTest) Run(spec *api.TerminalSpec) error {
@@ -128,6 +129,13 @@ func (f *ControllerTest) Write(req *api.WriteRequest) error {
 func (f *ControllerTest) Subscribe(req *api.SubscribeRequest, response *api.ResponseWithFD) error {
 	if f.SubscribeFunc != nil {
 		return f.SubscribeFunc(req, response)
+	}
+	return errdefs.ErrFuncNotSet
+}
+
+func (f *ControllerTest) Switch(name api.ProcessName) error {
+	if f.SwitchFunc != nil {
+		return f.SwitchFunc(name)
 	}
 	return errdefs.ErrFuncNotSet
 }

--- a/internal/terminal/terminalrpc/rpc_server.go
+++ b/internal/terminal/terminalrpc/rpc_server.go
@@ -73,3 +73,7 @@ func (s *TerminalControllerRPC) Write(req *api.WriteRequest, _ *api.Empty) error
 func (s *TerminalControllerRPC) Subscribe(req *api.SubscribeRequest, response *api.ResponseWithFD) error {
 	return s.Core.Subscribe(req, response)
 }
+
+func (s *TerminalControllerRPC) Switch(req *api.SwitchRequest, _ *api.Empty) error {
+	return s.Core.Switch(req.Name)
+}

--- a/internal/terminal/terminalrunner/errors.go
+++ b/internal/terminal/terminalrunner/errors.go
@@ -24,6 +24,10 @@ var (
 	ErrPipeRead  error = errors.New("could not read pipe->pipe")
 )
 
+// ErrUnknownProcess is returned by Switch when the requested process name does
+// not match any spawned process in the running terminal's spec.
+var ErrUnknownProcess = errors.New("unknown process")
+
 // errTerminalClosing is returned by Subscribe (and any future post-Close
 // RPC handler) when the runner has observed ctx cancel and refuses to
 // register a new attacher. Package-private — callers across the RPC

--- a/internal/terminal/terminalrunner/processes.go
+++ b/internal/terminal/terminalrunner/processes.go
@@ -36,6 +36,11 @@ import (
 // the PTY reader's buffer size in terminal.go.
 const processDrainBufSize = 8192
 
+// processInputBufSize is the read buffer used by the operator-input relay when
+// copying the attach session's input into the current process's socket.
+// Matches the PTY writer's buffer size in terminal.go.
+const processInputBufSize = 4096
+
 // procState holds the runtime state for one supervised process spawned from a
 // non-empty TerminalSpec.Processes. Each process runs with socketpair stdio
 // (not a PTY); the parent end is drained into the process's capture file by a
@@ -97,6 +102,20 @@ func (sr *Exec) startProcesses() error {
 		return errors.New("startProcesses called with empty Spec.Processes")
 	}
 
+	// The operator's attach session focuses the first process in spec order
+	// (declaration order, independent of Turn) until a Switch RPC moves it.
+	// Set current before any drain goroutine starts so the per-read
+	// "am I current?" check never races an unset value.
+	sr.processesMu.Lock()
+	sr.current = api.ProcessName(specs[0].Name)
+	sr.processesMu.Unlock()
+
+	// Wire the operator IO relay before spawning so each process's drain can
+	// mirror its socket onto the attach session the moment it produces output.
+	if err := sr.setupProcessOperatorIO(); err != nil {
+		return err
+	}
+
 	for _, turn := range orderedTurns(specs) {
 		group := processesWithTurn(specs, turn)
 		if err := sr.spawnGroup(turn, group); err != nil {
@@ -104,6 +123,112 @@ func (sr *Exec) startProcesses() error {
 		}
 	}
 	return nil
+}
+
+// setupProcessOperatorIO wires the operator-facing IO plumbing for the
+// process-set path, mirroring startPty's ptyPipes setup so the existing attach
+// handler (connections.go) and Subscribe path work unchanged:
+//
+//   - pipeInW receives the operator's input (written by the attach handler);
+//     relayOperatorInput drains pipeInR into whichever process is current.
+//   - multiOutW fans the current process's output out to attachers and
+//     subscribers. Unlike the single-child path there is no always-on capture
+//     writer here — each process drains to its own capture file, so the
+//     operator sink is purely the live multiplex.
+func (sr *Exec) setupProcessOperatorIO() error {
+	pipeInR, pipeInW, err := os.Pipe()
+	if err != nil {
+		return fmt.Errorf("open process input pipe: %w", err)
+	}
+	multiOutW := NewDynamicMultiWriter(sr.logger)
+
+	sr.ptyPipesMu.Lock()
+	if sr.ptyPipes == nil {
+		sr.ptyPipes = &ptyPipes{}
+	}
+	sr.ptyPipes.pipeInR = pipeInR
+	sr.ptyPipes.pipeInW = pipeInW
+	sr.ptyPipes.multiOutW = multiOutW
+	sr.ptyPipesMu.Unlock()
+
+	go sr.relayOperatorInput(pipeInR)
+	return nil
+}
+
+// relayOperatorInput copies the operator's input stream (pipeInR, fed by the
+// attach handler via pipeInW) into the current process's socket. The target is
+// re-resolved on every chunk under processesMu, so a Switch RPC redirects
+// subsequent input atomically. The relay exits when the runner's context is
+// canceled (the ctx watcher closes pipeInR, unblocking the Read).
+func (sr *Exec) relayOperatorInput(pipeInR *os.File) {
+	go func() {
+		<-sr.ctx.Done()
+		_ = pipeInR.Close()
+	}()
+
+	buf := make([]byte, processInputBufSize)
+	for {
+		n, errRead := pipeInR.Read(buf)
+		if n > 0 {
+			sr.processesMu.Lock()
+			target := sr.currentProcessLocked()
+			sr.processesMu.Unlock()
+			// Resolve-then-write outside the lock: a closed parentEnd (the
+			// target exited between resolve and write) surfaces as a write
+			// error we log and move past rather than holding processesMu
+			// across a blocking write.
+			if target != nil {
+				if _, errWrite := target.parentEnd.Write(buf[:n]); errWrite != nil {
+					sr.logger.Debug("operator input write to process failed",
+						"process", target.spec.Name, "err", errWrite)
+				}
+			}
+		}
+		if errRead != nil {
+			if !errors.Is(errRead, io.EOF) && !errors.Is(errRead, os.ErrClosed) {
+				sr.logger.Debug("operator input relay read ended", "err", errRead)
+			}
+			return
+		}
+	}
+}
+
+// Switch focuses the operator's attach session on the named process. It
+// validates the name against the spawned processes and atomically swaps the
+// relay target under processesMu; an unknown name is rejected with a wrapped
+// ErrUnknownProcess and leaves the current focus unchanged.
+func (sr *Exec) Switch(name api.ProcessName) error {
+	sr.processesMu.Lock()
+	defer sr.processesMu.Unlock()
+	for _, c := range sr.processes {
+		if api.ProcessName(c.spec.Name) == name {
+			sr.current = name
+			sr.logger.Info("switched current process", "process", name)
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: %q", ErrUnknownProcess, name)
+}
+
+// currentProcessLocked returns the procState that currently owns the operator
+// focus, or nil if none matches (e.g. before startProcesses set current).
+// Callers must hold processesMu.
+func (sr *Exec) currentProcessLocked() *procState {
+	for _, c := range sr.processes {
+		if api.ProcessName(c.spec.Name) == sr.current {
+			return c
+		}
+	}
+	return nil
+}
+
+// isCurrentProcess reports whether name holds the operator focus. It reads
+// sr.current under processesMu — the same lock Switch takes — so a drain
+// goroutine's per-read focus check serializes against a concurrent Switch.
+func (sr *Exec) isCurrentProcess(name string) bool {
+	sr.processesMu.Lock()
+	defer sr.processesMu.Unlock()
+	return sr.current == api.ProcessName(name)
 }
 
 // orderedTurns returns the distinct Turn values present in specs, ascending.
@@ -249,6 +374,17 @@ func (sr *Exec) openProcessCapture(spec api.ProcessSpec) (*os.File, error) {
 func (sr *Exec) drainProcess(c *procState) {
 	defer c.closeCapture()
 
+	// Snapshot the operator output fan-out once. It is wired by
+	// setupProcessOperatorIO before any drain goroutine starts and never
+	// reassigned, so a single read here is safe and avoids per-iteration
+	// lock traffic on ptyPipesMu.
+	sr.ptyPipesMu.RLock()
+	var operatorOut *DynamicMultiWriter
+	if sr.ptyPipes != nil {
+		operatorOut = sr.ptyPipes.multiOutW
+	}
+	sr.ptyPipesMu.RUnlock()
+
 	// Closing parentEnd unblocks a still-running Read so the drain goroutine
 	// exits on Close even if the process is still alive. The watcher waits on
 	// whichever comes first — runner Close (ctx cancel) or the drain returning
@@ -268,8 +404,8 @@ func (sr *Exec) drainProcess(c *procState) {
 	buf := make([]byte, processDrainBufSize)
 	for {
 		n, errRead := c.parentEnd.Read(buf)
-		if n > 0 && c.captureFile != nil {
-			if _, errWrite := c.captureFile.Write(buf[:n]); errWrite != nil {
+		if n > 0 {
+			if errWrite := sr.writeProcessChunk(c, operatorOut, buf[:n]); errWrite != nil {
 				sr.logger.Error("process capture write error", "process", c.spec.Name, "err", errWrite)
 				return
 			}
@@ -283,6 +419,28 @@ func (sr *Exec) drainProcess(c *procState) {
 			return
 		}
 	}
+}
+
+// writeProcessChunk persists one drained chunk to the process's capture file
+// and, when the process currently holds the operator focus, mirrors it onto the
+// attach session. isCurrentProcess reads sr.current under processesMu — the
+// same lock Switch takes — so a focus change serializes against this per-chunk
+// decision and the operator output flips atomically at buffer granularity. Only
+// a failed capture write is returned (the drain's durable sink is gone, so it
+// must stop); a failed operator-mirror write is non-fatal because the capture
+// file remains and DynamicMultiWriter already prunes a single stale attacher.
+func (sr *Exec) writeProcessChunk(c *procState, operatorOut *DynamicMultiWriter, p []byte) error {
+	if c.captureFile != nil {
+		if _, err := c.captureFile.Write(p); err != nil {
+			return err
+		}
+	}
+	if operatorOut != nil && sr.isCurrentProcess(c.spec.Name) {
+		if _, err := operatorOut.Write(p); err != nil {
+			sr.logger.Debug("operator mirror write ended", "process", c.spec.Name, "err", err)
+		}
+	}
+	return nil
 }
 
 // watchProcessExit observes the process's exit and records the cause on the

--- a/internal/terminal/terminalrunner/processes_switch_test.go
+++ b/internal/terminal/terminalrunner/processes_switch_test.go
@@ -1,0 +1,273 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrunner
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// syncBuf is a goroutine-safe io.Writer used as a stand-in operator attacher on
+// the process-set fan-out: the supervisor's mirror goroutine writes to it while
+// the test goroutine inspects what arrived.
+type syncBuf struct {
+	mu sync.Mutex
+	b  []byte
+}
+
+func (s *syncBuf) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.b = append(s.b, p...)
+	return len(p), nil
+}
+
+func (s *syncBuf) bytes() []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]byte(nil), s.b...)
+}
+
+func (s *syncBuf) len() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.b)
+}
+
+// testOperatorPipes returns the operator-facing input pipe and output fan-out
+// that startProcesses wired, failing the test if the relay was not set up.
+func (sr *Exec) testOperatorPipes(t *testing.T) (*os.File, *DynamicMultiWriter) {
+	t.Helper()
+	sr.ptyPipesMu.RLock()
+	defer sr.ptyPipesMu.RUnlock()
+	if sr.ptyPipes == nil || sr.ptyPipes.pipeInW == nil || sr.ptyPipes.multiOutW == nil {
+		t.Fatal("operator IO not wired by startProcesses")
+	}
+	return sr.ptyPipes.pipeInW, sr.ptyPipes.multiOutW
+}
+
+// waitUntil polls cond until it holds or processTestTimeout elapses.
+func waitUntil(t *testing.T, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(processTestTimeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("condition not met within %s: %s", processTestTimeout, msg)
+}
+
+// TestStartProcesses_CurrentDefaultsToFirstInSpecOrder asserts the operator
+// focus initializes to the first process in declaration order, independent of
+// ProcessSpec.Turn (here the first-declared process has the highest turn, so a
+// turn-ordered default would pick the wrong one).
+func TestStartProcesses_CurrentDefaultsToFirstInSpecOrder(t *testing.T) {
+	sr := newProcessesTestExec(t, []api.ProcessSpec{
+		{Name: "first", Command: "/bin/sh", CommandArgs: []string{"-c", "sleep 0.05"}, Turn: 5},
+		{Name: "second", Command: "/bin/sh", CommandArgs: []string{"-c", "sleep 0.05"}, Turn: 0},
+	})
+	if err := sr.startProcesses(); err != nil {
+		t.Fatalf("startProcesses: %v", err)
+	}
+
+	sr.processesMu.Lock()
+	got := sr.current
+	sr.processesMu.Unlock()
+	if got != "first" {
+		t.Fatalf("current = %q; want %q (first in spec order, not lowest turn)", got, "first")
+	}
+}
+
+// TestSwitch_InvalidNameRejected asserts Switch validates the process name and
+// rejects an unknown one with a wrapped ErrUnknownProcess, leaving the current
+// focus unchanged.
+func TestSwitch_InvalidNameRejected(t *testing.T) {
+	sr := newProcessesTestExec(t, []api.ProcessSpec{
+		{Name: "a", Command: "/bin/sh", CommandArgs: []string{"-c", "sleep 0.05"}},
+	})
+	if err := sr.startProcesses(); err != nil {
+		t.Fatalf("startProcesses: %v", err)
+	}
+
+	err := sr.Switch("ghost")
+	if !errors.Is(err, ErrUnknownProcess) {
+		t.Fatalf("Switch(ghost) error = %v; want wrapped ErrUnknownProcess", err)
+	}
+
+	sr.processesMu.Lock()
+	got := sr.current
+	sr.processesMu.Unlock()
+	if got != "a" {
+		t.Fatalf("current = %q after rejected switch; want unchanged %q", got, "a")
+	}
+}
+
+// TestSwitch_OutputFollowsFocus asserts that only the current process's output
+// reaches the operator while non-current processes keep draining to their own
+// capture files, and that Switch flips which process the operator sees.
+func TestSwitch_OutputFollowsFocus(t *testing.T) {
+	dir := t.TempDir()
+	capA := filepath.Join(dir, "a.cap")
+	capB := filepath.Join(dir, "b.cap")
+
+	// Two self-emitting processes so a non-current process is actively
+	// producing output (the case that exercises operator-side isolation).
+	sr := newProcessesTestExec(t, []api.ProcessSpec{
+		{
+			Name:        "a",
+			Command:     "/bin/sh",
+			CommandArgs: []string{"-c", "while :; do printf A; sleep 0.02; done"},
+			CaptureFile: capA,
+		},
+		{
+			Name:        "b",
+			Command:     "/bin/sh",
+			CommandArgs: []string{"-c", "while :; do printf B; sleep 0.02; done"},
+			CaptureFile: capB,
+		},
+	})
+	if err := sr.startProcesses(); err != nil {
+		t.Fatalf("startProcesses: %v", err)
+	}
+
+	_, multiOutW := sr.testOperatorPipes(t)
+	sink := &syncBuf{}
+	multiOutW.Add(sink)
+
+	// current == a: the operator must see only 'A', never 'B' from the
+	// non-current process.
+	waitUntil(t, func() bool { return sink.len() > 0 }, "operator received initial output")
+	time.Sleep(60 * time.Millisecond) // a few emit cycles
+	if got := sink.bytes(); bytes.ContainsRune(got, 'B') {
+		t.Fatalf("operator saw 'B' from non-current process while a is current: %q", got)
+	}
+
+	if err := sr.Switch("b"); err != nil {
+		t.Fatalf("Switch(b): %v", err)
+	}
+
+	// After the switch the operator must start seeing 'B'. Once a 'B' has
+	// landed, every subsequent byte must be 'B' — the now-non-current 'a'
+	// must no longer reach the operator.
+	waitUntil(t, func() bool { return bytes.ContainsRune(sink.bytes(), 'B') },
+		"operator received b output after switch")
+	mark := sink.len()
+	time.Sleep(60 * time.Millisecond)
+	tail := sink.bytes()[mark:]
+	if len(tail) == 0 {
+		t.Fatal("operator received no output after switch settled")
+	}
+	if bytes.ContainsRune(tail, 'A') {
+		t.Fatalf("operator saw 'A' from non-current process after switch: %q", tail)
+	}
+
+	// Both processes drain to their own capture files regardless of focus.
+	waitUntil(t, func() bool {
+		a, _ := os.ReadFile(capA)
+		b, _ := os.ReadFile(capB)
+		return len(a) > 0 && len(b) > 0
+	}, "both capture files received output independent of focus")
+}
+
+// TestSwitch_InputFollowsFocus asserts operator input is delivered only to the
+// current process, and that Switch redirects subsequent input. Each process is
+// a cat that echoes its stdin to stdout (drained into its capture file), so the
+// capture files are a faithful record of what input each process received.
+func TestSwitch_InputFollowsFocus(t *testing.T) {
+	dir := t.TempDir()
+	capA := filepath.Join(dir, "a.cap")
+	capB := filepath.Join(dir, "b.cap")
+
+	sr := newProcessesTestExec(t, []api.ProcessSpec{
+		{Name: "a", Command: "/bin/cat", CaptureFile: capA},
+		{Name: "b", Command: "/bin/cat", CaptureFile: capB},
+	})
+	if err := sr.startProcesses(); err != nil {
+		t.Fatalf("startProcesses: %v", err)
+	}
+	pipeInW, _ := sr.testOperatorPipes(t)
+
+	// current == a: input reaches a only.
+	if _, err := pipeInW.WriteString("to-a"); err != nil {
+		t.Fatalf("write to-a: %v", err)
+	}
+	waitCapture(t, capA, "to-a")
+	if b, _ := os.ReadFile(capB); len(b) != 0 {
+		t.Fatalf("process b capture = %q; want empty while a is current", b)
+	}
+
+	// Switch to b: subsequent input reaches b only; a's record is unchanged.
+	if err := sr.Switch("b"); err != nil {
+		t.Fatalf("Switch(b): %v", err)
+	}
+	if _, err := pipeInW.WriteString("to-b"); err != nil {
+		t.Fatalf("write to-b: %v", err)
+	}
+	waitCapture(t, capB, "to-b")
+	waitCapture(t, capA, "to-a")
+}
+
+// TestSwitch_ConcurrentSwitchAndInput drives Switch and operator input
+// concurrently. It is a race-detector guard: the focus state is shared between
+// the Switch caller, the input relay, and the drain goroutines, all under
+// processesMu. Every Switch onto a valid name must succeed.
+func TestSwitch_ConcurrentSwitchAndInput(t *testing.T) {
+	dir := t.TempDir()
+	sr := newProcessesTestExec(t, []api.ProcessSpec{
+		{Name: "a", Command: "/bin/cat", CaptureFile: filepath.Join(dir, "a.cap")},
+		{Name: "b", Command: "/bin/cat", CaptureFile: filepath.Join(dir, "b.cap")},
+	})
+	if err := sr.startProcesses(); err != nil {
+		t.Fatalf("startProcesses: %v", err)
+	}
+	pipeInW, _ := sr.testOperatorPipes(t)
+
+	const iters = 300
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		names := []api.ProcessName{"a", "b"}
+		for i := range iters {
+			if err := sr.Switch(names[i%2]); err != nil {
+				t.Errorf("Switch(%q): %v", names[i%2], err)
+				return
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iters {
+			if _, err := pipeInW.WriteString("x"); err != nil {
+				t.Errorf("operator write: %v", err)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+}

--- a/internal/terminal/terminalrunner/terminal_runner.go
+++ b/internal/terminal/terminalrunner/terminal_runner.go
@@ -48,4 +48,8 @@ type TerminalRunner interface {
 	Metadata() (*api.TerminalDoc, error)
 	WritePTY(data []byte) error
 	Subscribe(req *api.SubscribeRequest, response *api.ResponseWithFD) error
+	// Switch focuses the operator's attach session on the named supervised
+	// process (process-set path only). Validates the name against the
+	// spawned processes; an unknown name is rejected with a wrapped error.
+	Switch(name api.ProcessName) error
 }

--- a/internal/terminal/terminalrunner/terminal_runner_exec.go
+++ b/internal/terminal/terminalrunner/terminal_runner_exec.go
@@ -53,6 +53,14 @@ type Exec struct {
 	processes   []*procState
 	processesMu sync.Mutex
 
+	// current names the supervised process whose socket is mirrored onto the
+	// operator's attach session (process-set path only). It defaults to the
+	// first process in spec order at startProcesses time and is moved by the
+	// Switch RPC. Guarded by processesMu — the same lock that protects the
+	// processes slice — so a Switch and a drain/relay goroutine's
+	// "am I current?" check serialize against each other.
+	current api.ProcessName
+
 	gates struct {
 		StdinOpen bool
 		OutputOn  bool

--- a/internal/terminal/terminalrunner/terminal_runner_fake.go
+++ b/internal/terminal/terminalrunner/terminal_runner_fake.go
@@ -44,6 +44,7 @@ type Test struct {
 	PostAttachShellFunc func() error
 	WritePTYFunc        func(data []byte) error
 	SubscribeFunc       func(req *api.SubscribeRequest, response *api.ResponseWithFD) error
+	SwitchFunc          func(name api.ProcessName) error
 }
 
 func NewTerminalRunnerTest(_ context.Context) TerminalRunner {
@@ -164,6 +165,13 @@ func (sr *Test) WritePTY(data []byte) error {
 func (sr *Test) Subscribe(req *api.SubscribeRequest, response *api.ResponseWithFD) error {
 	if sr.SubscribeFunc != nil {
 		return sr.SubscribeFunc(req, response)
+	}
+	return errdefs.ErrFuncNotSet
+}
+
+func (sr *Test) Switch(name api.ProcessName) error {
+	if sr.SwitchFunc != nil {
+		return sr.SwitchFunc(name)
 	}
 	return errdefs.ErrFuncNotSet
 }

--- a/pkg/api/terminal.go
+++ b/pkg/api/terminal.go
@@ -37,6 +37,10 @@ type TerminalController interface {
 	Stop(args *StopArgs) error
 	Write(req *WriteRequest) error
 	Subscribe(req *SubscribeRequest, reply *ResponseWithFD) error
+	// Switch focuses the operator's attach session on the named supervised
+	// process. The name must match a ProcessSpec.Name in the running
+	// terminal's spec; an unknown name is rejected with a wrapped error.
+	Switch(name ProcessName) error
 }
 
 type TerminalDoc struct {
@@ -126,6 +130,11 @@ type TerminalSpec struct {
 	// supervisor behavior that consumes this list (spawn, drain, gating,
 	// switch, replay, lifecycle) ships in later phases of the supervisor
 	// series; phase 1 introduces the schema only.
+	//
+	// The first process in this slice (declaration order, independent of
+	// ProcessSpec.Turn) is the supervisor's initially-focused process: the
+	// operator's attach session relays IO to it until a Switch RPC moves the
+	// focus elsewhere.
 	Processes []ProcessSpec `json:"processes,omitempty" yaml:"processes,omitempty"`
 
 	// CyclePrefix is the byte sequence the attach client interprets as the
@@ -141,6 +150,11 @@ type TerminalSpec struct {
 	// Validate.
 	SwitchReplayBytes int `json:"switchReplayBytes,omitempty" yaml:"switchReplayBytes,omitempty"`
 }
+
+// ProcessName identifies a supervised process by its ProcessSpec.Name. The
+// Switch RPC and the supervisor's current-process state address processes by
+// this name.
+type ProcessName string
 
 // ProcessSpec declares one process supervised by a TerminalSpec whose
 // Processes list is non-empty. Each process is spawned with its own Command +
@@ -306,6 +320,7 @@ const (
 	TerminalMethodStop      = TerminalService + ".Stop"
 	TerminalMethodWrite     = TerminalService + ".Write"
 	TerminalMethodSubscribe = TerminalService + ".Subscribe"
+	TerminalMethodSwitch    = TerminalService + ".Switch"
 )
 
 type PingMessage struct {
@@ -326,6 +341,13 @@ type StopArgs struct {
 // caret notation or hex-escape interpretation.
 type WriteRequest struct {
 	Data []byte
+}
+
+// SwitchRequest names the supervised process the operator's attach session
+// should focus on. Name must match a ProcessSpec.Name in the running
+// terminal's spec; the supervisor rejects unknown names.
+type SwitchRequest struct {
+	Name ProcessName
 }
 
 // SubscribeRequest identifies the caller of a Subscribe RPC. ClientID

--- a/pkg/terminal/server/adapter.go
+++ b/pkg/terminal/server/adapter.go
@@ -117,3 +117,11 @@ func (a *rpcAdapter) Subscribe(req *api.SubscribeRequest, response *api.Response
 	}
 	return r.Subscribe(req, response)
 }
+
+func (a *rpcAdapter) Switch(name api.ProcessName) error {
+	r := a.srv.getRunner()
+	if r == nil {
+		return errors.New("server: terminal not running")
+	}
+	return r.Switch(name)
+}


### PR DESCRIPTION
## Summary

Phase 3 of the multi-process supervisor series (#276–#282), following #277/#285 (spawn + per-process capture drain). It introduces the "current process" multiplex: the supervisor relays operator IO to exactly one process's socket at a time, with a `Switch` RPC to move the focus.

- **Supervisor `current` state.** `Exec` gains a `current api.ProcessName` field guarded by the existing `processesMu` (the lock that already protects the `processes` slice), so a `Switch` and a drain/relay goroutine's "am I current?" check serialize against each other. `startProcesses` sets it to the **first process in spec declaration order** (independent of `Turn`) before any drain goroutine starts.
- **Operator IO relay (process path).** `startProcesses` now wires the same `ptyPipes` plumbing `startPty` uses (an input pipe + a `DynamicMultiWriter` fan-out), so the existing attach handler (`connections.go`) and `Subscribe` path work unchanged. A new `relayOperatorInput` goroutine copies the attach session's input into whichever process is current; each process's drain mirrors its output onto the fan-out **only while it holds the focus**. Non-current processes keep draining to their own capture files only. Unlike the single-child path there is no always-on capture writer on the operator fan-out — each process owns its capture file.
- **`Switch` RPC.** `terminalrpc.TerminalControllerRPC.Switch` validates the name against the spawned processes and atomically swaps the relay target under `processesMu`; an unknown name is rejected with a wrapped `ErrUnknownProcess` and leaves the focus unchanged. Replay-on-switch is **not** in this phase (phase 5) — the operator sees output as it arrives post-switch.

### Non-obvious calls (reviewer please push back)

- **Scope spilled beyond `terminalrunner` + `terminalrpc` for necessary glue.** The RPC server's `Core` is typed `api.TerminalController`, so reaching `s.Core.Switch(...)` required adding `Switch(name ProcessName) error` to that interface plus its three implementers (`Controller`, the `rpcAdapter` facade, and `ControllerTest`) and to the `TerminalRunner` interface + its fake. `api.ProcessName` (a `string` newtype) and `api.SwitchRequest` are new. The substantive logic still lives in `terminalrunner`; the rest is mechanical interface plumbing.
- **No RPC *client* method / CLI wiring in this PR.** The AC requires only that `terminalrpc.Switch` exist and validate, plus supervisor state + IO flip (tested at the runner level). The in-tty cycle key that drives `Switch` is phase 4 (#279); the rpcclient/CLI consumer is deferred to that phase to keep this PR scoped to the supervisor + RPC surface.
- **Process-set path is still not reachable through `Controller.Run`** — it rejects an empty top-level `Command` (`controller.go:120`, `ErrSpecCmdMissing`), unchanged since phase 2. Phase 3's behavior is exercised at the runner level (as phase 2's tests are); end-to-end controller wiring for the process path is a separate concern not in this issue's AC.
- **Atomicity granularity.** The focus check is per drained chunk (per `Read`), so the swap is atomic at buffer granularity — exactly the issue's "operator sees output as it arrives post-switch." `relayOperatorInput` resolves the target under the lock then writes outside it, so a target that exits between resolve and write surfaces as a logged write error rather than holding `processesMu` across a blocking write.

## Test plan

- [x] `make sbsh-sb` — builds `sbsh`/`sb`; binary is `ELF 64-bit LSB executable` (verified via ELF magic; `file` is not installed on the dev host).
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` — the CI unit-test command; all packages pass.
- [x] `go test -tags=integration ./cmd/sb/get/...` — the CI integration command.
- [x] `E2E_BIN_DIR=$(pwd) go test ./e2e` — the CI e2e job; passes.
- [x] `pre-commit run --files <changed>` — all hooks pass (golangci-lint included).
- [ ] `make test-race` / `go test -race` — **not run**: the dev host has no C compiler (`gcc`/`clang` absent), and `-race` requires cgo. CI's `test.yaml` runs the unit suite without `-race` (the `test-race` Makefile target is not in CI), so this matches CI. The new `TestSwitch_ConcurrentSwitchAndInput` is written as a race-detector guard for when the toolchain is present.

New tests (`internal/terminal/terminalrunner/processes_switch_test.go`):
- `TestStartProcesses_CurrentDefaultsToFirstInSpecOrder` — focus defaults to first-in-spec-order, not lowest `Turn`.
- `TestSwitch_InvalidNameRejected` — unknown name → wrapped `ErrUnknownProcess`, focus unchanged.
- `TestSwitch_OutputFollowsFocus` — only the current process's output reaches the operator; non-current (actively emitting) process is isolated to its capture; `Switch` flips the operator's view.
- `TestSwitch_InputFollowsFocus` — operator input reaches only the current process; `Switch` redirects subsequent input.
- `TestSwitch_ConcurrentSwitchAndInput` — concurrent `Switch` + operator input (race-detector guard).

## Acceptance criteria

- [x] `terminalrpc.Switch(name)` exists and validates the process name.
- [x] Supervisor maintains `current` state; defaults to first process in spec.
- [x] After `Switch(b)`, operator input is delivered to process `b` and `b`'s output reaches the operator.
- [x] Switch is race-free under concurrent input + output (serialized on `processesMu`; race-detector test added, see test-plan note re: cgo).
- [x] Unit tests: switch flips IO, invalid name rejected, concurrent switch + input.
- [x] `make sbsh-sb` + `make test` green.

Closes #278