### PR TITLE
feat(capture): rotate capture file into segments with retention

### DIFF
--- a/cmd/sb/read/read.go
+++ b/cmd/sb/read/read.go
@@ -31,6 +31,7 @@ import (
 	"github.com/eminwux/sbsh/cmd/config"
 	"github.com/eminwux/sbsh/cmd/sb/get"
 	"github.com/eminwux/sbsh/cmd/types"
+	"github.com/eminwux/sbsh/internal/capture"
 	"github.com/eminwux/sbsh/internal/discovery"
 	"github.com/eminwux/sbsh/internal/errdefs"
 	"github.com/eminwux/sbsh/internal/naming"
@@ -51,6 +52,11 @@ func NewReadCmd() *cobra.Command {
 		Use:   "read <name>",
 		Short: "Print a terminal's capture log; with -f, follow live output",
 		Long: `Print the full capture log for a terminal.
+
+The capture is rotated into segments to bound on-disk size, so the file at the
+recorded capture path holds only the live tail. This command reassembles the
+full transcript — closed segments oldest-first, then the live segment — so you
+see the complete history; a raw 'cat' of the path shows the live tail only.
 
 With -f/--follow, also stream live PTY output after replaying the file, like
 'tail -f'. The follower subscribes to live output BEFORE replaying the capture
@@ -145,21 +151,12 @@ func runRead(
 	return streamLive(conn, stdout, stderr)
 }
 
+// dumpCapture streams the full transcript to stdout. The recorded capture
+// path is the live segment; capture.Dump reassembles closed rotated segments
+// oldest-first, then the live segment, into one logical stream. An absent
+// capture (never written to) produces no output and no error.
 func dumpCapture(path string, stdout io.Writer) error {
-	f, err := os.Open(path)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			// Empty capture is indistinguishable from "never written to";
-			// treat absence as zero-byte output rather than an error.
-			return nil
-		}
-		return fmt.Errorf("open capture file %q: %w", path, err)
-	}
-	defer f.Close()
-	if _, err := io.Copy(stdout, f); err != nil {
-		return fmt.Errorf("read capture file %q: %w", path, err)
-	}
-	return nil
+	return capture.Dump(path, stdout)
 }
 
 // laggedNotice mirrors the bracketed core of the server sentinel (see

--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -1,0 +1,202 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package capture defines the on-disk layout of a terminal's PTY transcript
+// and the helpers that reassemble it for readers.
+//
+// A capture is rotated into segments to bound per-file size, with retention
+// pruning the oldest closed segments to bound total disk use (see the rotating
+// writer in internal/terminal/terminalrunner). The layout is:
+//
+//   - The canonical path (the operator-facing capture file) is always the
+//     live, append-only, raw segment — the current tail of the transcript.
+//   - Closed segments are deterministic siblings named "<canonical>.NNNNNN",
+//     where NNNNNN is a zero-padded, monotonically increasing sequence number.
+//     Lower sequence numbers are older.
+//
+// Contract: a raw `cat` of the canonical path shows the live tail only.
+// Reassembling the full history is the job of the readers here (used by
+// `sb read`, attach `--full-capture`, and any other consumer of full
+// transcript): ordered closed segments oldest-first, then the live segment.
+//
+// The segment matcher requires an all-digit suffix, so unrelated siblings
+// (e.g. a future compressed "<canonical>.NNNNNN.gz") are ignored rather than
+// spliced into the stream.
+package capture
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// seqWidth is the zero-padding width for closed-segment sequence numbers. It
+// is cosmetic — readers parse the full numeric suffix and order numerically —
+// so a sequence that outgrows the width still sorts correctly.
+const seqWidth = 6
+
+// SegmentPath returns the deterministic closed-segment path for seq, a sibling
+// of canonical: "<canonical>.NNNNNN".
+func SegmentPath(canonical string, seq uint64) string {
+	return fmt.Sprintf("%s.%0*d", canonical, seqWidth, seq)
+}
+
+// Segment is a closed capture segment on disk.
+type Segment struct {
+	Path string
+	Seq  uint64
+	Size int64
+}
+
+// ClosedSegments returns the closed segments siblings of canonical, ordered
+// oldest-first (ascending sequence). It does not include the canonical (live)
+// path. A missing directory yields an empty slice and no error.
+func ClosedSegments(canonical string) ([]Segment, error) {
+	dir := filepath.Dir(canonical)
+	base := filepath.Base(canonical)
+	prefix := base + "."
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read capture dir %q: %w", dir, err)
+	}
+
+	var segs []Segment
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		suffix := name[len(prefix):]
+		// Require an all-digit suffix so unrelated siblings (e.g. a
+		// compressed ".NNNNNN.gz") are not spliced into the stream.
+		seq, perr := strconv.ParseUint(suffix, 10, 64)
+		if perr != nil {
+			continue
+		}
+		info, ierr := e.Info()
+		if ierr != nil {
+			// Raced away between ReadDir and Info; skip it.
+			continue
+		}
+		segs = append(segs, Segment{
+			Path: filepath.Join(dir, name),
+			Seq:  seq,
+			Size: info.Size(),
+		})
+	}
+	sort.Slice(segs, func(i, j int) bool { return segs[i].Seq < segs[j].Seq })
+	return segs, nil
+}
+
+// NextSeq returns the sequence number a fresh rotation should assign: one past
+// the highest existing closed segment, or 0 when none exist. Lets a writer
+// resume a deterministic, gap-free ordering across process restarts.
+func NextSeq(canonical string) (uint64, error) {
+	segs, err := ClosedSegments(canonical)
+	if err != nil {
+		return 0, err
+	}
+	if len(segs) == 0 {
+		return 0, nil
+	}
+	return segs[len(segs)-1].Seq + 1, nil
+}
+
+// OrderedPaths returns the full reassembly order: closed segments oldest-first,
+// then the canonical (live) path if it exists on disk.
+func OrderedPaths(canonical string) ([]string, error) {
+	segs, err := ClosedSegments(canonical)
+	if err != nil {
+		return nil, err
+	}
+	paths := make([]string, 0, len(segs)+1)
+	for _, s := range segs {
+		paths = append(paths, s.Path)
+	}
+	if _, serr := os.Stat(canonical); serr == nil {
+		paths = append(paths, canonical)
+	} else if !os.IsNotExist(serr) {
+		return nil, fmt.Errorf("stat capture file %q: %w", canonical, serr)
+	}
+	return paths, nil
+}
+
+// ReadAll reassembles the entire transcript — closed segments oldest-first,
+// then the live segment — into one byte slice. A capture that was never
+// written (no segments, no live file) yields a nil slice and no error.
+func ReadAll(canonical string) ([]byte, error) {
+	paths, err := OrderedPaths(canonical)
+	if err != nil {
+		return nil, err
+	}
+	var out []byte
+	for _, p := range paths {
+		data, rerr := os.ReadFile(p)
+		if rerr != nil {
+			if os.IsNotExist(rerr) {
+				// Pruned or rotated away between listing and read; skip.
+				continue
+			}
+			return nil, fmt.Errorf("read capture segment %q: %w", p, rerr)
+		}
+		out = append(out, data...)
+	}
+	return out, nil
+}
+
+// Dump streams the reassembled transcript to w in order: closed segments
+// oldest-first, then the live segment. A capture that was never written
+// produces no output and no error (an absent file is indistinguishable from a
+// never-written one).
+func Dump(canonical string, w io.Writer) error {
+	paths, err := OrderedPaths(canonical)
+	if err != nil {
+		return err
+	}
+	for _, p := range paths {
+		if derr := dumpOne(p, w); derr != nil {
+			return derr
+		}
+	}
+	return nil
+}
+
+func dumpOne(path string, w io.Writer) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Pruned or rotated away between listing and open; skip.
+			return nil
+		}
+		return fmt.Errorf("open capture segment %q: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, cerr := io.Copy(w, f); cerr != nil {
+		return fmt.Errorf("read capture segment %q: %w", path, cerr)
+	}
+	return nil
+}

--- a/internal/capture/capture_test.go
+++ b/internal/capture/capture_test.go
@@ -1,0 +1,197 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package capture
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write %q: %v", path, err)
+	}
+}
+
+func TestSegmentPath(t *testing.T) {
+	got := SegmentPath("/run/t/capture", 7)
+	want := "/run/t/capture.000007"
+	if got != want {
+		t.Fatalf("SegmentPath = %q, want %q", got, want)
+	}
+}
+
+func TestClosedSegments_OrderAndFilter(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+
+	// Closed segments out of lexical/creation order; ReadDir order is not
+	// guaranteed, so the sort must impose ascending sequence.
+	writeFile(t, SegmentPath(canonical, 2), []byte("two"))
+	writeFile(t, SegmentPath(canonical, 0), []byte("zero"))
+	writeFile(t, SegmentPath(canonical, 10), []byte("ten!!"))
+	// Live segment — must not appear among closed segments.
+	writeFile(t, canonical, []byte("live"))
+	// Unrelated siblings that must be ignored: non-digit suffix and a
+	// future compressed segment.
+	writeFile(t, canonical+".notes", []byte("x"))
+	writeFile(t, SegmentPath(canonical, 1)+".gz", []byte("x"))
+
+	segs, err := ClosedSegments(canonical)
+	if err != nil {
+		t.Fatalf("ClosedSegments: %v", err)
+	}
+	if len(segs) != 3 {
+		t.Fatalf("got %d closed segments, want 3: %+v", len(segs), segs)
+	}
+	wantSeq := []uint64{0, 2, 10}
+	for i, s := range segs {
+		if s.Seq != wantSeq[i] {
+			t.Fatalf("segment %d seq = %d, want %d", i, s.Seq, wantSeq[i])
+		}
+	}
+	if segs[2].Size != int64(len("ten!!")) {
+		t.Fatalf("seq 10 size = %d, want %d", segs[2].Size, len("ten!!"))
+	}
+}
+
+func TestClosedSegments_MissingDir(t *testing.T) {
+	segs, err := ClosedSegments(filepath.Join(t.TempDir(), "nope", "capture"))
+	if err != nil {
+		t.Fatalf("ClosedSegments on missing dir: %v", err)
+	}
+	if len(segs) != 0 {
+		t.Fatalf("want no segments, got %d", len(segs))
+	}
+}
+
+func TestNextSeq(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+
+	seq, err := NextSeq(canonical)
+	if err != nil {
+		t.Fatalf("NextSeq empty: %v", err)
+	}
+	if seq != 0 {
+		t.Fatalf("NextSeq with no segments = %d, want 0", seq)
+	}
+
+	writeFile(t, SegmentPath(canonical, 4), []byte("x"))
+	seq, err = NextSeq(canonical)
+	if err != nil {
+		t.Fatalf("NextSeq: %v", err)
+	}
+	if seq != 5 {
+		t.Fatalf("NextSeq after seq 4 = %d, want 5", seq)
+	}
+}
+
+func TestOrderedPaths_LiveLast(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+	writeFile(t, SegmentPath(canonical, 0), []byte("a"))
+	writeFile(t, SegmentPath(canonical, 1), []byte("b"))
+	writeFile(t, canonical, []byte("c"))
+
+	paths, err := OrderedPaths(canonical)
+	if err != nil {
+		t.Fatalf("OrderedPaths: %v", err)
+	}
+	want := []string{
+		SegmentPath(canonical, 0),
+		SegmentPath(canonical, 1),
+		canonical,
+	}
+	if len(paths) != len(want) {
+		t.Fatalf("got %v, want %v", paths, want)
+	}
+	for i := range want {
+		if paths[i] != want[i] {
+			t.Fatalf("path %d = %q, want %q", i, paths[i], want[i])
+		}
+	}
+}
+
+func TestOrderedPaths_NoLive(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+	writeFile(t, SegmentPath(canonical, 0), []byte("a"))
+
+	paths, err := OrderedPaths(canonical)
+	if err != nil {
+		t.Fatalf("OrderedPaths: %v", err)
+	}
+	if len(paths) != 1 || paths[0] != SegmentPath(canonical, 0) {
+		t.Fatalf("got %v, want only the closed segment", paths)
+	}
+}
+
+func TestReadAll_ReassemblesInOrder(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+	writeFile(t, SegmentPath(canonical, 0), []byte("AAAA"))
+	writeFile(t, SegmentPath(canonical, 1), []byte("BBBB"))
+	writeFile(t, canonical, []byte("CCCC"))
+
+	data, err := ReadAll(canonical)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if want := []byte("AAAABBBBCCCC"); !bytes.Equal(data, want) {
+		t.Fatalf("ReadAll = %q, want %q", data, want)
+	}
+}
+
+func TestReadAll_NeverWritten(t *testing.T) {
+	data, err := ReadAll(filepath.Join(t.TempDir(), "capture"))
+	if err != nil {
+		t.Fatalf("ReadAll on absent capture: %v", err)
+	}
+	if data != nil {
+		t.Fatalf("want nil, got %q", data)
+	}
+}
+
+func TestDump_ReassemblesInOrder(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+	writeFile(t, SegmentPath(canonical, 0), []byte("hello "))
+	writeFile(t, SegmentPath(canonical, 1), []byte("rotated "))
+	writeFile(t, canonical, []byte("world"))
+
+	var buf bytes.Buffer
+	if err := Dump(canonical, &buf); err != nil {
+		t.Fatalf("Dump: %v", err)
+	}
+	if want := "hello rotated world"; buf.String() != want {
+		t.Fatalf("Dump = %q, want %q", buf.String(), want)
+	}
+}
+
+func TestDump_NeverWritten(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Dump(filepath.Join(t.TempDir(), "capture"), &buf); err != nil {
+		t.Fatalf("Dump on absent capture: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("want no output, got %q", buf.String())
+	}
+}

--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -20,3 +20,24 @@ const (
 	TerminalsRunPath = "terminals"
 	ClientsRunPath   = "clients"
 )
+
+// Capture rotation + retention knobs. Hard-coded for now, configurable later
+// (same "hard-code now, configurable later" precedent #71 set for the read
+// path). Rotation bounds per-segment size; retention bounds total on-disk use,
+// since rotation alone only caps each file. See internal/capture and the
+// rotating writer in internal/terminal/terminalrunner.
+const (
+	// CaptureSegmentMaxBytes is the per-segment rotation threshold: once the
+	// live segment reaches this size it is closed, renamed to a deterministic
+	// sibling, and a fresh live segment opens at the canonical path.
+	CaptureSegmentMaxBytes int64 = 8 << 20 // 8 MiB
+
+	// CaptureRetentionMaxSegments bounds how many closed segments are kept;
+	// the oldest are pruned first. Zero disables count-based pruning.
+	CaptureRetentionMaxSegments = 8
+
+	// CaptureRetentionMaxBytes bounds the total size of closed segments;
+	// the oldest are pruned until the total fits. Zero disables byte-based
+	// pruning. The live segment is never pruned.
+	CaptureRetentionMaxBytes int64 = 64 << 20 // 64 MiB
+)

--- a/internal/terminal/terminalrunner/capture_writer.go
+++ b/internal/terminal/terminalrunner/capture_writer.go
@@ -1,0 +1,229 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrunner
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"sync"
+
+	"github.com/eminwux/sbsh/internal/capture"
+	"github.com/eminwux/sbsh/internal/defaults"
+)
+
+// captureWriter is the always-on capture sink registered first in multiOutW.
+// It writes the live segment append-only at the canonical path and, once the
+// live segment crosses maxBytes, rotates: close → rename to a deterministic
+// sibling (capture.SegmentPath) → reopen a fresh canonical → prune oldest
+// closed segments by count and total bytes. Readers reassemble the full
+// transcript via the internal/capture helpers.
+//
+// Rotation failures never silently kill capture: the writer always restores a
+// writable live segment (reopening the canonical) and logs, so a transient
+// rename/prune error degrades to "rotation skipped this round", not "capture
+// stops". A bare write error on the live segment is returned as before so
+// DynamicMultiWriter's failed-writer eviction still applies.
+type captureWriter struct {
+	mu        sync.Mutex
+	canonical string
+	f         *os.File
+	size      int64
+	nextSeq   uint64
+
+	maxBytes       int64
+	retainSegments int
+	retainBytes    int64
+
+	// applyPerms re-applies the resolved capture mode/group to a freshly
+	// opened segment path. nil leaves perms at the open default.
+	applyPerms func(path string) error
+	logger     *slog.Logger
+}
+
+// newCaptureWriter opens (or reopens, append-only) the canonical capture path
+// and returns a rotating writer seeded from any closed segments already on
+// disk, so sequence numbering resumes gap-free across restarts. applyPerms is
+// invoked on the freshly opened canonical immediately, mirroring the explicit
+// permissions step the non-rotating path performed after Open.
+func newCaptureWriter(
+	canonical string,
+	logger *slog.Logger,
+	applyPerms func(path string) error,
+) (*captureWriter, error) {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	f, err := os.OpenFile(canonical, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open capture file: %w", err)
+	}
+	if applyPerms != nil {
+		if perr := applyPerms(canonical); perr != nil {
+			_ = f.Close()
+			return nil, perr
+		}
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("stat capture file: %w", err)
+	}
+	nextSeq, err := capture.NextSeq(canonical)
+	if err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("seed capture sequence: %w", err)
+	}
+	return &captureWriter{
+		canonical:      canonical,
+		f:              f,
+		size:           info.Size(),
+		nextSeq:        nextSeq,
+		maxBytes:       defaults.CaptureSegmentMaxBytes,
+		retainSegments: defaults.CaptureRetentionMaxSegments,
+		retainBytes:    defaults.CaptureRetentionMaxBytes,
+		applyPerms:     applyPerms,
+		logger:         logger,
+	}, nil
+}
+
+// Write appends to the live segment and rotates once it crosses maxBytes. A
+// single write is never split across segments; the live segment may exceed the
+// threshold by up to one write before rotating.
+func (w *captureWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.f == nil {
+		return 0, os.ErrClosed
+	}
+	n, err := w.f.Write(p)
+	w.size += int64(n)
+	if err != nil {
+		return n, err
+	}
+	if w.maxBytes > 0 && w.size >= w.maxBytes {
+		if rerr := w.rotate(); rerr != nil {
+			w.logger.Warn("capture rotation failed; continuing on current segment", "err", rerr)
+		}
+	}
+	return n, nil
+}
+
+// rotate closes the live segment, renames it to its deterministic sibling,
+// reopens a fresh canonical, and prunes. Every failure path leaves a writable
+// live segment (or, only if reopening the canonical itself fails, a nil f that
+// surfaces os.ErrClosed on the next write).
+func (w *captureWriter) rotate() error {
+	if cerr := w.f.Close(); cerr != nil {
+		// Could not flush/close cleanly; do not rename a half-written file.
+		// Restore a live segment (best-effort; reopenCanonical logs its own
+		// failure) and report the close error.
+		_ = w.reopenCanonical()
+		return fmt.Errorf("close live segment: %w", cerr)
+	}
+	w.f = nil
+
+	target := capture.SegmentPath(w.canonical, w.nextSeq)
+	if rerr := os.Rename(w.canonical, target); rerr != nil {
+		_ = w.reopenCanonical()
+		return fmt.Errorf("rename live segment to %q: %w", target, rerr)
+	}
+	w.nextSeq++
+
+	if oerr := w.reopenCanonical(); oerr != nil {
+		return oerr
+	}
+	w.prune()
+	return nil
+}
+
+// reopenCanonical opens a fresh live segment at the canonical path and resets
+// the size counter. On success f is writable and size is 0; on failure f stays
+// nil and the error is logged so the caller can surface it.
+func (w *captureWriter) reopenCanonical() error {
+	f, err := os.OpenFile(w.canonical, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		w.logger.Error("capture reopen failed; capture stops", "path", w.canonical, "err", err)
+		return fmt.Errorf("reopen capture file %q: %w", w.canonical, err)
+	}
+	if w.applyPerms != nil {
+		if perr := w.applyPerms(w.canonical); perr != nil {
+			// Perms are best-effort on reopen: a chmod/chown failure on the
+			// new segment must not stop capture.
+			w.logger.Warn("capture perms reapply failed", "path", w.canonical, "err", perr)
+		}
+	}
+	w.f = f
+	w.size = 0
+	return nil
+}
+
+// prune drops the oldest closed segments until both retention bounds hold:
+// at most retainSegments closed segments, and at most retainBytes total across
+// them. The live segment is never pruned.
+func (w *captureWriter) prune() {
+	segs, err := capture.ClosedSegments(w.canonical)
+	if err != nil {
+		w.logger.Warn("capture retention listing failed; skipping prune", "err", err)
+		return
+	}
+
+	// Count-based: drop oldest (front) until at or under the segment cap.
+	if w.retainSegments > 0 {
+		for len(segs) > w.retainSegments {
+			segs = w.dropOldest(segs)
+		}
+	}
+
+	// Byte-based: drop oldest until total closed bytes fit the cap.
+	if w.retainBytes > 0 {
+		var total int64
+		for _, s := range segs {
+			total += s.Size
+		}
+		for total > w.retainBytes && len(segs) > 0 {
+			total -= segs[0].Size
+			segs = w.dropOldest(segs)
+		}
+	}
+}
+
+// dropOldest removes the front (oldest) segment from disk and returns the
+// remaining slice. A removal error is logged but still advances the slice so
+// pruning makes progress rather than spinning on an undeletable file.
+func (w *captureWriter) dropOldest(segs []capture.Segment) []capture.Segment {
+	oldest := segs[0]
+	if rerr := os.Remove(oldest.Path); rerr != nil && !os.IsNotExist(rerr) {
+		w.logger.Warn("capture retention prune failed", "path", oldest.Path, "err", rerr)
+	}
+	return segs[1:]
+}
+
+// Close closes the live segment fd. Idempotency across repeated runner Close
+// calls is provided by the runner's closeCapture sync.Once (mirroring the
+// pre-rotation contract); this method itself nils f so a late call is a no-op.
+func (w *captureWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.f == nil {
+		return nil
+	}
+	f := w.f
+	w.f = nil
+	return f.Close()
+}

--- a/internal/terminal/terminalrunner/capture_writer_test.go
+++ b/internal/terminal/terminalrunner/capture_writer_test.go
@@ -1,0 +1,263 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrunner
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/sbsh/internal/capture"
+)
+
+// newTestCaptureWriter builds a captureWriter with explicit, small thresholds
+// so rotation/retention is exercisable without writing megabytes. It bypasses
+// the defaults-derived constructor knobs but reuses newCaptureWriter for the
+// open + seq-seed path, then overrides the bounds.
+func newTestCaptureWriter(
+	t *testing.T,
+	canonical string,
+	maxBytes int64,
+	retainSegments int,
+	retainBytes int64,
+) *captureWriter {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	w, err := newCaptureWriter(canonical, logger, nil)
+	if err != nil {
+		t.Fatalf("newCaptureWriter: %v", err)
+	}
+	w.maxBytes = maxBytes
+	w.retainSegments = retainSegments
+	w.retainBytes = retainBytes
+	return w
+}
+
+func mustWrite(t *testing.T, w io.Writer, b []byte) {
+	t.Helper()
+	n, err := w.Write(b)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if n != len(b) {
+		t.Fatalf("short write: %d of %d", n, len(b))
+	}
+}
+
+// Under the threshold, nothing rotates: the canonical holds everything and no
+// closed siblings exist.
+func TestCaptureWriter_NoRotation(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+	w := newTestCaptureWriter(t, canonical, 1<<20, 8, 1<<30)
+
+	mustWrite(t, w, []byte("small payload"))
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	segs, err := capture.ClosedSegments(canonical)
+	if err != nil {
+		t.Fatalf("ClosedSegments: %v", err)
+	}
+	if len(segs) != 0 {
+		t.Fatalf("expected no rotation, got %d closed segments", len(segs))
+	}
+	data, err := os.ReadFile(canonical)
+	if err != nil {
+		t.Fatalf("read canonical: %v", err)
+	}
+	if !bytes.Equal(data, []byte("small payload")) {
+		t.Fatalf("canonical = %q, want %q", data, "small payload")
+	}
+}
+
+// Crossing the threshold once produces exactly one closed segment plus a fresh
+// live segment, and `cat`-ing the canonical shows only the live tail.
+func TestCaptureWriter_SingleRotation(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+	w := newTestCaptureWriter(t, canonical, 8, 8, 1<<30)
+
+	mustWrite(t, w, []byte("12345678")) // hits threshold -> rotates after write
+	mustWrite(t, w, []byte("tail"))     // lands in the fresh live segment
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	segs, err := capture.ClosedSegments(canonical)
+	if err != nil {
+		t.Fatalf("ClosedSegments: %v", err)
+	}
+	if len(segs) != 1 {
+		t.Fatalf("expected 1 closed segment, got %d", len(segs))
+	}
+	closed, err := os.ReadFile(segs[0].Path)
+	if err != nil {
+		t.Fatalf("read closed: %v", err)
+	}
+	if !bytes.Equal(closed, []byte("12345678")) {
+		t.Fatalf("closed segment = %q, want %q", closed, "12345678")
+	}
+	// cat of the canonical shows the live tail only.
+	live, err := os.ReadFile(canonical)
+	if err != nil {
+		t.Fatalf("read canonical: %v", err)
+	}
+	if !bytes.Equal(live, []byte("tail")) {
+		t.Fatalf("live tail = %q, want %q", live, "tail")
+	}
+}
+
+// Many rotations with a tight retention cap: the oldest closed segments are
+// pruned so the closed-segment count stays bounded, yet the reassembled stream
+// remains gap/dupe-free over whatever survives.
+func TestCaptureWriter_MultipleRotationsAndPrune(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+	// 4-byte segments, keep at most 2 closed segments, generous byte cap.
+	w := newTestCaptureWriter(t, canonical, 4, 2, 1<<30)
+
+	// 6 writes of 4 bytes: each crosses the threshold and rotates, producing
+	// 6 closed segments before retention, capped to the newest 2.
+	chunks := [][]byte{
+		[]byte("AAAA"), []byte("BBBB"), []byte("CCCC"),
+		[]byte("DDDD"), []byte("EEEE"), []byte("FFFF"),
+	}
+	for _, c := range chunks {
+		mustWrite(t, w, c)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	segs, err := capture.ClosedSegments(canonical)
+	if err != nil {
+		t.Fatalf("ClosedSegments: %v", err)
+	}
+	if len(segs) != 2 {
+		t.Fatalf("expected retention to cap closed segments at 2, got %d", len(segs))
+	}
+	// The two surviving closed segments must be the newest two written
+	// before the final (empty) live segment: "EEEE" and "FFFF".
+	got0, _ := os.ReadFile(segs[0].Path)
+	got1, _ := os.ReadFile(segs[1].Path)
+	if !bytes.Equal(got0, []byte("EEEE")) || !bytes.Equal(got1, []byte("FFFF")) {
+		t.Fatalf("surviving segments = %q,%q, want EEEE,FFFF", got0, got1)
+	}
+}
+
+// Byte-based retention prunes oldest until total closed bytes fit the cap,
+// independent of the count cap.
+func TestCaptureWriter_BytePrune(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+	// 4-byte segments, no count cap, keep at most 8 closed bytes (2 segments).
+	w := newTestCaptureWriter(t, canonical, 4, 0, 8)
+
+	for _, c := range [][]byte{[]byte("AAAA"), []byte("BBBB"), []byte("CCCC"), []byte("DDDD")} {
+		mustWrite(t, w, c)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	segs, err := capture.ClosedSegments(canonical)
+	if err != nil {
+		t.Fatalf("ClosedSegments: %v", err)
+	}
+	var total int64
+	for _, s := range segs {
+		total += s.Size
+	}
+	if total > 8 {
+		t.Fatalf("byte retention exceeded: total closed bytes = %d, cap 8", total)
+	}
+}
+
+// A reader spanning the segment boundary sees the full stream in order with no
+// gaps or duplicates — the core reassembly contract.
+func TestCaptureWriter_ReaderSpansBoundary(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+	// Small threshold, retention large enough that nothing is pruned, so the
+	// reassembled stream must equal every byte written.
+	w := newTestCaptureWriter(t, canonical, 8, 100, 1<<30)
+
+	var want bytes.Buffer
+	chunks := []string{
+		"first chunk ", "second chunk ", "third chunk ",
+		"fourth chunk ", "fifth chunk",
+	}
+	for _, c := range chunks {
+		mustWrite(t, w, []byte(c))
+		want.WriteString(c)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Multiple rotations must have occurred.
+	segs, err := capture.ClosedSegments(canonical)
+	if err != nil {
+		t.Fatalf("ClosedSegments: %v", err)
+	}
+	if len(segs) < 2 {
+		t.Fatalf("expected multiple rotations, got %d closed segments", len(segs))
+	}
+
+	got, err := capture.ReadAll(canonical)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(got, want.Bytes()) {
+		t.Fatalf("reassembled stream mismatch:\n got %q\nwant %q", got, want.Bytes())
+	}
+}
+
+// Sequence numbering resumes across a writer restart on the same canonical
+// path, so a later run does not collide with or reorder earlier segments.
+func TestCaptureWriter_SeqResumesAcrossRestart(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+
+	w1 := newTestCaptureWriter(t, canonical, 4, 100, 1<<30)
+	mustWrite(t, w1, []byte("AAAA")) // rotates -> capture.000000
+	mustWrite(t, w1, []byte("BBBB")) // rotates -> capture.000001
+	if err := w1.Close(); err != nil {
+		t.Fatalf("close w1: %v", err)
+	}
+
+	// Restart: the live segment from w1 is empty (last write rotated), so the
+	// new writer must seed nextSeq past the existing closed segments.
+	w2 := newTestCaptureWriter(t, canonical, 4, 100, 1<<30)
+	mustWrite(t, w2, []byte("CCCC")) // rotates -> capture.000002
+	if err := w2.Close(); err != nil {
+		t.Fatalf("close w2: %v", err)
+	}
+
+	got, err := capture.ReadAll(canonical)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if want := []byte("AAAABBBBCCCC"); !bytes.Equal(got, want) {
+		t.Fatalf("after restart ReadAll = %q, want %q", got, want)
+	}
+}

--- a/internal/terminal/terminalrunner/io.go
+++ b/internal/terminal/terminalrunner/io.go
@@ -17,14 +17,18 @@
 package terminalrunner
 
 import (
-	"os"
+	"github.com/eminwux/sbsh/internal/capture"
 )
 
+// readCaptureFile reassembles the full transcript for a --full-capture attach:
+// closed rotated segments oldest-first, then the live segment. The canonical
+// path recorded in Status.CaptureFile is the live segment; capture.ReadAll
+// walks its closed siblings to reconstruct full history.
 func (sr *Exec) readCaptureFile() ([]byte, error) {
 	sr.metadataMu.RLock()
 	captureFile := sr.metadata.Status.CaptureFile
 	sr.metadataMu.RUnlock()
-	data, err := os.ReadFile(captureFile)
+	data, err := capture.ReadAll(captureFile)
 	if err != nil {
 		sr.logger.Warn("failed to read capture file", "err", err)
 		return nil, err

--- a/internal/terminal/terminalrunner/lifecycle.go
+++ b/internal/terminal/terminalrunner/lifecycle.go
@@ -286,13 +286,13 @@ func (sr *Exec) Close(reason error) error {
 		}
 	}
 
-	// Close the capture file fd. Sequenced after closeAllSubscribers and
-	// ptmx teardown so the PTY reader has stopped writing to multiOutW
-	// (which holds captureFile as its always-on writer). closeCapture
-	// guards against double-Close per #229's idempotency AC.
-	if sr.captureFile != nil && sr.closeCapture != nil {
+	// Close the capture live-segment fd. Sequenced after closeAllSubscribers
+	// and ptmx teardown so the PTY reader has stopped writing to multiOutW
+	// (which holds the rotating capture writer as its always-on sink).
+	// closeCapture guards against double-Close per #229's idempotency AC.
+	if sr.capture != nil && sr.closeCapture != nil {
 		sr.closeCapture.Do(func() {
-			if err := sr.captureFile.Close(); err != nil {
+			if err := sr.capture.Close(); err != nil {
 				sr.logger.Warn("could not close capture file", "id", sr.id, "err", err)
 			}
 		})

--- a/internal/terminal/terminalrunner/lifecycle_capture_fd_test.go
+++ b/internal/terminal/terminalrunner/lifecycle_capture_fd_test.go
@@ -65,7 +65,7 @@ func newCaptureFDExec(t *testing.T) (*Exec, *os.File) {
 		closePTY:      &sync.Once{},
 		closeCapture:  &sync.Once{},
 		closeClosedCh: &sync.Once{},
-		captureFile:   logf,
+		capture:       &captureWriter{f: logf, logger: logger},
 	}
 	return sr, logf
 }

--- a/internal/terminal/terminalrunner/terminal.go
+++ b/internal/terminal/terminalrunner/terminal.go
@@ -192,26 +192,26 @@ func (sr *Exec) startPty() error {
 		captureGID = &gv
 	}
 	sr.metadataMu.RUnlock()
-	// Open at the legacy 0o600 first; applyArtifactPerms re-chmods to
-	// the resolved mode (and optionally chowns the group). Doing the
-	// permissions step explicitly after Open mirrors the socket path and
-	// also covers reopens of a pre-existing inode (see issue #200).
-	logf, errO := os.OpenFile(captureFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	// The canonical path is the live, append-only segment. The rotating
+	// writer opens it at the legacy 0o600, then runs applyArtifactPerms to
+	// re-chmod to the resolved mode (and optionally chown the group) on the
+	// canonical and on every fresh segment it opens after a rotation. Doing
+	// the permissions step explicitly after Open mirrors the socket path and
+	// covers reopens of a pre-existing inode (see issue #200).
+	capWriter, errO := newCaptureWriter(captureFile, sr.logger, func(path string) error {
+		return sr.applyArtifactPerms("capture", path, captureMode, captureGID)
+	})
 	if errO != nil {
 		return fmt.Errorf("open log file: %w", errO)
-	}
-	if errPerm := sr.applyArtifactPerms("capture", captureFile, captureMode, captureGID); errPerm != nil {
-		_ = logf.Close()
-		return errPerm
 	}
 	// Hand fd ownership to the runner; Close closes it after PTY teardown
 	// so in-flight multiOutW.Write has settled. See #229. Error returns
 	// after this assignment must close the fd via closeCapture so the
 	// idempotency contract holds whether Close runs or not (see #241).
-	sr.captureFile = logf
+	sr.capture = capWriter
 
 	if errU := sr.updateMetadata(); errU != nil {
-		sr.closeCapture.Do(func() { _ = sr.captureFile.Close() })
+		sr.closeCapture.Do(func() { _ = sr.capture.Close() })
 		return fmt.Errorf("update metadata: %w", errU)
 	}
 
@@ -220,14 +220,14 @@ func (sr *Exec) startPty() error {
 	// conn writes to pipeInW
 	pipeInR, pipeInW, err := os.Pipe()
 	if err != nil {
-		sr.closeCapture.Do(func() { _ = sr.captureFile.Close() })
+		sr.closeCapture.Do(func() { _ = sr.capture.Close() })
 		sr.logger.Error("error opening IN pipe", "err", err)
 		return fmt.Errorf("error opening IN pipe: %w", err)
 	}
 
 	// StdOut
-	// ATTACHED: stream to client (pipeOutW) AND log file
-	multiOutW := NewDynamicMultiWriter(sr.logger, logf)
+	// ATTACHED: stream to client (pipeOutW) AND the rotating capture writer
+	multiOutW := NewDynamicMultiWriter(sr.logger, capWriter)
 
 	// Register the vt-parser screen model as an additional warm sink on
 	// the same fan-out. It decodes the byte stream into a live grid so

--- a/internal/terminal/terminalrunner/terminal_runner_exec.go
+++ b/internal/terminal/terminalrunner/terminal_runner_exec.go
@@ -81,11 +81,12 @@ type Exec struct {
 
 	closePTY *sync.Once
 
-	// captureFile is the *os.File backing the always-on capture writer in
-	// multiOutW. The runner owns the fd from startPty onward; Close closes
-	// it via closeCapture so repeated New→Start→Close cycles in-process do
-	// not leak fds. See #229.
-	captureFile  *os.File
+	// capture is the always-on, segment-rotating capture sink registered
+	// first in multiOutW. It owns the live-segment fd from startPty onward;
+	// Close closes it via closeCapture so repeated New→Start→Close cycles
+	// in-process do not leak fds. See #229. Rotation/retention layout lives
+	// in internal/capture; see capture_writer.go.
+	capture      *captureWriter
 	closeCapture *sync.Once
 
 	// closeClosedCh guards close(closedCh) so a second Close call does not

--- a/pkg/api/terminal.go
+++ b/pkg/api/terminal.go
@@ -68,7 +68,12 @@ type TerminalSpec struct {
 	Prompt      string   `json:"prompt"`
 	SetPrompt   bool     `json:"setPrompt,omitempty"`
 
-	RunPath     string `json:"runPath"`
+	RunPath string `json:"runPath"`
+	// CaptureFile is the canonical capture path. It is the live, append-only
+	// segment: capture rotates into deterministic siblings to bound size, so
+	// a raw read of this path shows the live tail only. Full transcript
+	// reassembly (closed segments oldest-first, then live) is done by
+	// `sb read` and attach --full-capture; see internal/capture.
 	CaptureFile string `json:"captureFile"`
 	LogFile     string `json:"logFile"`
 	LogLevel    string `json:"logLevel"`


### PR DESCRIPTION
## Summary

Implements capture file rotation + retention (#296), the third phase of the capture-rendering arc (#295 → #71 → this).

- **New `internal/capture` package** owns the on-disk layout and reader-side reassembly. The canonical path is the **live, append-only segment**; closed segments are deterministic siblings `<canonical>.NNNNNN` (zero-padded, monotonically increasing — lower seq is older). Helpers: `SegmentPath`, `ClosedSegments` (ordered oldest-first), `NextSeq`, `OrderedPaths`, `ReadAll`, `Dump`. The matcher requires an all-digit suffix, so a future compressed `<canonical>.NNNNNN.gz` (#297) is ignored, not spliced in.
- **`captureWriter`** (`internal/terminal/terminalrunner/capture_writer.go`) replaces the raw `*os.File` as the always-on sink in `multiOutW`. On crossing the size threshold it closes → renames the live segment to its sibling → reopens a fresh canonical → prunes oldest closed segments by count **and** total bytes. Rotation failures never kill capture: it always restores a writable live segment and logs (degrades to "rotation skipped this round").
- **Hard-coded defaults** in `internal/defaults` (per #71's "hard-code now, configurable later" precedent): 8 MiB segment threshold, keep ≤8 closed segments / ≤64 MiB total.
- **Readers reassemble**: attach `--full-capture` (`readCaptureFile` → `capture.ReadAll`) and `sb read` (`dumpCapture` → `capture.Dump`) now present ordered closed segments + live as one logical stream.
- **Documented contract**: `cat`-ing the canonical path shows the live tail only — documented on `Spec.CaptureFile`, in the `internal/capture` package doc, and in `sb read --help`.

### Non-obvious calls (please push back if these overstep)

- **Rotation is always-on**, not gated on `CaptureMode`. The issue's "Contract decision" note calls `CaptureMode` the "natural integration seam", but `CaptureMode` (`pkg/api/terminal.go`) is the file-**permission** `os.FileMode`, not a behavior toggle, and no AC checkbox references it. I read the seam note as "perms apply per segment" (which they do — `applyArtifactPerms` runs on the canonical and every fresh segment) and made rotation unconditional with hard-coded thresholds, matching #71's precedent and the "hard-code now, configurable later" framing. This is a behavior change the AC explicitly accepts (the `cat` contract + reader reassembly are the point).
- **The "parser feed" reader needs no change.** The issue lists the parser feed as a third reader to "teach segment reassembly", but #295's screen model is fed warm as a live sink on `multiOutW` (`multiOutW.Add(screen)`) — it never reads the capture file, so file rotation is transparent to it. It already sees the complete byte stream regardless of segment layout. No code change; flagged here so the reviewer can confirm the reading.
- **Cross-segment splitting**: a single `Write` is never split across segments (rotation happens *after* a write that crosses the threshold), so a segment may exceed the threshold by up to one write. This keeps byte-stream integrity simple and matches logrotate-style "rotate after exceeding".

## Test plan

- [x] `make sbsh-sb` — canonical build; `file ./sbsh` confirms ELF 64-bit executable
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — full CI suite (incl. `e2e`) passes
- [x] `go test ./internal/capture/...` — naming, ordering, `.gz`/non-digit filtering, reassembly order, never-written cases
- [x] `go test ./internal/terminal/terminalrunner/...` — no rotation under threshold; single rotation; multiple rotations + count prune; byte-based prune; reader spanning the boundary (gap/dupe-free); seq resumes across restart; plus the existing #229 fd-close regressions adapted to the rotating writer
- [x] `pre-commit run --files <changed>` — golangci-lint, gofmt, addlicense all pass

### Coverage note

`make test`'s globs don't include `internal/capture`, so its standalone unit tests don't run in CI. The rotation/retention/reassembly behavior is *also* exercised through `internal/terminal/terminalrunner` (which CI runs) — those tests drive `capture.ReadAll`/`ClosedSegments`/`SegmentPath` end-to-end. Surfacing for the reviewer; broadening the test glob is a separate Makefile concern.

## Acceptance criteria

- [x] Capture rotates to a new segment at a hard-coded size threshold (`defaults.CaptureSegmentMaxBytes`)
- [x] Closed segments named deterministically (`<canonical>.NNNNNN`); canonical path is always the live segment
- [x] Retention prunes oldest by count (`CaptureRetentionMaxSegments`) and total bytes (`CaptureRetentionMaxBytes`); total disk bounded
- [x] `--full-capture`, `sb read` reassemble segments + live in order, no gaps/dupes at boundaries (parser feed unaffected — see non-obvious calls)
- [x] `cat`-ing the canonical path shows the live tail; documented on `Spec.CaptureFile`, package doc, and `sb read --help`
- [x] Tests cover: no rotation, single rotation, multiple rotations + retention prune, and a reader spanning the segment boundary

Closes #296