### PR TITLE
feat(attach): repaint current screen on attach; --full-capture for full replay

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -113,6 +113,8 @@ var (
 		"sb/attach/disableDetachKeystroke",
 	)
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SB_ATTACH_FULL_CAPTURE = DefineKV("SB_ATTACH_FULL_CAPTURE", "sb/attach/fullCapture")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SB_DETACH_NAME = DefineKV("SB_DETACH_NAME", "sb/detach/name")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SB_DETACH_ID = DefineKV("SB_DETACH_ID", "sb/detach/id")

--- a/cmd/sb/attach/attach.go
+++ b/cmd/sb/attach/attach.go
@@ -172,6 +172,9 @@ func setupAttachCmdFlags(attachCmd *cobra.Command) {
 	_ = viper.BindPFlag(config.SB_ATTACH_SOCKET.ViperKey, attachCmd.Flags().Lookup("socket"))
 	attachCmd.Flags().Bool("disable-detach", false, "Disable detach keystroke (^] twice)")
 	_ = viper.BindPFlag(config.SB_ATTACH_DISABLE_DETACH_KEYSTROKE.ViperKey, attachCmd.Flags().Lookup("disable-detach"))
+	attachCmd.Flags().
+		Bool("full-capture", false, "Replay the entire raw capture buffer on attach instead of repainting the current screen")
+	_ = viper.BindPFlag(config.SB_ATTACH_FULL_CAPTURE.ViperKey, attachCmd.Flags().Lookup("full-capture"))
 }
 
 func run(
@@ -194,8 +197,18 @@ func run(
 	}
 
 	disableDetach := viper.GetBool(config.SB_ATTACH_DISABLE_DETACH_KEYSTROKE.ViperKey)
+	fullCapture := viper.GetBool(config.SB_ATTACH_FULL_CAPTURE.ViperKey)
 
-	logger.DebugContext(ctx, "delegating to pkg/attach.Run", "socket", socketPath, "disable_detach", disableDetach)
+	logger.DebugContext(
+		ctx,
+		"delegating to pkg/attach.Run",
+		"socket",
+		socketPath,
+		"disable_detach",
+		disableDetach,
+		"full_capture",
+		fullCapture,
+	)
 
 	runErr := attach.Run(ctx, attach.Options{
 		SocketPath:             socketPath,
@@ -203,6 +216,7 @@ func run(
 		Stdout:                 os.Stdout,
 		Stderr:                 os.Stderr,
 		DisableDetachKeystroke: disableDetach,
+		FullCapture:            fullCapture,
 		Logger:                 logger,
 	})
 	if runErr == nil || errors.Is(runErr, context.Canceled) || errors.Is(runErr, errdefs.ErrContextDone) {

--- a/internal/client/clientrunner/io.go
+++ b/internal/client/clientrunner/io.go
@@ -144,7 +144,14 @@ func (sr *Exec) startConnectionManager() error {
 
 func (sr *Exec) attach() error {
 	var response struct{}
-	conn, err := sr.terminalClient.Attach(sr.ctx, &sr.id, &response)
+	sr.metadataMu.RLock()
+	fullCapture := sr.metadata.Spec.FullCapture
+	sr.metadataMu.RUnlock()
+	conn, err := sr.terminalClient.Attach(
+		sr.ctx,
+		&api.AttachRequest{ClientID: sr.id, FullCapture: fullCapture},
+		&response,
+	)
 	if err != nil {
 		sr.logger.ErrorContext(sr.ctx, "attach: failed to attach", "error", err)
 		return err

--- a/internal/client/clientrunner/io_test.go
+++ b/internal/client/clientrunner/io_test.go
@@ -47,7 +47,7 @@ func (m *mockTerminalClient) Detach(_ context.Context, _ *api.ID) error {
 	return nil
 }
 
-func (m *mockTerminalClient) Attach(_ context.Context, _ *api.ID, _ any) (net.Conn, error) {
+func (m *mockTerminalClient) Attach(_ context.Context, _ *api.AttachRequest, _ any) (net.Conn, error) {
 	return nil, errors.New("not implemented in mock")
 }
 

--- a/internal/terminal/controller.go
+++ b/internal/terminal/controller.go
@@ -306,22 +306,22 @@ func (c *Controller) Resize(args api.ResizeArgs) {
 	}
 }
 
-func (c *Controller) Attach(id *api.ID, response *api.ResponseWithFD) error {
+func (c *Controller) Attach(req *api.AttachRequest, response *api.ResponseWithFD) error {
 	c.srMu.RLock()
 	sr := c.sr
 	c.srMu.RUnlock()
 	if sr == nil {
 		return errors.New("terminal runner not initialized")
 	}
-	err := sr.Attach(id, response)
+	err := sr.Attach(req, response)
 	if err != nil {
-		c.logger.ErrorContext(c.ctx, "Attach failed", "id", id, "error", err)
+		c.logger.ErrorContext(c.ctx, "Attach failed", "id", req.ClientID, "error", err)
 		return err
 	}
 
 	errPostAttach := sr.PostAttachShell()
 	if errPostAttach != nil {
-		c.logger.ErrorContext(c.ctx, "Attach failed", "id", id, "error", errPostAttach)
+		c.logger.ErrorContext(c.ctx, "Attach failed", "id", req.ClientID, "error", errPostAttach)
 		return errPostAttach
 	}
 

--- a/internal/terminal/controller_fake.go
+++ b/internal/terminal/controller_fake.go
@@ -32,7 +32,7 @@ type ControllerTest struct {
 	PingFunc       func(in *api.PingMessage) (*api.PingMessage, error)
 	CloseFunc      func(reason error) error
 	ResizeFunc     func()
-	AttachFunc     func(id *api.ID, response *api.ResponseWithFD) error
+	AttachFunc     func(req *api.AttachRequest, response *api.ResponseWithFD) error
 	DetachFunc     func(id *api.ID) error
 	MetadataFunc   func() (*api.TerminalDoc, error)
 	StateFunc      func() (*api.TerminalStatusMode, error)
@@ -84,9 +84,9 @@ func (f *ControllerTest) Resize(_ api.ResizeArgs) {
 	}
 }
 
-func (f *ControllerTest) Attach(id *api.ID, response *api.ResponseWithFD) error {
+func (f *ControllerTest) Attach(req *api.AttachRequest, response *api.ResponseWithFD) error {
 	if f.AttachFunc != nil {
-		return f.AttachFunc(id, response)
+		return f.AttachFunc(req, response)
 	}
 	return errdefs.ErrFuncNotSet
 }

--- a/internal/terminal/terminalrpc/rpc_server.go
+++ b/internal/terminal/terminalrpc/rpc_server.go
@@ -54,8 +54,8 @@ func (s *TerminalControllerRPC) Detach(id *api.ID, _ *api.Empty) error {
 	return s.Core.Detach(id)
 }
 
-func (s *TerminalControllerRPC) Attach(id *api.ID, response *api.ResponseWithFD) error {
-	return s.Core.Attach(id, response)
+func (s *TerminalControllerRPC) Attach(req *api.AttachRequest, response *api.ResponseWithFD) error {
+	return s.Core.Attach(req, response)
 }
 
 func (s *TerminalControllerRPC) Metadata(_ api.Empty, metadata *api.TerminalDoc) error {

--- a/internal/terminal/terminalrunner/connections.go
+++ b/internal/terminal/terminalrunner/connections.go
@@ -107,28 +107,30 @@ func (sr *Exec) handleClient(client *ioClient) {
 		})
 	}
 
-	// Snapshot the capture replay *before* wiring the fan-out so it can be
-	// seeded ahead of any live PTY output in the ring. Reading here (rather
-	// than writing it directly to client.conn after Add, as before) keeps
-	// the single drain goroutine the sole writer of client.conn: replay and
-	// live output are serialized through one ring, so the drain's per-write
-	// SetWriteDeadline can never race a large initial replay written on a
-	// second goroutine (issue #299). An unreadable capture is non-fatal —
-	// fall through with an empty replay rather than denying the live attach.
-	log, errLog := sr.readLogFile()
-	if errLog != nil {
-		sr.logger.Warn("failed to read log file for client attach", "err", errLog)
-		log = nil
-	}
+	// Snapshot the initial attach paint *before* wiring the fan-out so it can
+	// be seeded ahead of any live PTY output in the ring. Seeding here (rather
+	// than writing it directly to client.conn after Add) keeps the single
+	// drain goroutine the sole writer of client.conn: paint and live output
+	// are serialized through one ring, so the drain's per-write
+	// SetWriteDeadline can never race a large initial paint written on a
+	// second goroutine (issue #299).
+	//
+	// Default: a bounded repaint of the current screen from the vt-parser
+	// model, so a long-lived terminal no longer floods every newly attached
+	// client with its whole history. --full-capture (client.fullCapture) opts
+	// back into replaying the entire raw capture buffer. An empty paint (no
+	// screen model, or an unreadable capture) is non-fatal — the live attach
+	// proceeds with no seed rather than being denied.
+	initial := sr.initialAttachPaint(client)
 
 	// WRITER: bounded ring + per-write deadline + lagged-detach. Seed the
-	// replay into the ring (seedReplay grows the byte bound to fit it so a
-	// >1 MiB capture cannot trip the lagged path on the first live Write).
-	// Adding the writer to multiOutW *before* starting Run is safe — Write
-	// just enqueues into the ring until Run starts draining, and the seeded
-	// replay already sits ahead of any live bytes that arrive after Add.
+	// initial paint into the ring (seedReplay grows the byte bound to fit it
+	// so a >1 MiB full capture cannot trip the lagged path on the first live
+	// Write). Adding the writer to multiOutW *before* starting Run is safe —
+	// Write just enqueues into the ring until Run starts draining, and the
+	// seeded paint already sits ahead of any live bytes that arrive after Add.
 	aw := newSubscriberWriter(client.conn, defaultSubscriberBufferBytes, detach, sr.logger)
-	aw.seedReplay(log)
+	aw.seedReplay(initial)
 	client.outWriter = aw
 	multiOutW.Add(aw)
 	go aw.Run()
@@ -155,6 +157,32 @@ func (sr *Exec) handleClient(client *ioClient) {
 		sr.logger.Warn("failed to update metadata on attach", "err", errAttach)
 		return
 	}
+}
+
+// initialAttachPaint returns the bytes written to a newly attached client
+// before live PTY output begins. For a full-capture client it is the entire
+// raw capture buffer (legacy behavior); otherwise it is a repaint of the
+// current screen from the vt-parser model. A nil/empty result means "write
+// nothing" — a missing capture or an absent screen model never denies the
+// attach, which proceeds with live output only.
+func (sr *Exec) initialAttachPaint(client *ioClient) []byte {
+	if client.fullCapture {
+		log, errLog := sr.readCaptureFile()
+		if errLog != nil {
+			sr.logger.Warn("failed to read capture file for client attach", "err", errLog)
+			return nil
+		}
+		return log
+	}
+
+	sr.ptyPipesMu.RLock()
+	screen := sr.ptyPipes.screen
+	sr.ptyPipesMu.RUnlock()
+	if screen == nil {
+		sr.logger.Warn("no screen model for client attach repaint", "client", client.id)
+		return nil
+	}
+	return screen.repaint()
 }
 
 func (sr *Exec) addClient(c *ioClient) {

--- a/internal/terminal/terminalrunner/connections_attach_paint_test.go
+++ b/internal/terminal/terminalrunner/connections_attach_paint_test.go
@@ -1,0 +1,93 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrunner
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// Default attach (fullCapture=false) synthesizes a bounded repaint from the
+// live screen model — the current screen, not the raw capture file.
+func TestInitialAttachPaintRepaintsScreen(t *testing.T) {
+	sr := newScreenExec()
+	screen := newScreenModel()
+	feed(screen, "current screen state")
+	sr.ptyPipesMu.Lock()
+	sr.ptyPipes.screen = screen
+	sr.ptyPipesMu.Unlock()
+
+	id := api.ID("c1")
+	got := string(sr.initialAttachPaint(&ioClient{id: &id, fullCapture: false}))
+
+	if !strings.Contains(got, escClearScreen) {
+		t.Errorf("repaint paint should clear the screen; got %q", got)
+	}
+	if !strings.Contains(got, "current screen state") {
+		t.Errorf("repaint paint should contain the live screen; got %q", got)
+	}
+}
+
+// --full-capture (fullCapture=true) replays the entire raw capture buffer
+// verbatim, byte-for-byte, including control sequences and history.
+func TestInitialAttachPaintFullCaptureReplaysRaw(t *testing.T) {
+	sr := newScreenExec()
+
+	raw := "line one\r\n\x1b[31mcolored\x1b[0m\r\nline three\r\n"
+	captureFile := filepath.Join(t.TempDir(), "capture.raw")
+	if err := os.WriteFile(captureFile, []byte(raw), 0o600); err != nil {
+		t.Fatalf("write capture file: %v", err)
+	}
+	sr.metadataMu.Lock()
+	sr.metadata.Status.CaptureFile = captureFile
+	sr.metadataMu.Unlock()
+
+	id := api.ID("c2")
+	got := sr.initialAttachPaint(&ioClient{id: &id, fullCapture: true})
+	if string(got) != raw {
+		t.Errorf("full-capture should replay the raw buffer verbatim; got %q want %q", got, raw)
+	}
+}
+
+// A missing/unreadable capture on the full-capture path returns no bytes
+// (write nothing) rather than denying the attach.
+func TestInitialAttachPaintFullCaptureMissingFile(t *testing.T) {
+	sr := newScreenExec()
+	sr.metadataMu.Lock()
+	sr.metadata.Status.CaptureFile = filepath.Join(t.TempDir(), "does-not-exist")
+	sr.metadataMu.Unlock()
+
+	id := api.ID("c3")
+	if got := sr.initialAttachPaint(&ioClient{id: &id, fullCapture: true}); got != nil {
+		t.Errorf("missing capture should yield no bytes; got %q", got)
+	}
+}
+
+// An absent screen model on the repaint path returns no bytes rather than
+// panicking — the attach still proceeds with live output only.
+func TestInitialAttachPaintRepaintNoScreen(t *testing.T) {
+	sr := newScreenExec() // ptyPipes.screen is nil
+
+	id := api.ID("c4")
+	if got := sr.initialAttachPaint(&ioClient{id: &id, fullCapture: false}); got != nil {
+		t.Errorf("nil screen model should yield no bytes; got %q", got)
+	}
+}

--- a/internal/terminal/terminalrunner/io.go
+++ b/internal/terminal/terminalrunner/io.go
@@ -20,13 +20,13 @@ import (
 	"os"
 )
 
-func (sr *Exec) readLogFile() ([]byte, error) {
+func (sr *Exec) readCaptureFile() ([]byte, error) {
 	sr.metadataMu.RLock()
 	captureFile := sr.metadata.Status.CaptureFile
 	sr.metadataMu.RUnlock()
 	data, err := os.ReadFile(captureFile)
 	if err != nil {
-		sr.logger.Warn("failed to read log file", "err", err)
+		sr.logger.Warn("failed to read capture file", "err", err)
 		return nil, err
 	}
 	return data, nil

--- a/internal/terminal/terminalrunner/lifecycle.go
+++ b/internal/terminal/terminalrunner/lifecycle.go
@@ -370,8 +370,8 @@ func (sr *Exec) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func (sr *Exec) Attach(clientID *api.ID, response *api.ResponseWithFD) error {
-	cliFD, err := sr.CreateNewClient(clientID)
+func (sr *Exec) Attach(req *api.AttachRequest, response *api.ResponseWithFD) error {
+	cliFD, err := sr.CreateNewClient(&req.ClientID, req.FullCapture)
 	if err != nil {
 		return err
 	}
@@ -382,7 +382,7 @@ func (sr *Exec) Attach(clientID *api.ID, response *api.ResponseWithFD) error {
 
 	fds := []int{cliFD}
 
-	sr.logger.Debug("Attach response", "id", clientID, "ok", payload.OK, "fds", fds)
+	sr.logger.Debug("Attach response", "id", req.ClientID, "fullCapture", req.FullCapture, "ok", payload.OK, "fds", fds)
 
 	response.JSON = payload
 	response.FDs = fds

--- a/internal/terminal/terminalrunner/sockets.go
+++ b/internal/terminal/terminalrunner/sockets.go
@@ -199,7 +199,7 @@ func (sr *Exec) OpenSocketCtrl() error {
 	return nil
 }
 
-func (sr *Exec) CreateNewClient(clientID *api.ID) (int, error) {
+func (sr *Exec) CreateNewClient(clientID *api.ID, fullCapture bool) (int, error) {
 	sr.logger.Debug("CreateNewClient: creating socketpair", "id", clientID)
 	sv, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|sockCloexec, 0)
 	if err != nil {
@@ -219,7 +219,7 @@ func (sr *Exec) CreateNewClient(clientID *api.ID) (int, error) {
 	}
 	_ = f.Close() // release the duplicate, keep using ioConn
 
-	cl := &ioClient{id: clientID, conn: ioConn}
+	cl := &ioClient{id: clientID, conn: ioConn, fullCapture: fullCapture}
 
 	sr.addClient(cl)
 	sr.logger.Info("CreateNewClient: client added", "id", clientID)

--- a/internal/terminal/terminalrunner/terminal_runner.go
+++ b/internal/terminal/terminalrunner/terminal_runner.go
@@ -47,7 +47,7 @@ type TerminalRunner interface {
 	Resize(args api.ResizeArgs)
 	CreateMetadata() error
 	Detach(id *api.ID) error
-	Attach(id *api.ID, response *api.ResponseWithFD) error
+	Attach(req *api.AttachRequest, response *api.ResponseWithFD) error
 	SetupShell() error
 	OnInitShell() error
 	PostAttachShell() error

--- a/internal/terminal/terminalrunner/terminal_runner_exec.go
+++ b/internal/terminal/terminalrunner/terminal_runner_exec.go
@@ -120,6 +120,10 @@ type ioClient struct {
 	id        *api.ID
 	conn      net.Conn
 	outWriter *subscriberWriter
+	// fullCapture selects the attach replay mode for this client: when true
+	// the full raw capture buffer is replayed, otherwise a bounded repaint
+	// of the current screen is synthesized from the screen model.
+	fullCapture bool
 }
 
 func NewTerminalRunnerExec(ctx context.Context, logger *slog.Logger, spec *api.TerminalSpec) TerminalRunner {

--- a/internal/terminal/terminalrunner/terminal_runner_fake.go
+++ b/internal/terminal/terminalrunner/terminal_runner_fake.go
@@ -36,7 +36,7 @@ type Test struct {
 	ResizeFunc          func(args api.ResizeArgs)
 	IDFunc              func() api.ID
 	CreateMetadataFunc  func() error
-	AttachFunc          func(id *api.ID, response *api.ResponseWithFD) error
+	AttachFunc          func(req *api.AttachRequest, response *api.ResponseWithFD) error
 	DetachFunc          func(id *api.ID) error
 	SetupShellFunc      func() error
 	OnInitShellFunc     func() error
@@ -111,9 +111,9 @@ func (sr *Test) CreateMetadata() error {
 	return nil
 }
 
-func (sr *Test) Attach(id *api.ID, response *api.ResponseWithFD) error {
+func (sr *Test) Attach(req *api.AttachRequest, response *api.ResponseWithFD) error {
 	if sr.AttachFunc != nil {
-		return sr.AttachFunc(id, response)
+		return sr.AttachFunc(req, response)
 	}
 	return errdefs.ErrFuncNotSet
 }

--- a/internal/terminal/terminalrunner/terminal_screen.go
+++ b/internal/terminal/terminalrunner/terminal_screen.go
@@ -26,6 +26,16 @@ import (
 
 const sgrReset = "\x1b[0m"
 
+// Escape sequences used to synthesize an attach repaint (see repaint).
+const (
+	escEnterAltScreen = "\x1b[?1049h" // switch to the alternate screen buffer
+	escClearScreen    = "\x1b[2J"     // erase the entire screen
+	escCursorHome     = "\x1b[H"      // move cursor to row 1, col 1
+	escCursorTo       = "\x1b[%d;%dH" // move cursor to row, col (1-based)
+	escShowCursor     = "\x1b[?25h"   // make the cursor visible
+	escHideCursor     = "\x1b[?25l"   // hide the cursor
+)
+
 // vt10x color encoding boundaries. The 16 ANSI colors occupy [0,16):
 // [0,8) are the basic colors and [8,16) their bright variants. [16,256)
 // is the xterm 256-color palette. 24-bit truecolor is packed as the
@@ -127,6 +137,59 @@ func (m *screenModel) snapshot() *api.ScreenshotResult {
 	}
 	res.Text, res.ANSI = renderGrid(m.vt, cols, rows)
 	return res
+}
+
+// repaint synthesizes a byte sequence that, written to a freshly attached
+// client's raw-mode terminal, reproduces the current screen: alt-screen
+// mode if active, a cleared grid, every visible cell with its SGR colors at
+// its absolute position, and the cursor's position and visibility. Unlike
+// the raw capture replay it is bounded to the viewport regardless of how
+// long the session has run, which is the whole point of repaint-on-attach.
+//
+// Absolute per-row cursor positioning (CSI row;1H) is used instead of
+// newlines so the paint is correct in raw mode, where a bare "\n" is a line
+// feed that does not return the carriage. It is taken under the vt10x state
+// lock so cells, cursor, and mode form one consistent frame.
+func (m *screenModel) repaint() []byte {
+	m.vt.Lock()
+	defer m.vt.Unlock()
+
+	cols, rows := m.vt.Size()
+	cur := m.vt.Cursor()
+	altScreen := m.vt.Mode()&vt10x.ModeAltScreen != 0
+	cursorVisible := m.vt.CursorVisible()
+
+	textLines := make([]string, rows)
+	ansiLines := make([]string, rows)
+	for y := range rows {
+		textLines[y], ansiLines[y] = renderLine(m.vt, cols, y)
+	}
+	// Trailing blank rows need no paint — the screen clear already blanked
+	// them. Stop at the last non-empty row (plain text is the canonical
+	// emptiness signal, mirroring renderGrid).
+	end := len(textLines)
+	for end > 0 && textLines[end-1] == "" {
+		end--
+	}
+
+	var b strings.Builder
+	if altScreen {
+		b.WriteString(escEnterAltScreen)
+	}
+	b.WriteString(escClearScreen)
+	b.WriteString(escCursorHome)
+	for y := range end {
+		fmt.Fprintf(&b, escCursorTo, y+1, 1)
+		b.WriteString(ansiLines[y])
+	}
+	// vt10x cursor coordinates are 0-based; CSI row;colH is 1-based.
+	fmt.Fprintf(&b, escCursorTo, cur.Y+1, cur.X+1)
+	if cursorVisible {
+		b.WriteString(escShowCursor)
+	} else {
+		b.WriteString(escHideCursor)
+	}
+	return []byte(b.String())
 }
 
 // renderGrid walks the grid row by row and produces both the plain-text

--- a/internal/terminal/terminalrunner/terminal_screen_test.go
+++ b/internal/terminal/terminalrunner/terminal_screen_test.go
@@ -212,6 +212,93 @@ func TestScreenModelConcurrentWriteAndSnapshot(t *testing.T) {
 	}
 }
 
+// An empty screen (no output yet, the "empty capture" case) repaints to a
+// bare clear-screen + home, no alt-screen switch, cursor home and visible.
+func TestRepaintEmptyScreen(t *testing.T) {
+	m := newScreenModel()
+	got := string(m.repaint())
+
+	if strings.Contains(got, escEnterAltScreen) {
+		t.Errorf("empty primary screen must not enter alt screen; got %q", got)
+	}
+	if !strings.Contains(got, escClearScreen) || !strings.Contains(got, escCursorHome) {
+		t.Errorf("repaint must clear and home; got %q", got)
+	}
+	// Cursor lands at row 1, col 1 and stays visible.
+	if !strings.HasSuffix(got, "\x1b[1;1H"+escShowCursor) {
+		t.Errorf("empty repaint should end at home with a visible cursor; got %q", got)
+	}
+}
+
+// A plain line of output repaints by positioning at row 1 and writing the
+// glyphs — no newlines, which would stairstep in raw mode.
+func TestRepaintPlainOutput(t *testing.T) {
+	m := newScreenModel()
+	feed(m, "hello world")
+	got := string(m.repaint())
+
+	if !strings.Contains(got, "\x1b[1;1Hhello world") {
+		t.Errorf("repaint should position row 1 then write the line; got %q", got)
+	}
+	if strings.Contains(got, "\n") {
+		t.Errorf("repaint must not use newlines (raw mode); got %q", got)
+	}
+}
+
+// Reattaching to an alt-screen app (vim/htop) must re-enter the alternate
+// buffer and paint its current contents, not the primary screen's history.
+func TestRepaintAltScreen(t *testing.T) {
+	m := newScreenModel()
+	feed(m, "primary content")
+	feed(m, "\x1b[?1049h", "\x1b[2J\x1b[H", "ALT SCREEN APP")
+
+	got := string(m.repaint())
+	if !strings.HasPrefix(got, escEnterAltScreen) {
+		t.Errorf("alt-screen repaint must switch to the alt buffer first; got %q", got)
+	}
+	if !strings.Contains(got, "ALT SCREEN APP") {
+		t.Errorf("repaint should paint the alt-screen contents; got %q", got)
+	}
+	if strings.Contains(got, "primary content") {
+		t.Errorf("alt-screen repaint must not leak primary content; got %q", got)
+	}
+}
+
+// The cursor's position and hidden state survive the repaint.
+func TestRepaintCursorPositionAndVisibility(t *testing.T) {
+	m := newScreenModel()
+	feed(m, "\x1b[5;10H", "\x1b[?25l") // CUP row 5 col 10, then hide cursor
+
+	got := string(m.repaint())
+	if !strings.Contains(got, "\x1b[5;10H") {
+		t.Errorf("repaint should restore the cursor to row 5 col 10; got %q", got)
+	}
+	if !strings.HasSuffix(got, escHideCursor) {
+		t.Errorf("repaint should end with the cursor hidden; got %q", got)
+	}
+}
+
+// Repaint is bounded to the viewport regardless of session length: feeding
+// far more lines than the grid has rows still paints at most one positioned
+// row per grid row, never the whole scrollback history.
+func TestRepaintBoundedToViewport(t *testing.T) {
+	m := newScreenModel()
+	for i := range 1000 {
+		feed(m, "line\r\n")
+		_ = i
+	}
+	got := string(m.repaint())
+
+	if n := strings.Count(got, "\x1b[1;1H"); n != 1 {
+		t.Errorf("repaint should home exactly once; got %d in %q", n, got)
+	}
+	// At most rows positioned writes (CSI <row>;1H) — one per grid row.
+	positioned := strings.Count(got, ";1H")
+	if positioned > vt100Rows+1 { // +1 for the final cursor-restore CUP
+		t.Errorf("repaint painted %d positioned rows, exceeds viewport %d", positioned, vt100Rows)
+	}
+}
+
 func newScreenExec() *Exec {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Exec{

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -41,6 +41,12 @@ type ClientSpec struct {
 	// When true, users can detach by pressing ^] twice. When false, detach keystroke is disabled.
 	DetachKeystroke bool `json:"detachKeystroke,omitempty"`
 
+	// FullCapture, when true, makes attach replay the entire raw capture
+	// buffer (the legacy behavior) instead of the default bounded repaint
+	// of the current screen. It is forwarded to the terminal server via the
+	// Attach RPC; the server owns the replay. Set by the --full-capture flag.
+	FullCapture bool `json:"fullCapture,omitempty"`
+
 	// ClientMode determines whether the client runs a new terminal or attaches to an existing one.
 	ClientMode ClientMode `json:"clientMode,omitempty"`
 }

--- a/pkg/api/terminal.go
+++ b/pkg/api/terminal.go
@@ -29,7 +29,7 @@ type TerminalController interface {
 	Close(reason error) error
 	Resize(ResizeArgs)
 	Detach(id *ID) error
-	Attach(id *ID, reply *ResponseWithFD) error
+	Attach(req *AttachRequest, reply *ResponseWithFD) error
 	Metadata() (*TerminalDoc, error)
 	State() (*TerminalStatusMode, error)
 	Stop(args *StopArgs) error
@@ -242,6 +242,17 @@ type WriteRequest struct {
 // not appear in TerminalStatus.Attachers.
 type SubscribeRequest struct {
 	ClientID ID
+}
+
+// AttachRequest is the argument for an Attach RPC. ClientID identifies the
+// attaching client (used for attacher accounting and to label the IO fd
+// the server hands back). FullCapture opts into replaying the entire raw
+// capture buffer on attach — the legacy behavior — instead of the default
+// bounded repaint synthesized from the live screen model. It mirrors the
+// CLI's --full-capture flag, which plumbs through ClientSpec.FullCapture.
+type AttachRequest struct {
+	ClientID    ID
+	FullCapture bool
 }
 
 // ResponseWithFD carries a normal JSON result plus OOB file descriptors.

--- a/pkg/attach/attach.go
+++ b/pkg/attach/attach.go
@@ -57,6 +57,11 @@ type Options struct {
 	// escape sequence and triggers a clean detach when it fires.
 	DisableDetachKeystroke bool
 
+	// FullCapture, when true, replays the entire raw capture buffer on
+	// attach instead of the default bounded repaint of the current screen.
+	// It flows through ClientSpec.FullCapture to the terminal server.
+	FullCapture bool
+
 	// Logger is a structured logger for diagnostics. Defaults to a
 	// discard logger when nil so embedders aren't forced to wire one
 	// in.
@@ -129,6 +134,7 @@ func Run(ctx context.Context, opts Options) error {
 			SockerCtrl:      clientCtrlSocket,
 			ClientMode:      api.AttachToTerminal,
 			DetachKeystroke: !opts.DisableDetachKeystroke,
+			FullCapture:     opts.FullCapture,
 			TerminalSpec: &api.TerminalSpec{
 				SocketFile: opts.SocketPath,
 			},

--- a/pkg/attach/attach_test.go
+++ b/pkg/attach/attach_test.go
@@ -72,7 +72,7 @@ func (f *fakeTerminalController) State(_ *api.Empty, out *api.TerminalStatusMode
 	return nil
 }
 
-func (f *fakeTerminalController) Attach(_ *api.ID, _ *api.Empty) error {
+func (f *fakeTerminalController) Attach(_ *api.AttachRequest, _ *api.Empty) error {
 	f.attachCalls.Add(1)
 	if f.attachBlock != nil {
 		<-f.attachBlock

--- a/pkg/builder/client.go
+++ b/pkg/builder/client.go
@@ -41,6 +41,7 @@ type clientConfig struct {
 	mode            api.ClientMode
 	modeSet         bool
 	detachKeystroke *bool
+	fullCapture     bool
 	terminalSpec    *api.TerminalSpec
 }
 
@@ -87,6 +88,13 @@ func WithClientDetachKeystroke(enable bool) ClientOption {
 		v := enable
 		c.detachKeystroke = &v
 	}
+}
+
+// WithClientFullCapture opts into replaying the entire raw capture
+// buffer on attach instead of the default bounded screen repaint. The
+// default is false (repaint). Mirrors the CLI's --full-capture flag.
+func WithClientFullCapture(enable bool) ClientOption {
+	return func(c *clientConfig) { c.fullCapture = enable }
 }
 
 // WithClientTerminalSpec embeds a pre-built TerminalSpec into the
@@ -166,6 +174,7 @@ func BuildClientDoc(
 			SockerCtrl:      cfg.socketFile,
 			TerminalSpec:    cfg.terminalSpec,
 			DetachKeystroke: detach,
+			FullCapture:     cfg.fullCapture,
 			ClientMode:      mode,
 		},
 	}

--- a/pkg/builder/client_test.go
+++ b/pkg/builder/client_test.go
@@ -64,6 +64,9 @@ func TestBuildClientDoc_Defaults(t *testing.T) {
 	if !doc.Spec.DetachKeystroke {
 		t.Fatal("expected DetachKeystroke to default true")
 	}
+	if doc.Spec.FullCapture {
+		t.Fatal("expected FullCapture to default false (repaint)")
+	}
 	if doc.Spec.ClientMode != api.RunNewTerminal {
 		t.Fatalf("mode: want RunNewTerminal, got %v", doc.Spec.ClientMode)
 	}
@@ -85,6 +88,7 @@ func TestBuildClientDoc_Overrides(t *testing.T) {
 		builder.WithClientLogFile("/tmp/custom.log"),
 		builder.WithClientMode(api.AttachToTerminal),
 		builder.WithClientDetachKeystroke(false),
+		builder.WithClientFullCapture(true),
 		builder.WithClientTerminalSpec(embed),
 	)
 	if err != nil {
@@ -107,6 +111,9 @@ func TestBuildClientDoc_Overrides(t *testing.T) {
 	}
 	if doc.Spec.DetachKeystroke {
 		t.Fatal("expected DetachKeystroke=false after WithClientDetachKeystroke(false)")
+	}
+	if !doc.Spec.FullCapture {
+		t.Fatal("expected FullCapture=true after WithClientFullCapture(true)")
 	}
 	if doc.Spec.TerminalSpec != embed {
 		t.Fatal("expected embedded TerminalSpec to be the same pointer")

--- a/pkg/rpcclient/terminal/iface.go
+++ b/pkg/rpcclient/terminal/iface.go
@@ -27,7 +27,7 @@ type Client interface {
 	Ping(ctx context.Context, ping *api.PingMessage, pong *api.PingMessage) error
 	Resize(ctx context.Context, args *api.ResizeArgs) error
 	Detach(ctx context.Context, id *api.ID) error
-	Attach(ctx context.Context, clientID *api.ID, response any) (net.Conn, error)
+	Attach(ctx context.Context, req *api.AttachRequest, response any) (net.Conn, error)
 	Close() error
 	Metadata(ctx context.Context, metadata *api.TerminalDoc) error
 	State(ctx context.Context, state *api.TerminalStatusMode) error

--- a/pkg/rpcclient/terminal/rpc_session.go
+++ b/pkg/rpcclient/terminal/rpc_session.go
@@ -187,7 +187,7 @@ func (c *client) Detach(ctx context.Context, id *api.ID) error {
 }
 
 // Attach (uses FD-aware codec) returns the IO net.Conn built from the FD sent via SCM_RIGHTS; also fills 'out' with JSON result.
-func (c *client) Attach(ctx context.Context, id *api.ID, out any) (net.Conn, error) {
+func (c *client) Attach(ctx context.Context, req *api.AttachRequest, out any) (net.Conn, error) {
 	var gotFDs []int
 
 	c.logger.InfoContext(ctx, "Attach RPC call starting")
@@ -195,7 +195,7 @@ func (c *client) Attach(ctx context.Context, id *api.ID, out any) (net.Conn, err
 	err := c.callWithCodec(
 		ctx,
 		api.TerminalMethodAttach,
-		id,
+		req,
 		out,
 		func(conn net.Conn) (rpc.ClientCodec, func(), error) {
 			c.logger.DebugContext(ctx, "preparing codec for Attach")

--- a/pkg/spawn/client.go
+++ b/pkg/spawn/client.go
@@ -167,7 +167,7 @@ func validateClientInputs(doc *api.ClientDoc, opts ClientOptions) error {
 // If --id and --name are both set the CLI rejects the combination,
 // so spawn deterministically prefers ID (matches CLI precedence).
 func buildClientAttachArgs(doc *api.ClientDoc, opts ClientOptions) []string {
-	const maxAttachArgs = 8 // --run-path X attach --socket S --id I --disable-detach
+	const maxAttachArgs = 9 // --run-path X attach --socket S --id I --disable-detach --full-capture
 	args := make([]string, 0, maxAttachArgs+len(opts.ExtraArgs))
 
 	if doc.Spec.RunPath != "" {
@@ -178,6 +178,10 @@ func buildClientAttachArgs(doc *api.ClientDoc, opts ClientOptions) []string {
 
 	if !doc.Spec.DetachKeystroke {
 		args = append(args, "--disable-detach")
+	}
+
+	if doc.Spec.FullCapture {
+		args = append(args, "--full-capture")
 	}
 
 	term := doc.Spec.TerminalSpec

--- a/pkg/spawn/client_test.go
+++ b/pkg/spawn/client_test.go
@@ -157,6 +157,34 @@ func TestBuildClientAttachArgs_ByName_DisableDetach(t *testing.T) {
 	}
 }
 
+// TestBuildClientAttachArgs_FullCapture covers the --full-capture leg:
+// ClientSpec.FullCapture=true appends the flag (after --disable-detach,
+// before the terminal selector), mirroring the --disable-detach precedent.
+func TestBuildClientAttachArgs_FullCapture(t *testing.T) {
+	t.Parallel()
+	doc := &api.ClientDoc{
+		Spec: api.ClientSpec{
+			RunPath:         "/run/sbsh",
+			SockerCtrl:      "/run/sbsh/clients/c-4/socket",
+			ClientMode:      api.AttachToTerminal,
+			DetachKeystroke: true, // no --disable-detach
+			FullCapture:     true,
+			TerminalSpec:    &api.TerminalSpec{ID: "t-4"},
+		},
+	}
+	got := buildClientAttachArgs(doc, ClientOptions{})
+	want := []string{
+		"--run-path", "/run/sbsh",
+		"attach",
+		"--socket", "/run/sbsh/clients/c-4/socket",
+		"--full-capture",
+		"--id", "t-4",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildClientAttachArgs = %q; want %q", got, want)
+	}
+}
+
 // TestBuildClientAttachArgs_IDWinsOverName locks down the tie-break
 // rule: when a TerminalSpec carries both ID and Name, spawn emits
 // --id only (no positional name arg). This matches `sb attach`, which

--- a/pkg/terminal/server/adapter.go
+++ b/pkg/terminal/server/adapter.go
@@ -65,12 +65,12 @@ func (a *rpcAdapter) Detach(id *api.ID) error {
 	return r.Detach(id)
 }
 
-func (a *rpcAdapter) Attach(id *api.ID, response *api.ResponseWithFD) error {
+func (a *rpcAdapter) Attach(req *api.AttachRequest, response *api.ResponseWithFD) error {
 	r := a.srv.getRunner()
 	if r == nil {
 		return errors.New("server: terminal not running")
 	}
-	if err := r.Attach(id, response); err != nil {
+	if err := r.Attach(req, response); err != nil {
 		return err
 	}
 	return r.PostAttachShell()

--- a/pkg/terminal/server/server_attach_fdleak_linux_test.go
+++ b/pkg/terminal/server/server_attach_fdleak_linux_test.go
@@ -108,7 +108,7 @@ func TestServer_AttachDetachCycles_NoFDLeak(t *testing.T) {
 }
 
 func attachDetachOnce(ctx context.Context, client rpcclient.Client, id api.ID) error {
-	conn, err := client.Attach(ctx, &id, nil)
+	conn, err := client.Attach(ctx, &api.AttachRequest{ClientID: id}, nil)
 	if err != nil {
 		return fmt.Errorf("Attach(%s): %w", id, err)
 	}

--- a/pkg/terminal/server/server_attach_pausedattacher_linux_test.go
+++ b/pkg/terminal/server/server_attach_pausedattacher_linux_test.go
@@ -112,7 +112,7 @@ func TestServer_PausedAttacher_DoesNotHeadOfLineBlock(t *testing.T) {
 
 func attachClient(ctx context.Context, t *testing.T, client rpcclient.Client, id api.ID) net.Conn {
 	t.Helper()
-	conn, err := client.Attach(ctx, &id, nil)
+	conn, err := client.Attach(ctx, &api.AttachRequest{ClientID: id}, nil)
 	if err != nil {
 		t.Fatalf("Attach(%s): %v", id, err)
 	}


### PR DESCRIPTION
## Summary

- On attach, the terminal used to replay the **entire** capture file to every newly attached client (`readLogFile` → write whole buffer). On a long-lived terminal this floods the client with the full session history on every attach. This implements #71: **default attach now repaints the current screen** (synthesized from #295's vt-parser screen model, bounded to the viewport regardless of session length), and **`--full-capture`** opts back into the legacy full-raw-replay as an explicit escape hatch.
- `readLogFile` is renamed to `readCaptureFile` (it reads `Spec.CaptureFile` and the old name collided with `api.ClientSpec.LogFile`), including the internal warn line and the caller string.

## Design / how it works

- **Repaint synthesis** (`screenModel.repaint()`, `terminal_screen.go`): under the vt10x state lock, emits alt-screen enter (if active), clear+home, each visible row at an **absolute** cursor position (`CSI row;1H` — not newlines, which stairstep in raw mode) with its SGR colors, then restores the cursor position and visibility. Trailing blank rows are skipped (the clear already blanked them).
- **Flag plumbing** mirrors the `--disable-detach` precedent: `--full-capture` → `SB_ATTACH_FULL_CAPTURE` viper key → `pkg/attach.Options.FullCapture` → `api.ClientSpec.FullCapture`. Builder parity: `WithClientFullCapture`. Spawn parity: `buildClientAttachArgs` re-emits `--full-capture`.
- **The decision is server-side** (the server owns the attach replay in `handleClient`), so the flag is carried across the Attach RPC. The `Attach` RPC arg changed from `*api.ID` to a new `api.AttachRequest{ClientID, FullCapture}` (same shape as the existing `SubscribeRequest`), threaded through every Attach implementation + fakes. `clientrunner` reads `Spec.FullCapture` and forwards it.
- **Integrated with #301** (merged mid-task): the initial paint is **seeded through the subscriber ring** (`aw.seedReplay`) rather than written directly to `client.conn`, preserving #301's sole-writer / no-write-deadline-race guarantee for the full-capture (>1 MiB) path. `initialAttachPaint` returns the repaint or the raw capture; the seed mechanism is unchanged.

## Non-obvious calls (reviewer please confirm)

- **Server-side consumption diverges from `DetachKeystroke`.** The issue says plumb "the same way `--disable-detach` does." That precedent is consumed purely client-side (`clientrunner`); the replay is server-side, so `FullCapture` additionally crosses the Attach RPC. The CLI→viper→`ClientSpec` portion matches the precedent exactly; the extra hop is inherent to where the behavior lives. This changes the public `Attach` RPC signature (`pkg/api`, `pkg/rpcclient`) — flagging in case that surface is sensitive.
- **Empty paint is non-fatal.** A missing/unreadable capture (full-capture path) or an absent screen model (repaint path) seeds nothing and the live attach proceeds — strictly more lenient than denying the attach.
- **`sbsh` root (create+attach) is left on the default repaint path.** A brand-new terminal has an empty screen, so repaint = clear screen; `--full-capture` is only wired on `sb attach`, matching the issue's `sb attach` framing.

## Test plan

- [x] `make sbsh-sb` + `file ./sbsh` → ELF executable
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (full CI target: cmd/sb, cmd/sbsh, internal/terminal, internal/client, `-tags=integration ./cmd/sb/get`, e2e)
- [x] `go test ./pkg/...` (incl. server attach fd-leak / paused-attacher)
- [x] `go test -race ./internal/terminal/terminalrunner/... -run 'Subscriber|Repaint|InitialAttachPaint|Screen|Client'`
- [x] library-consumer example `go build ./... && go vet ./...`
- [x] `pre-commit run --files <changed>` (golangci-lint, gofmt, addlicense)
- [x] Rebased onto current `origin/main` (resolved the #301 overlap in `handleClient`)

## Acceptance criteria

- [x] Default `sb attach` repaints the current screen from the screen model, not the whole capture (`screenModel.repaint()`, seeded via `initialAttachPaint`).
- [x] Alt-screen reattach shows a correct, uncorrupted screen — `TestRepaintAltScreen` (re-enters the alt buffer, paints alt contents, no primary leak).
- [x] `--full-capture` replays the entire raw capture buffer; plumbs through `ClientSpec` like `--disable-detach` (+ builder + spawn parity) — `TestInitialAttachPaintFullCaptureReplaysRaw`, `TestBuildClientAttachArgs_FullCapture`, builder tests.
- [x] `readLogFile` renamed to `readCaptureFile` (function, log message, caller string).
- [x] Tests cover empty capture (`TestRepaintEmptyScreen`, `TestInitialAttachPaintFullCaptureMissingFile`), plain-output screen (`TestRepaintPlainOutput`), alt-screen app (`TestRepaintAltScreen`), and the `--full-capture` path (`TestInitialAttachPaintFullCaptureReplaysRaw`).

Closes #71