### PR TITLE
fix: resolve reaper tracked exit reaped before RegisterChild

### DIFF
--- a/internal/terminal/terminalrunner/reaper_linux.go
+++ b/internal/terminal/terminalrunner/reaper_linux.go
@@ -45,6 +45,14 @@ type reaper struct {
 	trackedOnce    sync.Once
 	trackedExitCh  chan int // buffered 1; receives exit code for trackedPid
 	trackedStopped bool
+	// pendingExits records exit codes of children reaped before RegisterChild
+	// set trackedPid. startPty (and the tests) call RegisterChild *after*
+	// cmd.Start, so a fast-exiting child can be reaped here before its pid is
+	// known. Recording the exit lets a late RegisterChild still resolve the
+	// tracked exit instead of silently treating the child as an orphan and
+	// timing out on TrackedExitCh. Only populated while trackedPid == 0, so it
+	// is bounded to the (microsecond) pre-registration window.
+	pendingExits map[int]int
 }
 
 // newReaper constructs a reaper but does not start it. Call Start to install
@@ -93,6 +101,15 @@ func (r *reaper) RegisterChild(pid int) {
 		return
 	}
 	r.trackedPid = pid
+	// If the child already exited before we learned its pid, the reaper
+	// recorded its exit code in pendingExits; resolve the tracked exit now.
+	if code, ok := r.pendingExits[pid]; ok && !r.trackedStopped {
+		r.deliverTrackedExitLocked(code)
+		r.logger.Info("reaper: tracked child exited before registration", "pid", pid, "exit", code)
+	}
+	// Past registration, an unmatched reaped pid is a genuine orphan, so the
+	// recording window is closed; drop the map.
+	r.pendingExits = nil
 }
 
 // TrackedExitCh returns a channel that receives the exit code of the
@@ -130,30 +147,47 @@ func (r *reaper) drainOnce() int {
 }
 
 func (r *reaper) handleReaped(pid int, status syscall.WaitStatus) {
-	r.mu.Lock()
-	tracked := r.trackedPid
-	stopped := r.trackedStopped
-	r.mu.Unlock()
-
-	if tracked != 0 && pid == tracked && !stopped {
-		exitCode := status.ExitStatus()
-		if status.Signaled() {
-			// 128 + signal number is the shell-conventional encoding.
-			//nolint:mnd // shell-conventional encoding of signal death
-			exitCode = 128 + int(status.Signal())
-		}
-		r.trackedOnce.Do(func() {
-			r.mu.Lock()
-			r.trackedStopped = true
-			r.mu.Unlock()
-			r.trackedExitCh <- exitCode
-			close(r.trackedExitCh)
-		})
-		r.logger.Info("reaper: tracked child exited", "pid", pid, "exit", exitCode)
-		return
+	exitCode := status.ExitStatus()
+	if status.Signaled() {
+		// 128 + signal number is the shell-conventional encoding.
+		//nolint:mnd // shell-conventional encoding of signal death
+		exitCode = 128 + int(status.Signal())
 	}
 
-	r.logger.Debug("reaper: reaped orphan", "pid", pid, "status", status)
+	// The match/record decision is taken under a single lock so it cannot race
+	// RegisterChild: either we observe trackedPid and deliver, or we observe
+	// the pre-registration window and record for RegisterChild to resolve.
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	switch {
+	case r.trackedPid != 0 && pid == r.trackedPid && !r.trackedStopped:
+		r.deliverTrackedExitLocked(exitCode)
+		r.logger.Info("reaper: tracked child exited", "pid", pid, "exit", exitCode)
+	case r.trackedPid == 0:
+		// RegisterChild has not run yet, so this could be the tracked child
+		// reaped before its pid was registered. Record the exit; a late
+		// RegisterChild will resolve it.
+		if r.pendingExits == nil {
+			r.pendingExits = make(map[int]int)
+		}
+		r.pendingExits[pid] = exitCode
+		r.logger.Debug("reaper: recorded pre-registration exit", "pid", pid, "exit", exitCode)
+	default:
+		r.logger.Debug("reaper: reaped orphan", "pid", pid, "status", status)
+	}
+}
+
+// deliverTrackedExitLocked sends the tracked child's exit code on
+// trackedExitCh exactly once and closes the channel. The caller must hold
+// r.mu; the channel is buffered(1) and trackedOnce guards the single send, so
+// the send never blocks and holding the lock across it cannot deadlock.
+func (r *reaper) deliverTrackedExitLocked(exitCode int) {
+	r.trackedOnce.Do(func() {
+		r.trackedStopped = true
+		r.trackedExitCh <- exitCode
+		close(r.trackedExitCh)
+	})
 }
 
 func (r *reaper) loop() {

--- a/internal/terminal/terminalrunner/reaper_linux_test.go
+++ b/internal/terminal/terminalrunner/reaper_linux_test.go
@@ -98,3 +98,60 @@ func TestReaper_TrackedExitResolvesRace(t *testing.T) {
 	// Release to drop the os.Process handle cleanly.
 	_ = cmd.Process.Release()
 }
+
+// TestReaper_ExitBeforeRegisterResolves exercises the pre-registration window
+// deterministically: the child is reaped (into pendingExits) *before*
+// RegisterChild runs, then RegisterChild must still resolve the tracked exit.
+// This is the race TestReaper_TrackedExitResolvesRace only hits intermittently
+// under -race; here we drive drainOnce by hand instead of the signal loop so
+// the reap-before-register ordering is guaranteed rather than timing-dependent.
+func TestReaper_ExitBeforeRegisterResolves(t *testing.T) {
+	r := newReaper(discardLogger())
+	// Intentionally do not Start() the signal loop; drainOnce is driven
+	// directly below so registration provably loses the race.
+
+	cmd := exec.Command("/bin/sh", "-c", "exit 7")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	pid := cmd.Process.Pid
+
+	// Reap the child before registering. drainOnce records the exit in
+	// pendingExits because trackedPid is still 0.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		r.drainOnce()
+		r.mu.Lock()
+		_, ok := r.pendingExits[pid]
+		r.mu.Unlock()
+		if ok {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	r.mu.Lock()
+	_, recorded := r.pendingExits[pid]
+	r.mu.Unlock()
+	if !recorded {
+		t.Fatalf("child pid %d was not reaped into pendingExits before registration", pid)
+	}
+
+	// Late registration must resolve the recorded exit on TrackedExitCh.
+	r.RegisterChild(pid)
+
+	select {
+	case code, ok := <-r.TrackedExitCh():
+		if !ok {
+			t.Fatalf("TrackedExitCh closed without delivering a code")
+		}
+		if code != 7 {
+			t.Fatalf("tracked exit code = %d, want 7", code)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("RegisterChild after a pre-registration reap did not resolve the tracked exit")
+	}
+
+	_ = cmd.Process.Release()
+}


### PR DESCRIPTION
## Summary

`TestReaper_TrackedExitResolvesRace` was flaky (~1/30) under `-race` because the
fix it asserts didn't exist in the production reaper. `startPty`
(`terminal.go:180`) and the tests call `reaper.RegisterChild` *after*
`cmd.Start` (`terminal.go:148`), so a fast-exiting tracked child can be reaped
by the `SIGCHLD` drain loop before `trackedPid` is set. When that happened,
`handleReaped` saw `trackedPid == 0`, treated the pid as an orphan, and never
delivered on `TrackedExitCh` — the test's 3s `select` timed out. The same
register-after-start window exists in the real `startPty` path, not just the test.

This implements the issue's **suggested fix B** (record exit codes for
not-yet-registered pids), which the issue author flagged as "the more durable
option" because it also hardens the production window:

- `handleReaped` now records the exit code of any pid reaped while
  `trackedPid == 0` into a bounded `pendingExits` map (populated only during the
  pre-registration window).
- `RegisterChild` resolves immediately from `pendingExits` if the child already
  exited before its pid was known.
- The match/record decision is taken under a single `r.mu` acquisition so it
  cannot race `RegisterChild`. Delivery is extracted into
  `deliverTrackedExitLocked` (buffered-1 channel + `trackedOnce`, so the send
  never blocks under the lock).

A new deterministic test, `TestReaper_ExitBeforeRegisterResolves`, drives
`drainOnce` by hand to force the reap-before-register ordering (rather than
relying on `-race` timing), proving a late `RegisterChild` resolves the recorded
exit.

### Why fix B over fix A (test-only)

Fix A (block the child until after `RegisterChild`) would have made the test
pass by *avoiding* the race — but `TestReaper_TrackedExitResolvesRace` is named
and documented to verify the reaper *resolves* the race, so fix A defeats the
test's stated purpose and leaves the identical latent window in production
`startPty`. Fix B makes the asserted behavior real and is the author's
recommended option. Documented here so the reviewer can push back if the
broader-than-test-only blast radius oversteps.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/terminal/terminalrunner/...`
- [x] `make sbsh-sb` (verified ELF output for `sbsh` and `sb`)
- [x] `make test` (full CI target, incl. e2e)
- [x] `make test-race` (race target — directly relevant to this fix)
- [x] 30× `go test -race -count=1 -run TestReaper ./internal/terminal/terminalrunner/...` — 0 failures (was ~1/30 before)

Closes #286