### PR TITLE
feat(terminalrunner): vt-parser screen model + Screenshot RPC

### DIFF
--- a/cmd/sb/sb.go
+++ b/cmd/sb/sb.go
@@ -30,6 +30,7 @@ import (
 	"github.com/eminwux/sbsh/cmd/sb/get"
 	"github.com/eminwux/sbsh/cmd/sb/prune"
 	"github.com/eminwux/sbsh/cmd/sb/read"
+	"github.com/eminwux/sbsh/cmd/sb/screenshot"
 	"github.com/eminwux/sbsh/cmd/sb/stop"
 	"github.com/eminwux/sbsh/cmd/sb/validate"
 	"github.com/eminwux/sbsh/cmd/sb/version"
@@ -126,6 +127,7 @@ func setupRootCmd(rootCmd *cobra.Command) error {
 	rootCmd.AddCommand(get.NewGetCmd())
 	rootCmd.AddCommand(write.NewWriteCmd())
 	rootCmd.AddCommand(read.NewReadCmd())
+	rootCmd.AddCommand(screenshot.NewScreenshotCmd())
 
 	rootCmd.PersistentFlags().String("config", "", "config file (default is $HOME/.sbsh/config.yaml)")
 	if err := viper.BindPFlag(config.SB_ROOT_CONFIG.ViperKey, rootCmd.PersistentFlags().Lookup("config")); err != nil {

--- a/cmd/sb/screenshot/screenshot.go
+++ b/cmd/sb/screenshot/screenshot.go
@@ -1,0 +1,112 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package screenshot
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+
+	"github.com/eminwux/sbsh/cmd/config"
+	"github.com/eminwux/sbsh/cmd/sb/get"
+	"github.com/eminwux/sbsh/cmd/types"
+	"github.com/eminwux/sbsh/internal/discovery"
+	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/pkg/api"
+	rpcterminal "github.com/eminwux/sbsh/pkg/rpcclient/terminal"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type screenshotOpts struct {
+	runPath string
+	name    string
+	plain   bool
+}
+
+func NewScreenshotCmd() *cobra.Command {
+	screenshotCmd := &cobra.Command{
+		Use:   "screenshot <name>",
+		Short: "Print a terminal's current rendered screen",
+		Long: `Print the current rendered screen of a terminal.
+
+sbsh decodes the live PTY output into a screen model (the same grid an
+attached client would see) and prints it. By default the output includes
+SGR color sequences so colors are preserved; use --plain for the bare text
+grid with no escape sequences.`,
+		SilenceUsage:      true,
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: get.CompleteTerminals,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)
+			if !ok || logger == nil {
+				return errdefs.ErrLoggerNotFound
+			}
+			plain, _ := cmd.Flags().GetBool("plain")
+			opts := screenshotOpts{
+				runPath: viper.GetString(config.SB_ROOT_RUN_PATH.ViperKey),
+				name:    args[0],
+				plain:   plain,
+			}
+			if opts.name == "" {
+				return errdefs.ErrNoTerminalIdentifier
+			}
+			return runScreenshot(cmd.Context(), logger, os.Stdout, opts)
+		},
+	}
+
+	screenshotCmd.Flags().Bool("plain", false, "Print the bare text grid without SGR color escape sequences")
+	return screenshotCmd
+}
+
+func runScreenshot(
+	ctx context.Context,
+	logger *slog.Logger,
+	stdout io.Writer,
+	opts screenshotOpts,
+) error {
+	doc, err := discovery.FindTerminalByName(ctx, logger, opts.runPath, opts.name)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errdefs.ErrTerminalNotFound, err)
+	}
+	if doc == nil {
+		return fmt.Errorf("%w: terminal %q", errdefs.ErrTerminalNotFound, opts.name)
+	}
+
+	socket := doc.Status.SocketFile
+	if socket == "" {
+		return errors.New("terminal metadata has no control socket recorded")
+	}
+
+	rc := rpcterminal.NewUnix(socket, logger)
+	defer func() { _ = rc.Close() }()
+
+	var result api.ScreenshotResult
+	if scErr := rc.Screenshot(ctx, &api.ScreenshotArgs{}, &result); scErr != nil {
+		return fmt.Errorf("screenshot: %w", scErr)
+	}
+
+	out := result.ANSI
+	if opts.plain {
+		out = result.Text
+	}
+	_, err = io.WriteString(stdout, out)
+	return err
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.5
 
 require (
 	github.com/creack/pty v1.1.24
+	github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9L
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02 h1:AgcIVYPa6XJnU3phs104wLj8l5GEththEw6+F79YsIY=
+github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/internal/client/clientrunner/io_test.go
+++ b/internal/client/clientrunner/io_test.go
@@ -81,6 +81,10 @@ func (m *mockTerminalClient) Subscribe(_ context.Context, _ *api.SubscribeReques
 	return nil, errors.New("not implemented in mock")
 }
 
+func (m *mockTerminalClient) Screenshot(_ context.Context, _ *api.ScreenshotArgs, _ *api.ScreenshotResult) error {
+	return errors.New("not implemented in mock")
+}
+
 func Test_WaitReady_WithMultipleStates(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/terminal/controller.go
+++ b/internal/terminal/controller.go
@@ -386,6 +386,16 @@ func (c *Controller) Subscribe(req *api.SubscribeRequest, response *api.Response
 	return sr.Subscribe(req, response)
 }
 
+func (c *Controller) Screenshot(args *api.ScreenshotArgs) (*api.ScreenshotResult, error) {
+	c.srMu.RLock()
+	sr := c.sr
+	c.srMu.RUnlock()
+	if sr == nil {
+		return nil, errors.New("terminal runner not initialized")
+	}
+	return sr.Screenshot(args)
+}
+
 func (c *Controller) State() (*api.TerminalStatusMode, error) {
 	c.srMu.RLock()
 	sr := c.sr

--- a/internal/terminal/controller_fake.go
+++ b/internal/terminal/controller_fake.go
@@ -26,19 +26,20 @@ type ControllerTest struct {
 
 	AddedSpec *api.TerminalSpec
 
-	RunFunc       func(spec *api.TerminalSpec) error
-	WaitReadyFunc func() error
-	WaitCloseFunc func() error
-	PingFunc      func(in *api.PingMessage) (*api.PingMessage, error)
-	CloseFunc     func(reason error) error
-	ResizeFunc    func()
-	AttachFunc    func(id *api.ID, response *api.ResponseWithFD) error
-	DetachFunc    func(id *api.ID) error
-	MetadataFunc  func() (*api.TerminalDoc, error)
-	StateFunc     func() (*api.TerminalStatusMode, error)
-	StopFunc      func(args *api.StopArgs) error
-	WriteFunc     func(req *api.WriteRequest) error
-	SubscribeFunc func(req *api.SubscribeRequest, response *api.ResponseWithFD) error
+	RunFunc        func(spec *api.TerminalSpec) error
+	WaitReadyFunc  func() error
+	WaitCloseFunc  func() error
+	PingFunc       func(in *api.PingMessage) (*api.PingMessage, error)
+	CloseFunc      func(reason error) error
+	ResizeFunc     func()
+	AttachFunc     func(id *api.ID, response *api.ResponseWithFD) error
+	DetachFunc     func(id *api.ID) error
+	MetadataFunc   func() (*api.TerminalDoc, error)
+	StateFunc      func() (*api.TerminalStatusMode, error)
+	StopFunc       func(args *api.StopArgs) error
+	WriteFunc      func(req *api.WriteRequest) error
+	SubscribeFunc  func(req *api.SubscribeRequest, response *api.ResponseWithFD) error
+	ScreenshotFunc func(args *api.ScreenshotArgs) (*api.ScreenshotResult, error)
 }
 
 func (f *ControllerTest) Run(spec *api.TerminalSpec) error {
@@ -130,4 +131,11 @@ func (f *ControllerTest) Subscribe(req *api.SubscribeRequest, response *api.Resp
 		return f.SubscribeFunc(req, response)
 	}
 	return errdefs.ErrFuncNotSet
+}
+
+func (f *ControllerTest) Screenshot(args *api.ScreenshotArgs) (*api.ScreenshotResult, error) {
+	if f.ScreenshotFunc != nil {
+		return f.ScreenshotFunc(args)
+	}
+	return nil, errdefs.ErrFuncNotSet
 }

--- a/internal/terminal/terminalrpc/rpc_server.go
+++ b/internal/terminal/terminalrpc/rpc_server.go
@@ -87,3 +87,12 @@ func (s *TerminalControllerRPC) Write(req *api.WriteRequest, _ *api.Empty) error
 func (s *TerminalControllerRPC) Subscribe(req *api.SubscribeRequest, response *api.ResponseWithFD) error {
 	return s.Core.Subscribe(req, response)
 }
+
+func (s *TerminalControllerRPC) Screenshot(args *api.ScreenshotArgs, result *api.ScreenshotResult) error {
+	res, err := s.Core.Screenshot(args)
+	if err != nil {
+		return err
+	}
+	*result = *res
+	return nil
+}

--- a/internal/terminal/terminalrunner/lifecycle.go
+++ b/internal/terminal/terminalrunner/lifecycle.go
@@ -336,6 +336,27 @@ func (sr *Exec) Resize(args api.ResizeArgs) {
 		Cols: uint16(args.Cols),
 		Rows: uint16(args.Rows),
 	})
+	// Keep the screen model's grid in step with the PTY winsize so a
+	// Screenshot reflects the dimensions the child program is drawing for.
+	sr.ptyPipesMu.RLock()
+	screen := sr.ptyPipes.screen
+	sr.ptyPipesMu.RUnlock()
+	if screen != nil {
+		screen.resize(args.Cols, args.Rows)
+	}
+}
+
+// Screenshot returns a decoded snapshot of the terminal's current screen
+// from the warm-fed vt-parser model. It reads the live grid, not the raw
+// capture bytes.
+func (sr *Exec) Screenshot(_ *api.ScreenshotArgs) (*api.ScreenshotResult, error) {
+	sr.ptyPipesMu.RLock()
+	screen := sr.ptyPipes.screen
+	sr.ptyPipesMu.RUnlock()
+	if screen == nil {
+		return nil, errors.New("terminal not running")
+	}
+	return screen.snapshot(), nil
 }
 
 func (sr *Exec) Write(p []byte) (int, error) {

--- a/internal/terminal/terminalrunner/terminal.go
+++ b/internal/terminal/terminalrunner/terminal.go
@@ -229,10 +229,18 @@ func (sr *Exec) startPty() error {
 	// ATTACHED: stream to client (pipeOutW) AND log file
 	multiOutW := NewDynamicMultiWriter(sr.logger, logf)
 
+	// Register the vt-parser screen model as an additional warm sink on
+	// the same fan-out. It decodes the byte stream into a live grid so
+	// Screenshot can answer "what is on screen now" without re-reading the
+	// capture file. The capture writer (logf) is unchanged.
+	screen := newScreenModel()
+	multiOutW.Add(screen)
+
 	sr.ptyPipesMu.Lock()
 	sr.ptyPipes.pipeInR = pipeInR
 	sr.ptyPipes.pipeInW = pipeInW
 	sr.ptyPipes.multiOutW = multiOutW
+	sr.ptyPipes.screen = screen
 	sr.ptyPipesMu.Unlock()
 
 	go sr.terminalManager(pipeInR, multiOutW)

--- a/internal/terminal/terminalrunner/terminal_runner.go
+++ b/internal/terminal/terminalrunner/terminal_runner.go
@@ -54,4 +54,5 @@ type TerminalRunner interface {
 	Metadata() (*api.TerminalDoc, error)
 	WritePTY(data []byte) error
 	Subscribe(req *api.SubscribeRequest, response *api.ResponseWithFD) error
+	Screenshot(args *api.ScreenshotArgs) (*api.ScreenshotResult, error)
 }

--- a/internal/terminal/terminalrunner/terminal_runner_exec.go
+++ b/internal/terminal/terminalrunner/terminal_runner_exec.go
@@ -110,6 +110,10 @@ type ptyPipes struct {
 	pipeInR   *os.File
 	pipeInW   *os.File
 	multiOutW *DynamicMultiWriter
+	// screen is the vt-parser screen model, fed warm as an additional
+	// sink on multiOutW. Created and registered in startPty alongside the
+	// multiwriter, read by Screenshot. Guarded by the same ptyPipesMu.
+	screen *screenModel
 }
 
 type ioClient struct {

--- a/internal/terminal/terminalrunner/terminal_runner_fake.go
+++ b/internal/terminal/terminalrunner/terminal_runner_fake.go
@@ -44,6 +44,7 @@ type Test struct {
 	PostAttachShellFunc func() error
 	WritePTYFunc        func(data []byte) error
 	SubscribeFunc       func(req *api.SubscribeRequest, response *api.ResponseWithFD) error
+	ScreenshotFunc      func(args *api.ScreenshotArgs) (*api.ScreenshotResult, error)
 }
 
 func NewTerminalRunnerTest(_ context.Context) TerminalRunner {
@@ -167,4 +168,11 @@ func (sr *Test) Subscribe(req *api.SubscribeRequest, response *api.ResponseWithF
 		return sr.SubscribeFunc(req, response)
 	}
 	return errdefs.ErrFuncNotSet
+}
+
+func (sr *Test) Screenshot(args *api.ScreenshotArgs) (*api.ScreenshotResult, error) {
+	if sr.ScreenshotFunc != nil {
+		return sr.ScreenshotFunc(args)
+	}
+	return nil, errdefs.ErrFuncNotSet
 }

--- a/internal/terminal/terminalrunner/terminal_screen.go
+++ b/internal/terminal/terminalrunner/terminal_screen.go
@@ -1,0 +1,226 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrunner
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/eminwux/sbsh/pkg/api"
+	"github.com/hinshun/vt10x"
+)
+
+const sgrReset = "\x1b[0m"
+
+// vt10x color encoding boundaries. The 16 ANSI colors occupy [0,16):
+// [0,8) are the basic colors and [8,16) their bright variants. [16,256)
+// is the xterm 256-color palette. 24-bit truecolor is packed as the
+// 0xRRGGBB value (below 1<<24). The sentinel default colors
+// (DefaultFG/DefaultBG/DefaultCursor) sit at or above 1<<24.
+const (
+	ansiBasicEnd   = 8
+	ansiBrightEnd  = 16
+	palette256End  = 256
+	defaultColorAt = 1 << 24
+
+	// SGR parameter bases for the 16 ANSI colors (foreground and background).
+	sgrFGBasic  = 30
+	sgrFGBright = 90
+	sgrBGBasic  = 40
+	sgrBGBright = 100
+
+	rgbByteMask   = 0xff
+	rgbShiftRed   = 16
+	rgbShiftGreen = 8
+)
+
+// screenModel decodes the PTY byte stream into a live screen grid (cells,
+// cursor, colors, alt-screen state). It is registered as an *additional*
+// io.Writer sink on the DynamicMultiWriter — fed "warm" from the same
+// bytes the capture file receives — so a Screenshot stays O(1) and never
+// re-reads the capture file. The capture writer is untouched: the model
+// is a second reader of the stream, not a replacement.
+//
+// vt10x.Terminal is internally synchronized on a single mutex: Write
+// (called from the single PTY-reader goroutine via the multiwriter) and
+// the snapshot render path (called from a Screenshot RPC goroutine) share
+// it, so concurrent feed-and-read is safe.
+type screenModel struct {
+	vt vt10x.Terminal
+
+	// leftover holds a trailing partial UTF-8 rune that vt10x.Write could
+	// not consume at a chunk boundary. The multiwriter calls Write
+	// serially from the lone PTY reader, so no lock guards this field.
+	leftover []byte
+}
+
+// newScreenModel creates a screen model sized to the VT100 default the PTY
+// is started at (see startPty); Resize keeps it in step thereafter.
+func newScreenModel() *screenModel {
+	return &screenModel{vt: vt10x.New(vt10x.WithSize(vt100Cols, vt100Rows))}
+}
+
+// Write feeds raw PTY output into the parser. It satisfies io.Writer so
+// the model can join the DynamicMultiWriter fan-out. It always reports the
+// full payload as written and never returns an error: a parser hiccup must
+// not drop the model from the fan-out (which would silently stop tracking
+// the screen) — the capture file is the source of truth, the model is
+// best-effort.
+func (m *screenModel) Write(p []byte) (int, error) {
+	buf := p
+	if len(m.leftover) > 0 {
+		combined := make([]byte, 0, len(m.leftover)+len(p))
+		combined = append(combined, m.leftover...)
+		combined = append(combined, p...)
+		buf = combined
+		m.leftover = nil
+	}
+	// vt10x.Write returns the count of fully-decoded bytes; a trailing
+	// incomplete rune (split across this and the next chunk) is left
+	// unconsumed. Carry it so the next Write completes the rune instead
+	// of corrupting it.
+	n, _ := m.vt.Write(buf)
+	if n < len(buf) {
+		m.leftover = append([]byte(nil), buf[n:]...)
+	}
+	return len(p), nil
+}
+
+// resize keeps the screen grid in step with the PTY winsize so wrapping
+// and cursor bounds match what an attached client sees.
+func (m *screenModel) resize(cols, rows int) {
+	if cols > 0 && rows > 0 {
+		m.vt.Resize(cols, rows)
+	}
+}
+
+// snapshot renders the current grid into an api.ScreenshotResult under a
+// single state lock so cells, cursor, and size are a mutually consistent
+// frame (no Write can interleave mid-render).
+func (m *screenModel) snapshot() *api.ScreenshotResult {
+	m.vt.Lock()
+	defer m.vt.Unlock()
+
+	cols, rows := m.vt.Size()
+	cur := m.vt.Cursor()
+	res := &api.ScreenshotResult{
+		Cols:          cols,
+		Rows:          rows,
+		CursorX:       cur.X,
+		CursorY:       cur.Y,
+		CursorVisible: m.vt.CursorVisible(),
+		AltScreen:     m.vt.Mode()&vt10x.ModeAltScreen != 0,
+	}
+	res.Text, res.ANSI = renderGrid(m.vt, cols, rows)
+	return res
+}
+
+// renderGrid walks the grid row by row and produces both the plain-text
+// and the SGR-colored renderings. The caller must hold the vt10x state
+// lock (see snapshot); renderGrid uses the lock-free Cell accessor.
+// Trailing blank lines are trimmed so the output reads like a screen, not
+// an 80x24 block of padding.
+func renderGrid(v vt10x.View, cols, rows int) (string, string) {
+	textLines := make([]string, rows)
+	ansiLines := make([]string, rows)
+	for y := range rows {
+		textLines[y], ansiLines[y] = renderLine(v, cols, y)
+	}
+
+	// Drop trailing blank lines (plain text is the canonical "is this row
+	// empty" signal; the ANSI line for the same row is dropped in lockstep).
+	end := len(textLines)
+	for end > 0 && textLines[end-1] == "" {
+		end--
+	}
+
+	text := strings.Join(textLines[:end], "\n")
+	ansi := strings.Join(ansiLines[:end], "\n")
+	if text != "" {
+		text += "\n"
+	}
+	if ansi != "" {
+		ansi += "\n"
+	}
+	return text, ansi
+}
+
+// renderLine renders a single grid row, returning its plain text and its
+// SGR-colored form. Trailing blank columns are dropped.
+func renderLine(v vt10x.View, cols, y int) (string, string) {
+	last := -1
+	for x := range cols {
+		if ch := v.Cell(x, y).Char; ch != ' ' && ch != 0 {
+			last = x
+		}
+	}
+
+	var text, ansi strings.Builder
+	curFG, curBG := vt10x.DefaultFG, vt10x.DefaultBG
+	colored := false
+	for x := 0; x <= last; x++ {
+		g := v.Cell(x, y)
+		ch := g.Char
+		if ch == 0 {
+			ch = ' '
+		}
+		text.WriteRune(ch)
+
+		if g.FG != curFG || g.BG != curBG {
+			fmt.Fprintf(&ansi, "\x1b[%s;%sm", ansiFG(g.FG), ansiBG(g.BG))
+			curFG, curBG = g.FG, g.BG
+			if g.FG != vt10x.DefaultFG || g.BG != vt10x.DefaultBG {
+				colored = true
+			}
+		}
+		ansi.WriteRune(ch)
+	}
+	if colored {
+		ansi.WriteString(sgrReset)
+	}
+	return text.String(), ansi.String()
+}
+
+// ansiFG maps a vt10x foreground color to its SGR parameter.
+func ansiFG(c vt10x.Color) string {
+	return ansiColor(c, sgrFGBasic, sgrFGBright, "38", "39")
+}
+
+// ansiBG mirrors ansiFG for background colors.
+func ansiBG(c vt10x.Color) string {
+	return ansiColor(c, sgrBGBasic, sgrBGBright, "48", "49")
+}
+
+// ansiColor renders one color as an SGR parameter list. basicBase/brightBase
+// are the SGR bases for the 16 ANSI colors (30/90 fg, 40/100 bg); extPrefix
+// is "38"/"48" for the 256-color and truecolor forms; defaultParam is the
+// "reset to default" parameter (39 fg, 49 bg).
+func ansiColor(c vt10x.Color, basicBase, brightBase vt10x.Color, extPrefix, defaultParam string) string {
+	switch {
+	case c >= defaultColorAt: // DefaultFG / DefaultBG / DefaultCursor
+		return defaultParam
+	case c < ansiBasicEnd:
+		return fmt.Sprintf("%d", basicBase+c)
+	case c < ansiBrightEnd:
+		return fmt.Sprintf("%d", brightBase+(c-ansiBasicEnd))
+	case c < palette256End:
+		return fmt.Sprintf("%s;5;%d", extPrefix, c)
+	default:
+		return fmt.Sprintf("%s;2;%d;%d;%d", extPrefix,
+			(c>>rgbShiftRed)&rgbByteMask, (c>>rgbShiftGreen)&rgbByteMask, c&rgbByteMask)
+	}
+}

--- a/internal/terminal/terminalrunner/terminal_screen_test.go
+++ b/internal/terminal/terminalrunner/terminal_screen_test.go
@@ -1,0 +1,264 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrunner
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// feed writes each chunk to the model in order, mirroring how the
+// multiwriter hands the parser successive PTY read buffers.
+func feed(m *screenModel, chunks ...string) {
+	for _, c := range chunks {
+		_, _ = m.Write([]byte(c))
+	}
+}
+
+func TestScreenshotPlainOutput(t *testing.T) {
+	m := newScreenModel()
+	feed(m, "hello world")
+
+	snap := m.snapshot()
+	if snap.Cols != vt100Cols || snap.Rows != vt100Rows {
+		t.Fatalf("unexpected grid size: got %dx%d want %dx%d", snap.Cols, snap.Rows, vt100Cols, vt100Rows)
+	}
+	if !strings.Contains(snap.Text, "hello world") {
+		t.Errorf("plain text should contain the written line; got %q", snap.Text)
+	}
+	// Trailing blank rows are trimmed: a single line of output is one line.
+	if got := strings.Count(snap.Text, "\n"); got != 1 {
+		t.Errorf("expected one rendered line, got %d newlines in %q", got, snap.Text)
+	}
+}
+
+func TestScreenshotCursorPositioning(t *testing.T) {
+	m := newScreenModel()
+	// CUP (1-based) to row 5, col 10 -> 0-based cursor (x=9, y=4).
+	feed(m, "\x1b[5;10H")
+
+	snap := m.snapshot()
+	if snap.CursorX != 9 || snap.CursorY != 4 {
+		t.Errorf("cursor position: got (%d,%d) want (9,4)", snap.CursorX, snap.CursorY)
+	}
+	if !snap.CursorVisible {
+		t.Errorf("cursor should be visible by default")
+	}
+
+	// Hiding the cursor (DECTCEM reset) must be reflected in the snapshot.
+	feed(m, "\x1b[?25l")
+	if m.snapshot().CursorVisible {
+		t.Errorf("cursor should be hidden after \\x1b[?25l")
+	}
+}
+
+func TestScreenshotColorSGR(t *testing.T) {
+	m := newScreenModel()
+	// Red foreground, then reset.
+	feed(m, "\x1b[31mRED\x1b[0mplain")
+
+	snap := m.snapshot()
+	if !strings.Contains(snap.Text, "REDplain") {
+		t.Errorf("plain text drops SGR but keeps glyphs; got %q", snap.Text)
+	}
+	// The ANSI rendering must carry the decoded foreground color (SGR 31),
+	// proving the model tracks color state rather than echoing raw bytes.
+	if !strings.Contains(snap.ANSI, "\x1b[31;49m") {
+		t.Errorf("ANSI rendering should contain red foreground SGR; got %q", snap.ANSI)
+	}
+	// "plain" reverts to default colors, so a reset must appear before it.
+	if !strings.Contains(snap.ANSI, sgrReset) {
+		t.Errorf("ANSI rendering should reset back to default; got %q", snap.ANSI)
+	}
+}
+
+func TestScreenshot256AndBackgroundColor(t *testing.T) {
+	m := newScreenModel()
+	// 256-color foreground (208) on a blue background (SGR 44).
+	feed(m, "\x1b[38;5;208m\x1b[44mX")
+
+	ansi := m.snapshot().ANSI
+	if !strings.Contains(ansi, "38;5;208") {
+		t.Errorf("ANSI should carry 256-color foreground; got %q", ansi)
+	}
+	if !strings.Contains(ansi, "44") {
+		t.Errorf("ANSI should carry blue background; got %q", ansi)
+	}
+}
+
+func TestScreenshotAltScreen(t *testing.T) {
+	m := newScreenModel()
+	// Draw on the primary screen first.
+	feed(m, "primary content")
+	if m.snapshot().AltScreen {
+		t.Fatalf("should start on the primary screen")
+	}
+
+	// Enter the alternate screen (DECSET 1049) the way vim/htop do, then
+	// draw a full-screen UI on it.
+	feed(m, "\x1b[?1049h", "\x1b[2J\x1b[H", "ALT SCREEN APP")
+	alt := m.snapshot()
+	if !alt.AltScreen {
+		t.Errorf("AltScreen should be true after \\x1b[?1049h")
+	}
+	if !strings.Contains(alt.Text, "ALT SCREEN APP") {
+		t.Errorf("screenshot should reflect the alt-screen grid; got %q", alt.Text)
+	}
+	if strings.Contains(alt.Text, "primary content") {
+		t.Errorf("alt screen must not show primary content; got %q", alt.Text)
+	}
+
+	// Leave the alternate screen; the primary content is restored.
+	feed(m, "\x1b[?1049l")
+	restored := m.snapshot()
+	if restored.AltScreen {
+		t.Errorf("AltScreen should be false after \\x1b[?1049l")
+	}
+	if !strings.Contains(restored.Text, "primary content") {
+		t.Errorf("primary content should be restored on exit; got %q", restored.Text)
+	}
+	if strings.Contains(restored.Text, "ALT SCREEN APP") {
+		t.Errorf("alt-screen content must not leak back to primary; got %q", restored.Text)
+	}
+}
+
+// A multibyte rune split across two PTY read buffers must still decode to a
+// single glyph, not a corrupted pair. The model carries the trailing
+// partial rune between Writes.
+func TestScreenshotSplitMultibyteRune(t *testing.T) {
+	m := newScreenModel()
+	// "café" — the 'é' (U+00E9) is 0xC3 0xA9; split it across two writes.
+	feed(m, "caf\xc3", "\xa9!")
+
+	text := m.snapshot().Text
+	if !strings.Contains(text, "café!") {
+		t.Errorf("split multibyte rune should decode intact; got %q", text)
+	}
+}
+
+// The screen model is fed warm as an additional sink on the multiwriter;
+// adding it must not disturb the capture writer, which still receives the
+// exact same bytes.
+func TestScreenModelWarmFeedDoesNotDisturbCapture(t *testing.T) {
+	var capture bytes.Buffer
+	mw := NewDynamicMultiWriter(nil, &capture)
+	m := newScreenModel()
+	mw.Add(m)
+
+	raw := "\x1b[32mok\x1b[0m\r\n"
+	if _, err := mw.Write([]byte(raw)); err != nil {
+		t.Fatalf("multiwriter write: %v", err)
+	}
+
+	// Capture file gets the raw bytes verbatim (unchanged by the parser).
+	if capture.String() != raw {
+		t.Errorf("capture writer should receive raw bytes verbatim; got %q want %q", capture.String(), raw)
+	}
+	// The model decoded the same stream into a screen.
+	if !strings.Contains(m.snapshot().Text, "ok") {
+		t.Errorf("screen model should have decoded the warm-fed bytes; got %q", m.snapshot().Text)
+	}
+}
+
+// The warm feed (Write from the PTY reader goroutine) and Screenshot reads
+// (snapshot from an RPC goroutine) run concurrently. Run under -race to
+// prove vt10x's internal lock makes that safe.
+func TestScreenModelConcurrentWriteAndSnapshot(t *testing.T) {
+	m := newScreenModel()
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range 500 {
+			_, _ = m.Write([]byte("\x1b[31mx\x1b[0m"))
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range 500 {
+			_ = m.snapshot()
+		}
+	}()
+
+	wg.Wait()
+
+	// The grid survived the concurrent feed intact (dimensions unchanged).
+	if snap := m.snapshot(); snap.Cols != vt100Cols || snap.Rows != vt100Rows {
+		t.Errorf("grid corrupted under concurrent access: got %dx%d", snap.Cols, snap.Rows)
+	}
+}
+
+func newScreenExec() *Exec {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Exec{
+		ctx:       ctx,
+		ctxCancel: cancel,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		id:        "screen-test",
+		ptyPipes:  &ptyPipes{},
+	}
+}
+
+func TestExecScreenshotNotRunning(t *testing.T) {
+	sr := newScreenExec()
+	if _, err := sr.Screenshot(&api.ScreenshotArgs{}); err == nil {
+		t.Errorf("Screenshot before startPty should error; screen is nil")
+	}
+}
+
+func TestExecScreenshotDelegatesToModel(t *testing.T) {
+	sr := newScreenExec()
+	screen := newScreenModel()
+	feed(screen, "live grid")
+	sr.ptyPipesMu.Lock()
+	sr.ptyPipes.screen = screen
+	sr.ptyPipesMu.Unlock()
+
+	res, err := sr.Screenshot(&api.ScreenshotArgs{})
+	if err != nil {
+		t.Fatalf("Screenshot: %v", err)
+	}
+	if !strings.Contains(res.Text, "live grid") {
+		t.Errorf("Exec.Screenshot should return the model snapshot; got %q", res.Text)
+	}
+}
+
+// resize must keep the screen grid in step with the PTY winsize so a
+// Screenshot reports the dimensions the child program draws for. (Exec.Resize
+// forwards to this after pty.Setsize.)
+func TestScreenModelResize(t *testing.T) {
+	m := newScreenModel()
+	m.resize(100, 40)
+	if snap := m.snapshot(); snap.Cols != 100 || snap.Rows != 40 {
+		t.Errorf("screen grid should follow resize; got %dx%d want 100x40", snap.Cols, snap.Rows)
+	}
+	// A zero/negative dimension is ignored rather than collapsing the grid.
+	m.resize(0, 0)
+	if snap := m.snapshot(); snap.Cols != 100 || snap.Rows != 40 {
+		t.Errorf("resize with zero dims should be a no-op; got %dx%d", snap.Cols, snap.Rows)
+	}
+}

--- a/pkg/api/terminal.go
+++ b/pkg/api/terminal.go
@@ -35,6 +35,7 @@ type TerminalController interface {
 	Stop(args *StopArgs) error
 	Write(req *WriteRequest) error
 	Subscribe(req *SubscribeRequest, reply *ResponseWithFD) error
+	Screenshot(args *ScreenshotArgs) (*ScreenshotResult, error)
 }
 
 type TerminalDoc struct {
@@ -204,15 +205,16 @@ func (s TerminalStatusMode) String() string {
 const TerminalService = "TerminalController"
 
 const (
-	TerminalMethodResize    = TerminalService + ".Resize"
-	TerminalMethodPing      = TerminalService + ".Ping"
-	TerminalMethodAttach    = TerminalService + ".Attach"
-	TerminalMethodDetach    = TerminalService + ".Detach"
-	TerminalMethodMetadata  = TerminalService + ".Metadata"
-	TerminalMethodState     = TerminalService + ".State"
-	TerminalMethodStop      = TerminalService + ".Stop"
-	TerminalMethodWrite     = TerminalService + ".Write"
-	TerminalMethodSubscribe = TerminalService + ".Subscribe"
+	TerminalMethodResize     = TerminalService + ".Resize"
+	TerminalMethodPing       = TerminalService + ".Ping"
+	TerminalMethodAttach     = TerminalService + ".Attach"
+	TerminalMethodDetach     = TerminalService + ".Detach"
+	TerminalMethodMetadata   = TerminalService + ".Metadata"
+	TerminalMethodState      = TerminalService + ".State"
+	TerminalMethodStop       = TerminalService + ".Stop"
+	TerminalMethodWrite      = TerminalService + ".Write"
+	TerminalMethodSubscribe  = TerminalService + ".Subscribe"
+	TerminalMethodScreenshot = TerminalService + ".Screenshot"
 )
 
 type PingMessage struct {
@@ -246,4 +248,24 @@ type SubscribeRequest struct {
 type ResponseWithFD struct {
 	JSON any   // what to JSON-encode into "result"
 	FDs  []int // file descriptors to pass via SCM_RIGHTS
+}
+
+// ScreenshotArgs is the request for a Screenshot RPC. It carries no
+// fields today; it exists so the wire shape can grow (e.g. a format
+// selector) without breaking the method signature.
+type ScreenshotArgs struct{}
+
+// ScreenshotResult is a decoded snapshot of a terminal's current screen,
+// produced by the in-server vt-parser rather than from the raw capture
+// bytes. Text is the plain rendered grid; ANSI is the same grid with SGR
+// foreground/background color sequences so colors survive the round trip.
+type ScreenshotResult struct {
+	Cols          int    `json:"cols"`
+	Rows          int    `json:"rows"`
+	CursorX       int    `json:"cursorX"`
+	CursorY       int    `json:"cursorY"`
+	CursorVisible bool   `json:"cursorVisible"`
+	AltScreen     bool   `json:"altScreen"`
+	Text          string `json:"text"`
+	ANSI          string `json:"ansi"`
 }

--- a/pkg/rpcclient/terminal/iface.go
+++ b/pkg/rpcclient/terminal/iface.go
@@ -34,4 +34,5 @@ type Client interface {
 	Stop(ctx context.Context, args *api.StopArgs) error
 	Write(ctx context.Context, req *api.WriteRequest) error
 	Subscribe(ctx context.Context, req *api.SubscribeRequest, response any) (net.Conn, error)
+	Screenshot(ctx context.Context, args *api.ScreenshotArgs, result *api.ScreenshotResult) error
 }

--- a/pkg/rpcclient/terminal/rpc_session.go
+++ b/pkg/rpcclient/terminal/rpc_session.go
@@ -264,6 +264,18 @@ func (c *client) Stop(ctx context.Context, args *api.StopArgs) error {
 	return c.call(ctx, c.logger, api.TerminalMethodStop, args, &api.Empty{})
 }
 
+func (c *client) Screenshot(ctx context.Context, args *api.ScreenshotArgs, result *api.ScreenshotResult) error {
+	if args == nil {
+		args = &api.ScreenshotArgs{}
+	}
+	err := c.call(ctx, c.logger, api.TerminalMethodScreenshot, args, result)
+	if err != nil {
+		c.logger.ErrorContext(ctx, "Screenshot call failed", "error", err)
+		return fmt.Errorf("Screenshot call failed: %w", err)
+	}
+	return nil
+}
+
 func (c *client) Write(ctx context.Context, req *api.WriteRequest) error {
 	if req == nil {
 		req = &api.WriteRequest{}

--- a/pkg/terminal/server/adapter.go
+++ b/pkg/terminal/server/adapter.go
@@ -117,3 +117,11 @@ func (a *rpcAdapter) Subscribe(req *api.SubscribeRequest, response *api.Response
 	}
 	return r.Subscribe(req, response)
 }
+
+func (a *rpcAdapter) Screenshot(args *api.ScreenshotArgs) (*api.ScreenshotResult, error) {
+	r := a.srv.getRunner()
+	if r == nil {
+		return nil, errors.New("server: terminal not running")
+	}
+	return r.Screenshot(args)
+}


### PR DESCRIPTION
## Summary

First phase of the capture-rendering arc (#295). sbsh was a pure byte-stream relay with no way to ask "what is on this terminal's screen right now." This introduces an in-server vt-parser maintaining a screen model and proves it with its cheapest consumer, `sb screenshot`.

- **Screen model** (`internal/terminal/terminalrunner/terminal_screen.go`): wraps a vt10x terminal emulator, registered as an *additional* warm sink on the existing `DynamicMultiWriter` — fed the same bytes as the capture file, so the model stays current without re-reading the file and screenshot latency is O(1). The capture writer is unchanged; the parser is a second reader of the stream.
- **`Screenshot` built-in `TerminalController` method**, wired through the full stack alongside `Ping`/`Resize`/`Subscribe`: api interface (`pkg/api/terminal.go`), `terminalrpc/rpc_server.go`, `pkg/terminal/server/adapter.go`, the `Controller`, the `TerminalRunner` interface + `Exec`, and the RPC client (`pkg/rpcclient/terminal`). **Not** the #294 `ExtraHandler` seam — that is reserved for downstream library consumers; a screenshot that ships with sbsh is first-class.
- **`sb screenshot <terminal>` CLI**: prints the rendered screen. Default output carries SGR color sequences; `--plain` prints the bare text grid.
- `Resize` now also resizes the screen model so the grid tracks the PTY winsize.

### Dependency choice (AC leaves this to dev)

Used `github.com/hinshun/vt10x` (MIT) rather than a hand-rolled parser. A minimal in-tree parser robust enough to pass the alt-screen + SGR ACs would be far higher blast radius; vt10x maintains the full grid (cells, cursor, colors, alt-screen), is internally synchronized, and is an `io.Writer` so it drops directly into the multiwriter fan-out. It is now a direct dependency in `go.mod`.

### Non-obvious calls (reviewer please confirm)

- **ScreenshotResult shape**: returns `Cols/Rows/CursorX/CursorY/CursorVisible/AltScreen` plus `Text` (plain grid) and `ANSI` (grid re-rendered with SGR FG/BG). ANSI renders foreground/background colors (the exported `Glyph.FG/BG`); vt10x's text-attribute bits (bold/underline/reverse) are unexported, so they are intentionally not reconstructed. Color is the SGR state the AC calls out.
- **Trailing blank rows are trimmed** from the rendered output for readability; `Cols`/`Rows` still report the true grid size.
- **UTF-8 carry**: vt10x.Write drops a trailing partial rune at a chunk boundary; the model carries the unconsumed bytes to the next Write so a multibyte rune split across PTY reads decodes intact (covered by a test).
- **No explicit teardown** of the screen sink on Close: unlike subscribers it holds no fd or goroutine, so it is GC'd with the runner; the capture-file close sequencing is untouched.

## Test plan

- [x] `make sbsh-sb` + `file ./sbsh` → ELF executable
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` (CI unit target)
- [x] `go test -tags=integration ./cmd/sb/get/...` (CI integration target)
- [x] `go test ./e2e` (CI e2e target)
- [x] `go test -race` on the new screen tests (concurrent warm-feed Write + Screenshot snapshot)
- [x] library-consumer example builds + vets (public interface change)
- [x] `pre-commit run` on staged snapshot (go-fmt, go-mod-tidy, golangci-lint, addlicense) — all pass
- [x] Live smoke: launched `sbsh` under a PTY, ran commands incl. `printf '\033[31mREDTEXT\033[0m'`, then `sb screenshot <name>` — `--plain` shows the decoded grid; default shows ANSI with `\x1b[31;49mREDTEXT\x1b[0m` and the colored prompt, proving SGR decode end-to-end over RPC.

New unit tests cover the AC matrix: plain output, cursor positioning (+ visibility), color/SGR (16-color, 256-color, background), alt-screen enter/exit (DECSET 1049, as vim/htop emit), the warm-feed-doesn't-disturb-capture invariant, and `Exec.Screenshot` delegation.

## Acceptance criteria

- [x] vt-parser + screen model in `terminalrunner`, fed warm by the multiwriter
- [x] `Screenshot` is a built-in `TerminalController` method (api interface + `rpc_server.go` + `adapter.go`), not an `ExtraHandler`
- [x] `sb screenshot <terminal>` prints the current rendered screen
- [x] Tests cover plain output, cursor positioning, color/SGR state, and an alt-screen app — reflecting the live grid, not raw bytes
- [x] The capture file writer is unchanged — the parser is an additional reader

Closes #295