### PR TITLE
fix(terminalrunner): seed attach replay through ring to end write-deadline race

### DIFF
--- a/internal/terminal/terminalrunner/connections.go
+++ b/internal/terminal/terminalrunner/connections.go
@@ -107,10 +107,28 @@ func (sr *Exec) handleClient(client *ioClient) {
 		})
 	}
 
-	// WRITER: bounded ring + per-write deadline + lagged-detach. Adding
-	// the writer to multiOutW *before* starting Run is safe — Write just
-	// enqueues into the ring until Run starts draining.
+	// Snapshot the capture replay *before* wiring the fan-out so it can be
+	// seeded ahead of any live PTY output in the ring. Reading here (rather
+	// than writing it directly to client.conn after Add, as before) keeps
+	// the single drain goroutine the sole writer of client.conn: replay and
+	// live output are serialized through one ring, so the drain's per-write
+	// SetWriteDeadline can never race a large initial replay written on a
+	// second goroutine (issue #299). An unreadable capture is non-fatal —
+	// fall through with an empty replay rather than denying the live attach.
+	log, errLog := sr.readLogFile()
+	if errLog != nil {
+		sr.logger.Warn("failed to read log file for client attach", "err", errLog)
+		log = nil
+	}
+
+	// WRITER: bounded ring + per-write deadline + lagged-detach. Seed the
+	// replay into the ring (seedReplay grows the byte bound to fit it so a
+	// >1 MiB capture cannot trip the lagged path on the first live Write).
+	// Adding the writer to multiOutW *before* starting Run is safe — Write
+	// just enqueues into the ring until Run starts draining, and the seeded
+	// replay already sits ahead of any live bytes that arrive after Add.
 	aw := newSubscriberWriter(client.conn, defaultSubscriberBufferBytes, detach, sr.logger)
+	aw.seedReplay(log)
 	client.outWriter = aw
 	multiOutW.Add(aw)
 	go aw.Run()
@@ -135,17 +153,6 @@ func (sr *Exec) handleClient(client *ioClient) {
 
 	if errAttach := sr.updateTerminalAttachers(); errAttach != nil {
 		sr.logger.Warn("failed to update metadata on attach", "err", errAttach)
-		return
-	}
-
-	log, errLog := sr.readLogFile()
-	if errLog != nil {
-		sr.logger.Warn("failed to read log file for client attach", "err", errLog)
-		return
-	}
-
-	if _, errWrite := client.conn.Write(log); errWrite != nil {
-		sr.logger.Error("error in pty->conn initial write", "err", errWrite, "client", client.id)
 		return
 	}
 }

--- a/internal/terminal/terminalrunner/subscriber.go
+++ b/internal/terminal/terminalrunner/subscriber.go
@@ -99,6 +99,27 @@ func (s *subscriberWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+// seedReplay pre-loads the ring with the capture replay so the single
+// drain goroutine emits it ahead of any live PTY output, and grows the
+// byte bound by the replay size so a >1 MiB capture cannot make the first
+// live Write trip the lagged path and disconnect a freshly attached
+// client. Must be called before the writer is registered in the fan-out
+// (i.e. before any concurrent Write) and before Run starts. This keeps the
+// drain goroutine the sole writer of conn — its per-write SetWriteDeadline
+// can never race a large initial replay written on a second goroutine
+// (issue #299). A zero-length replay is a no-op, leaving the default bound.
+func (s *subscriberWriter) seedReplay(b []byte) {
+	if len(b) == 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, _ = s.buf.Write(b)
+	// Preserve the original headroom for live output on top of the seeded
+	// replay; without this the first live Write would overflow the bound.
+	s.maxBytes += len(b)
+}
+
 // Close requests a graceful shutdown. It signals drain so any pending
 // bytes are flushed to the conn; drain itself closes the conn on exit.
 // Safe to call repeatedly.

--- a/internal/terminal/terminalrunner/subscriber_test.go
+++ b/internal/terminal/terminalrunner/subscriber_test.go
@@ -18,6 +18,7 @@ package terminalrunner
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"log/slog"
 	"net"
@@ -73,6 +74,67 @@ func TestSubscriber_DeliversBytesInOrder(t *testing.T) {
 	}
 	if !detached.Load() {
 		t.Fatal("detach callback not invoked on clean close")
+	}
+}
+
+// TestSubscriber_SeededReplayPrecedesLiveOutputLargeCapture is the
+// regression for issue #299: attaching a second client to a busy terminal
+// with a large (>1 MiB) capture used to write the replay directly to the
+// conn on a second goroutine, racing the drain goroutine's per-write
+// SetWriteDeadline and disconnecting the new client with i/o timeout. The
+// fix seeds the replay into the ring and grows the byte bound so the single
+// drain goroutine emits replay-then-live in order without tripping the
+// lagged path. Without seedReplay's bound growth the first live Write would
+// overflow the 1 MiB ring and the client would receive laggedNotice plus a
+// truncated stream.
+func TestSubscriber_SeededReplayPrecedesLiveOutputLargeCapture(t *testing.T) {
+	// Not t.Parallel: tests in this file mutate subscriberWriteTimeout.
+	clientSide, serverSide := newPipeConnPair()
+	defer clientSide.Close()
+
+	// Replay larger than the 1 MiB ring bound — the case that exposed the bug.
+	replay := bytes.Repeat([]byte("R"), defaultSubscriberBufferBytes+4096)
+	live := []byte("LIVE-AFTER-REPLAY")
+
+	var detached atomic.Bool
+	sub := newSubscriberWriter(
+		serverSide,
+		defaultSubscriberBufferBytes,
+		func() { detached.Store(true) },
+		slog.Default(),
+	)
+	sub.seedReplay(replay)
+	go sub.Run()
+
+	// Live output arrives via the fan-out after the seed, exactly as the PTY
+	// reader would deliver it once the writer is registered in multiOutW.
+	go func() {
+		n, err := sub.Write(live)
+		if err != nil || n != len(live) {
+			t.Errorf("live Write: n=%d err=%v", n, err)
+		}
+		_ = sub.Close()
+	}()
+
+	got, err := io.ReadAll(clientSide)
+	if err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("read: %v", err)
+	}
+	if bytes.Contains(got, laggedNotice) {
+		t.Fatal("client was lagged-dropped during large replay (issue #299 regression)")
+	}
+	want := append(append([]byte(nil), replay...), live...)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("stream mismatch: got %d bytes, want %d (replay=%d live=%d)",
+			len(got), len(want), len(replay), len(live))
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for !detached.Load() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !detached.Load() {
+		t.Fatal("detach callback not invoked after clean close")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Attaching a second client to a busy terminal with a large (>1 MiB) capture file dumped the full replay and then immediately disconnected the new client with `i/o timeout`. Root cause (per #299): `handleClient` wrote the entire capture replay **directly to `client.conn`** *after* it had already started the bounded-writer drain goroutine on the **same conn**. `SetWriteDeadline` on a `net.UnixConn` is connection-global and absolute, so the drain goroutine's `now+5s` deadline applied to (and tripped) the large replay write, and the two goroutines interleaved bytes on the same fd.
- This implements the issue's **preferred option 1**: the replay is now enqueued *through the subscriber ring* so the single drain goroutine is the sole writer of `client.conn` and owns all write deadlines.

## Changes

- `subscriber.go`: new `seedReplay(b)` — pre-loads the ring with the capture replay (so it drains ahead of any live PTY output) and grows `maxBytes` by the replay size. The bound growth is essential: without it, a replay near or above the 1 MiB ring cap would make the *first* live `Write` overflow and lagged-drop a freshly attached client. The original 1 MiB headroom for live output is preserved on top of the seed.
- `connections.go` (`handleClient`): read the capture **before** wiring the fan-out, seed it into the writer, then `multiOutW.Add` + `go aw.Run()`. Removed the direct `client.conn.Write(log)` second-writer path entirely.
- `subscriber_test.go`: regression test `TestSubscriber_SeededReplayPrecedesLiveOutputLargeCapture` — seeds a >1 MiB replay, delivers live output via the ring, and asserts the client receives `replay`-then-`live` in order with no `laggedNotice` and no truncation.

## Non-obvious calls (reviewer please confirm)

- **Behavior change on unreadable capture:** the old code did `return` (aborting `handleClient`) when `readLogFile` failed — but in the old ordering the writer/reader were already wired, so the attach survived with no replay. In the new ordering `readLogFile` runs *first*, so a `return` there would deny the attach entirely. I instead **fall through with an empty replay** (log the warning, `log = nil`) so a missing/unreadable capture never denies the live attach. This is strictly more lenient and matches the old observable outcome (attach continues, no replay).
- **Snapshot-vs-live window:** there is a microsecond gap between `readLogFile` returning and `multiOutW.Add`. The issue notes option 2 (replay before fan-out) "reopens the snapshot-vs-live gap"; option 1 minimizes it because the seed is an in-memory copy followed immediately by `Add`, versus writing the whole (potentially slow) replay to the conn before `Add`. The capture file is itself a writer in `multiOutW`, so eliminating the window entirely would require snapshotting under the multiwriter lock — out of scope for this fix and not required by the AC.
- **Elevated `maxBytes` persists for the client's lifetime:** after the replay drains, the ring's lag bound stays at `replay + 1 MiB` rather than resetting to 1 MiB. This is harmless (still bounded, per-client, torn down on detach) and avoids a reset race; chose simplicity over reclaiming the slack.

## Test plan

- [x] `make sbsh-sb` + `file ./sbsh` → ELF executable
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` (full CI unit target)
- [x] `go test ./internal/terminal/terminalrunner/... -run Subscriber -race` (race detector, incl. new regression test)
- [x] `go test -tags=integration ./cmd/sb/get/...`
- [x] library-consumer example `go build ./... && go vet ./...`
- [x] `HOME=$HOME E2E_BIN_DIR=$(pwd) go test ./e2e`
- [x] `pre-commit run --files <changed>` (golangci-lint, gofmt, addlicense, etc.)

## Acceptance criteria

- [x] Attaching a second client to a terminal with an active session and a >1 MiB capture no longer disconnects with `i/o timeout` — replay is seeded into the ring, sole-writer ownership removes the deadline race.
- [x] Capture replay and live PTY output reach the client without byte interleaving/corruption — seeded ahead of live bytes, serialized through one drain goroutine (asserted by the regression test).
- [x] No drain-goroutine `SetWriteDeadline` can trip the initial replay write — the direct second-writer path is removed; the drain owns `client.conn` exclusively.
- [x] Regression test exercising attach-to-busy-terminal with capture larger than the subscriber ring bound.

Closes #299