### PR TITLE
feat(server): custom RPC handler registration on pkg/terminal/server

### DIFF
--- a/internal/terminal/controller_test.go
+++ b/internal/terminal/controller_test.go
@@ -156,7 +156,7 @@ func Test_ErrStartRPCServer(t *testing.T) {
 			OpenSocketCtrlFunc: func() error {
 				return nil
 			},
-			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error) {
+			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error, _ ...terminalrpc.ExtraHandler) {
 				readyCh <- errors.New("make server fail")
 			},
 		}
@@ -197,7 +197,7 @@ func Test_ErrStartTerminal(t *testing.T) {
 			OpenSocketCtrlFunc: func() error {
 				return nil
 			},
-			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error) {
+			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error, _ ...terminalrpc.ExtraHandler) {
 				readyCh <- nil
 			},
 			StartTerminalFunc: func(_ chan<- terminalrunner.Event) error {
@@ -239,7 +239,7 @@ func Test_ErrSetupShell(t *testing.T) {
 			OpenSocketCtrlFunc: func() error {
 				return nil
 			},
-			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error) {
+			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error, _ ...terminalrpc.ExtraHandler) {
 				readyCh <- nil
 			},
 			StartTerminalFunc: func(_ chan<- terminalrunner.Event) error {
@@ -284,7 +284,7 @@ func Test_ErrInitShell(t *testing.T) {
 			OpenSocketCtrlFunc: func() error {
 				return nil
 			},
-			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error) {
+			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error, _ ...terminalrpc.ExtraHandler) {
 				readyCh <- nil
 			},
 			StartTerminalFunc: func(_ chan<- terminalrunner.Event) error {
@@ -332,7 +332,7 @@ func Test_ErrContextDone(t *testing.T) {
 			OpenSocketCtrlFunc: func() error {
 				return nil
 			},
-			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error) {
+			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error, _ ...terminalrpc.ExtraHandler) {
 				readyCh <- nil
 			},
 			StartTerminalFunc: func(_ chan<- terminalrunner.Event) error {
@@ -384,7 +384,7 @@ func Test_ErrRPCServerExited(t *testing.T) {
 			OpenSocketCtrlFunc: func() error {
 				return nil
 			},
-			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error) {
+			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error, _ ...terminalrpc.ExtraHandler) {
 				readyCh <- nil
 			},
 			StartTerminalFunc: func(_ chan<- terminalrunner.Event) error {
@@ -435,7 +435,7 @@ func Test_WaitReady(t *testing.T) {
 			OpenSocketCtrlFunc: func() error {
 				return nil
 			},
-			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error) {
+			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error, _ ...terminalrpc.ExtraHandler) {
 				readyCh <- nil
 			},
 			StartTerminalFunc: func(_ chan<- terminalrunner.Event) error {
@@ -492,7 +492,7 @@ func Test_ErrCloseReq(t *testing.T) {
 			OpenSocketCtrlFunc: func() error {
 				return nil
 			},
-			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error) {
+			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error, _ ...terminalrpc.ExtraHandler) {
 				readyCh <- nil
 			},
 			StartTerminalFunc: func(_ chan<- terminalrunner.Event) error {
@@ -547,7 +547,7 @@ func Test_HandleEvent_EvCmdExited(t *testing.T) {
 			OpenSocketCtrlFunc: func() error {
 				return nil
 			},
-			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error) {
+			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error, _ ...terminalrpc.ExtraHandler) {
 				readyCh <- nil
 			},
 			StartTerminalFunc: func(_ chan<- terminalrunner.Event) error {
@@ -608,7 +608,7 @@ func Test_HandleEvent_EvError(_ *testing.T) {
 			OpenSocketCtrlFunc: func() error {
 				return nil
 			},
-			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error) {
+			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error, _ ...terminalrpc.ExtraHandler) {
 				readyCh <- nil
 			},
 			StartTerminalFunc: func(_ chan<- terminalrunner.Event) error {
@@ -667,7 +667,7 @@ func Test_TerminalState_Initializing(t *testing.T) {
 			OpenSocketCtrlFunc: func() error {
 				return nil
 			},
-			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error) {
+			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error, _ ...terminalrpc.ExtraHandler) {
 				readyCh <- nil
 			},
 			StartTerminalFunc: func(_ chan<- terminalrunner.Event) error {
@@ -746,7 +746,7 @@ func Test_TerminalState_Starting(t *testing.T) {
 			OpenSocketCtrlFunc: func() error {
 				return nil
 			},
-			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error) {
+			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error, _ ...terminalrpc.ExtraHandler) {
 				readyCh <- nil
 			},
 			StartTerminalFunc: func(_ chan<- terminalrunner.Event) error {
@@ -826,7 +826,7 @@ func Test_TerminalState_SettingUp(t *testing.T) {
 			OpenSocketCtrlFunc: func() error {
 				return nil
 			},
-			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error) {
+			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error, _ ...terminalrpc.ExtraHandler) {
 				readyCh <- nil
 			},
 			StartTerminalFunc: func(_ chan<- terminalrunner.Event) error {
@@ -903,7 +903,7 @@ func Test_TerminalState_Ready(t *testing.T) {
 			OpenSocketCtrlFunc: func() error {
 				return nil
 			},
-			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error) {
+			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error, _ ...terminalrpc.ExtraHandler) {
 				readyCh <- nil
 			},
 			StartTerminalFunc: func(_ chan<- terminalrunner.Event) error {
@@ -982,7 +982,7 @@ func Test_TerminalState_OnInit(t *testing.T) {
 			OpenSocketCtrlFunc: func() error {
 				return nil
 			},
-			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error) {
+			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error, _ ...terminalrpc.ExtraHandler) {
 				readyCh <- nil
 			},
 			StartTerminalFunc: func(_ chan<- terminalrunner.Event) error {
@@ -1059,7 +1059,7 @@ func Test_TerminalState_Exited(t *testing.T) {
 			OpenSocketCtrlFunc: func() error {
 				return nil
 			},
-			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error) {
+			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error, _ ...terminalrpc.ExtraHandler) {
 				readyCh <- nil
 			},
 			StartTerminalFunc: func(_ chan<- terminalrunner.Event) error {
@@ -1147,7 +1147,7 @@ func Test_TerminalState_PostAttach(t *testing.T) {
 			OpenSocketCtrlFunc: func() error {
 				return nil
 			},
-			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error) {
+			StartServerFunc: func(_ context.Context, _ *terminalrpc.TerminalControllerRPC, readyCh chan error, _ chan error, _ ...terminalrpc.ExtraHandler) {
 				readyCh <- nil
 			},
 			StartTerminalFunc: func(_ chan<- terminalrunner.Event) error {

--- a/internal/terminal/terminalrpc/rpc_server.go
+++ b/internal/terminal/terminalrpc/rpc_server.go
@@ -22,6 +22,20 @@ type TerminalControllerRPC struct {
 	Core api.TerminalController
 }
 
+// ExtraHandler is a custom JSON-RPC service registered alongside the
+// built-in TerminalController on the same listener. Name is the
+// net/rpc service name (the part before the dot in a "Service.Method"
+// wire call); Receiver is any value whose exported methods follow
+// net/rpc's signature scheme: func(args T1, reply *T2) error. Custom
+// services are namespaced by Name, so their methods never collide with
+// the built-in TerminalController methods; a Name equal to an
+// already-registered service (including the built-in one) is rejected
+// at registration by net/rpc.
+type ExtraHandler struct {
+	Name     string
+	Receiver any
+}
+
 func (s *TerminalControllerRPC) Ping(in *api.PingMessage, out *api.PingMessage) error {
 	pong, err := s.Core.Ping(in)
 	if err != nil {

--- a/internal/terminal/terminalrunner/control_server.go
+++ b/internal/terminal/terminalrunner/control_server.go
@@ -32,6 +32,7 @@ func (sr *Exec) StartServer(
 	sc *terminalrpc.TerminalControllerRPC,
 	readyCh chan error,
 	doneCh chan error,
+	extra ...terminalrpc.ExtraHandler,
 ) {
 	// Ensure ln is closed and no leaks on exit
 	defer func() {
@@ -58,6 +59,23 @@ func (sr *Exec) StartServer(
 		}
 		close(doneCh)
 		return
+	}
+	// Register embedder-supplied custom verbs on the same server, after
+	// the built-in service so a custom Name colliding with it is
+	// rejected by net/rpc ("service already defined"). Method-level
+	// collisions are impossible: net/rpc dispatches by full
+	// "Service.Method", and these live under distinct service names.
+	for _, h := range extra {
+		if err := srv.RegisterName(h.Name, h.Receiver); err != nil {
+			readyCh <- err
+			close(readyCh)
+			select {
+			case doneCh <- err:
+			default:
+			}
+			close(doneCh)
+			return
+		}
 	}
 	// Signal: the accept loop is about to run on an already-listening socket.
 	readyCh <- nil

--- a/internal/terminal/terminalrunner/terminal_runner.go
+++ b/internal/terminal/terminalrunner/terminal_runner.go
@@ -34,7 +34,13 @@ type TerminalRunner interface {
 	// from ln.Addr() so on-disk permissions match the OpenSocketCtrl
 	// path; callers do not re-implement the chmod/chown dance.
 	UseListener(ln net.Listener) error
-	StartServer(ctx context.Context, sc *terminalrpc.TerminalControllerRPC, readyCh chan error, doneCh chan error)
+	StartServer(
+		ctx context.Context,
+		sc *terminalrpc.TerminalControllerRPC,
+		readyCh chan error,
+		doneCh chan error,
+		extra ...terminalrpc.ExtraHandler,
+	)
 	StartTerminal(evCh chan<- Event) error
 	ID() api.ID
 	Close(reason error) error

--- a/internal/terminal/terminalrunner/terminal_runner_fake.go
+++ b/internal/terminal/terminalrunner/terminal_runner_fake.go
@@ -30,7 +30,7 @@ type Test struct {
 	mu                  sync.RWMutex // protects function pointer fields
 	OpenSocketCtrlFunc  func() error
 	UseListenerFunc     func(ln net.Listener) error
-	StartServerFunc     func(ctx context.Context, sc *terminalrpc.TerminalControllerRPC, readyCh chan error, doneCh chan error)
+	StartServerFunc     func(ctx context.Context, sc *terminalrpc.TerminalControllerRPC, readyCh chan error, doneCh chan error, extra ...terminalrpc.ExtraHandler)
 	StartTerminalFunc   func(evCh chan<- Event) error
 	CloseFunc           func(reason error) error
 	ResizeFunc          func(args api.ResizeArgs)
@@ -69,9 +69,10 @@ func (sr *Test) StartServer(
 	sc *terminalrpc.TerminalControllerRPC,
 	readyCh chan error,
 	doneCh chan error,
+	extra ...terminalrpc.ExtraHandler,
 ) {
 	if sr.StartServerFunc != nil {
-		sr.StartServerFunc(ctx, sc, readyCh, doneCh)
+		sr.StartServerFunc(ctx, sc, readyCh, doneCh, extra...)
 	}
 }
 

--- a/pkg/terminal/server/options.go
+++ b/pkg/terminal/server/options.go
@@ -1,0 +1,60 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package server
+
+// Handler is a custom JSON-RPC service an embedder registers alongside
+// the built-in attach/control protocol, served on the same listener.
+//
+// Name is the net/rpc service name — the part before the dot in a
+// "Service.Method" wire call. A client invokes a custom verb with
+// method "<Name>.<MethodName>". Receiver is any value whose exported
+// methods follow net/rpc's signature scheme:
+//
+//	func (r *Recv) MethodName(args ArgT, reply *ReplyT) error
+//
+// where ArgT and *ReplyT are exported (or builtin) types.
+//
+// Custom services are namespaced by Name, so their methods never
+// collide with the built-in TerminalController methods (Ping, Attach,
+// Subscribe, …). A Name equal to the built-in service is rejected — see
+// WithHandlers.
+type Handler struct {
+	Name     string
+	Receiver any
+}
+
+// Option configures a Server at construction time. Pass options to New.
+type Option func(*Server)
+
+// WithHandlers registers one or more custom JSON-RPC services to be
+// served on the same listener as the built-in attach/control protocol.
+// This is the extension point for embedders (e.g. kuketty surfacing
+// container-setup status to its daemon) that need an extra verb on the
+// already-permissioned control socket without forking the package or
+// standing up a second listener.
+//
+// The built-in protocol is unaffected when no handler is registered.
+// New validates the supplied handlers and returns an error if any has
+// an empty Name, a nil Receiver, a Name that collides with the built-in
+// service, or a Name duplicated within the set. A receiver whose
+// methods don't match net/rpc's scheme surfaces as an error from Serve
+// at registration time.
+func WithHandlers(handlers ...Handler) Option {
+	return func(s *Server) {
+		s.handlers = append(s.handlers, handlers...)
+	}
+}

--- a/pkg/terminal/server/server.go
+++ b/pkg/terminal/server/server.go
@@ -46,6 +46,8 @@ type Server struct {
 	spec   *api.TerminalSpec
 	logger *slog.Logger
 
+	handlers []Handler
+
 	mu          sync.Mutex
 	serveCalled bool
 	runner      terminalrunner.TerminalRunner
@@ -56,8 +58,10 @@ type Server struct {
 
 // New constructs a server bound to spec. The PTY is not spawned here —
 // the wrapped child is forked on Serve so a caller can listen on the
-// control socket and signal readiness first.
-func New(spec *api.TerminalSpec, logger *slog.Logger) (*Server, error) {
+// control socket and signal readiness first. Pass WithHandlers to
+// register custom JSON-RPC verbs on the same listener as the built-in
+// attach/control protocol.
+func New(spec *api.TerminalSpec, logger *slog.Logger, opts ...Option) (*Server, error) {
 	if spec == nil {
 		return nil, errors.New("server: nil TerminalSpec")
 	}
@@ -67,11 +71,41 @@ func New(spec *api.TerminalSpec, logger *slog.Logger) (*Server, error) {
 	if logger == nil {
 		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	}
-	return &Server{
+	s := &Server{
 		spec:   spec,
 		logger: logger,
 		stopCh: make(chan error, 1),
-	}, nil
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	if err := validateHandlers(s.handlers); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// validateHandlers rejects custom handler registrations that would
+// collide with the built-in service or with each other before Serve
+// reaches the runner, so embedders get a clear constructor error rather
+// than an opaque failure on the Serve goroutine.
+func validateHandlers(handlers []Handler) error {
+	seen := make(map[string]struct{}, len(handlers))
+	for _, h := range handlers {
+		switch {
+		case h.Name == "":
+			return errors.New("server: custom handler with empty Name")
+		case h.Name == api.TerminalService:
+			return fmt.Errorf("server: custom handler Name %q collides with the built-in service", h.Name)
+		case h.Receiver == nil:
+			return fmt.Errorf("server: custom handler %q has a nil Receiver", h.Name)
+		}
+		if _, dup := seen[h.Name]; dup {
+			return fmt.Errorf("server: duplicate custom handler Name %q", h.Name)
+		}
+		seen[h.Name] = struct{}{}
+	}
+	return nil
 }
 
 // Serve accepts on listener and dispatches the TerminalController
@@ -135,7 +169,11 @@ func (s *Server) bringUp(
 	}
 
 	svc := &terminalrpc.TerminalControllerRPC{Core: &rpcAdapter{srv: s}}
-	go runner.StartServer(ctx, svc, rpcReadyCh, rpcDoneCh)
+	extra := make([]terminalrpc.ExtraHandler, 0, len(s.handlers))
+	for _, h := range s.handlers {
+		extra = append(extra, terminalrpc.ExtraHandler{Name: h.Name, Receiver: h.Receiver})
+	}
+	go runner.StartServer(ctx, svc, rpcReadyCh, rpcDoneCh, extra...)
 
 	if err := <-rpcReadyCh; err != nil {
 		_ = runner.Close(err)

--- a/pkg/terminal/server/server_handlers_test.go
+++ b/pkg/terminal/server/server_handlers_test.go
@@ -1,0 +1,210 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/pkg/api"
+	rpcclient "github.com/eminwux/sbsh/pkg/rpcclient/terminal"
+	"github.com/eminwux/sbsh/pkg/terminal/server"
+)
+
+// SetupStatusArgs / SetupStatusReply are the request/response shapes for
+// the dummy custom verb. net/rpc requires the arg and reply types to be
+// exported, so these live at package scope with exported fields.
+type SetupStatusArgs struct {
+	Want string `json:"Want"`
+}
+
+type SetupStatusReply struct {
+	Status string `json:"Status"`
+	Echo   string `json:"Echo"`
+}
+
+// setupHandler is a stand-in for kuketty's container-setup-status verb:
+// a custom JSON-RPC service registered alongside the built-in protocol.
+type setupHandler struct{}
+
+func (setupHandler) GetSetupStatus(args SetupStatusArgs, reply *SetupStatusReply) error {
+	reply.Status = "ready"
+	reply.Echo = args.Want
+	return nil
+}
+
+// TestServer_CustomHandler_DispatchAndIsolation registers a custom verb
+// via WithHandlers and asserts (1) it dispatches over the same listener
+// as the built-in protocol and (2) the built-in attach/control protocol
+// (Ping) is unaffected on the same socket — the AC's dispatch + isolation
+// requirement.
+func TestServer_CustomHandler_DispatchAndIsolation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	tmp := t.TempDir()
+	socketPath := filepath.Join(tmp, "ctrl.sock")
+
+	listener, listenErr := net.Listen("unix", socketPath)
+	if listenErr != nil {
+		t.Fatalf("net.Listen: %v", listenErr)
+	}
+
+	spec := &api.TerminalSpec{
+		ID:            api.ID("test-custom-handler"),
+		Name:          "test-custom-handler",
+		Labels:        map[string]string{},
+		Command:       "/bin/sh",
+		CommandArgs:   []string{},
+		EnvInherit:    true,
+		RunPath:       tmp,
+		SocketFile:    socketPath,
+		CaptureFile:   filepath.Join(tmp, "capture.log"),
+		ShutdownGrace: 500 * time.Millisecond,
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	srv, newErr := server.New(spec, logger,
+		server.WithHandlers(server.Handler{Name: "SetupStatus", Receiver: setupHandler{}}),
+	)
+	if newErr != nil {
+		t.Fatalf("server.New: %v", newErr)
+	}
+
+	serveErrCh := make(chan error, 1)
+	go func() { serveErrCh <- srv.Serve(ctx, listener) }()
+	defer func() {
+		_ = srv.Stop(errors.New("test cleanup"))
+		select {
+		case <-serveErrCh:
+		case <-time.After(5 * time.Second):
+			t.Logf("Serve did not return within 5s of cleanup Stop")
+		}
+	}()
+
+	if waitErr := waitReady(ctx, srv, 10*time.Second); waitErr != nil {
+		t.Fatalf("waitReady: %v", waitErr)
+	}
+
+	// Custom verb dispatches on the control socket.
+	var reply SetupStatusReply
+	if err := rawCall(t, socketPath, "SetupStatus.GetSetupStatus",
+		SetupStatusArgs{Want: "phase1"}, &reply); err != nil {
+		t.Fatalf("custom verb call: %v", err)
+	}
+	if reply.Status != "ready" || reply.Echo != "phase1" {
+		t.Fatalf("custom verb reply = %+v, want {ready phase1}", reply)
+	}
+
+	// Built-in protocol is unaffected on the same socket.
+	client := rpcclient.NewUnix(socketPath, logger)
+	defer client.Close()
+	var pong api.PingMessage
+	if err := client.Ping(ctx, &api.PingMessage{Message: "PING"}, &pong); err != nil {
+		t.Fatalf("built-in Ping after custom registration: %v", err)
+	}
+	if pong.Message != "PONG" {
+		t.Fatalf("Ping reply = %q, want PONG", pong.Message)
+	}
+
+	// An unknown method on the custom service still surfaces an error
+	// rather than corrupting the built-in dispatch.
+	var discard SetupStatusReply
+	if err := rawCall(t, socketPath, "SetupStatus.Nonexistent",
+		SetupStatusArgs{}, &discard); err == nil {
+		t.Fatal("unknown custom method returned no error")
+	}
+}
+
+// TestServer_New_RejectsBadHandlers locks in the registration-time guards
+// from WithHandlers/New: a Name colliding with the built-in service, an
+// empty Name, a nil Receiver, and a duplicate Name are all rejected
+// before Serve.
+func TestServer_New_RejectsBadHandlers(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	spec := &api.TerminalSpec{Command: "/bin/sh"}
+
+	cases := []struct {
+		name     string
+		handlers []server.Handler
+	}{
+		{"collides with built-in", []server.Handler{{Name: api.TerminalService, Receiver: setupHandler{}}}},
+		{"empty name", []server.Handler{{Name: "", Receiver: setupHandler{}}}},
+		{"nil receiver", []server.Handler{{Name: "SetupStatus", Receiver: nil}}},
+		{"duplicate name", []server.Handler{
+			{Name: "SetupStatus", Receiver: setupHandler{}},
+			{Name: "SetupStatus", Receiver: setupHandler{}},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := server.New(spec, logger, server.WithHandlers(tc.handlers...)); err == nil {
+				t.Fatalf("New with %s handler returned no error", tc.name)
+			}
+		})
+	}
+}
+
+// rawCall issues a single JSON-RPC request over a fresh connection to the
+// control socket and decodes the reply. It speaks the same wire shape the
+// built-in codec uses ({id, method, params:[arg]} → {id, result, error})
+// so the test exercises real on-socket dispatch without depending on the
+// typed client, which only knows the built-in methods.
+func rawCall(t *testing.T, socketPath, method string, arg, reply any) error {
+	t.Helper()
+
+	conn, err := net.DialTimeout("unix", socketPath, 5*time.Second)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	if derr := conn.SetDeadline(time.Now().Add(5 * time.Second)); derr != nil {
+		return derr
+	}
+
+	req := struct {
+		ID     uint64 `json:"id"`
+		Method string `json:"method"`
+		Params [1]any `json:"params"`
+	}{ID: 1, Method: method, Params: [1]any{arg}}
+	if encErr := json.NewEncoder(conn).Encode(&req); encErr != nil {
+		return encErr
+	}
+
+	var resp struct {
+		ID     uint64           `json:"id"`
+		Result *json.RawMessage `json:"result"`
+		Error  *string          `json:"error"`
+	}
+	if decErr := json.NewDecoder(conn).Decode(&resp); decErr != nil {
+		return decErr
+	}
+	if resp.Error != nil {
+		return errors.New(*resp.Error)
+	}
+	if resp.Result == nil || reply == nil {
+		return nil
+	}
+	return json.Unmarshal(*resp.Result, reply)
+}


### PR DESCRIPTION
## Summary

- Adds an extension point on `pkg/terminal/server` so embedders (e.g. kuketty surfacing container-setup status to `kukeond`, eminwux/kukeon#617/#642) can register custom JSON-RPC verbs on the **same** control-socket listener as the built-in attach/control protocol — no fork, no second socket.
- Public surface: `server.New(spec, logger, server.WithHandlers(server.Handler{Name, Receiver})...)`. `Handler.Name` is the net/rpc service name (the part before the dot in a `"Service.Method"` wire call); `Receiver` is any value whose exported methods follow net/rpc's `func(args T1, reply *T2) error` scheme.

## Design notes (for reviewer push-back)

- **Namespacing comes free from net/rpc.** Custom verbs register under a distinct service name on the same `rpc.Server`; dispatch is by full `"Service.Method"`, so a custom service's methods can never collide with the built-in `TerminalController.*` methods. The only possible collision is at the *service-name* level.
- **Collision handling is belt-and-suspenders.** `New` validates up front and rejects an empty `Name`, a `Name` equal to the built-in service (`api.TerminalService`), a nil `Receiver`, or a duplicate `Name` within the set — a clean constructor error rather than an opaque failure on the Serve goroutine. As defense-in-depth, `StartServer` registers the built-in service *first*, then customs, so net/rpc's own "service already defined" rejection also fires (a receiver whose methods don't match net/rpc's scheme surfaces as an error from `Serve` at registration time).
- **Threading.** `terminalrunner.StartServer` gained a variadic `extra ...terminalrpc.ExtraHandler` param (interface, exec impl, fake updated). Variadic keeps the existing non-facade caller (`internal/terminal/controller.go`) compiling unchanged. The public `Handler` lives in `pkg/terminal/server` so embedders don't import `internal/...`.
- Built-in behavior is unchanged when no handler is registered (the existing facade tests still pass).

## Test plan

- [x] `make sbsh-sb` — builds `sbsh`, hardlinks `sb`; `file ./sbsh` → ELF executable
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (cmd/sb, cmd/sbsh, internal/terminal, internal/client, integration get, e2e — all green)
- [x] `go test ./pkg/terminal/server/...` — new `TestServer_CustomHandler_DispatchAndIsolation` (registers a dummy verb, asserts on-socket dispatch + built-in `Ping` isolation + unknown-method error) and `TestServer_New_RejectsBadHandlers` (collision/empty/nil/duplicate)
- [x] `pre-commit run --files <changed>` — golangci-lint, gofmt, addlicense all pass

## Acceptance criteria

- [x] Embedder can register one or more custom JSON-RPC verbs via the public `pkg/terminal/server` surface (`WithHandlers`)
- [x] Registered verbs dispatched over the same listener as the built-in protocol
- [x] Built-in attach/control protocol unaffected (regression-tested via `Ping` on the same socket)
- [x] A custom name colliding with a built-in method is rejected (error at registration: `New` + net/rpc)
- [x] Unit test registers a dummy verb and asserts dispatch + isolation from built-ins
- [x] `make sbsh-sb` + `go vet ./...` + `make test` green

Closes #291