### PR TITLE
feat(capture): gzip-compress closed capture segments on rotation

### DIFF
--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -25,19 +25,27 @@
 //     live, append-only, raw segment — the current tail of the transcript.
 //   - Closed segments are deterministic siblings named "<canonical>.NNNNNN",
 //     where NNNNNN is a zero-padded, monotonically increasing sequence number.
-//     Lower sequence numbers are older.
+//     Lower sequence numbers are older. On rotation a closed segment is gzip-
+//     compressed to "<canonical>.NNNNNN.gz" to stretch the retention budget;
+//     the live segment always stays raw and seekable.
 //
 // Contract: a raw `cat` of the canonical path shows the live tail only.
 // Reassembling the full history is the job of the readers here (used by
 // `sb read`, attach `--full-capture`, and any other consumer of full
 // transcript): ordered closed segments oldest-first, then the live segment.
+// Readers transparently decompress ".gz" closed segments, dispatching on file
+// extension, so a capture spanning gzip-closed and raw-live segments reads
+// back as the original byte stream.
 //
-// The segment matcher requires an all-digit suffix, so unrelated siblings
-// (e.g. a future compressed "<canonical>.NNNNNN.gz") are ignored rather than
-// spliced into the stream.
+// The segment matcher accepts both the raw "<canonical>.NNNNNN" form and the
+// compressed "<canonical>.NNNNNN.gz" form (collapsing the two to one segment
+// when both transiently coexist mid-rotation, preferring the raw copy).
+// Other siblings (a non-digit suffix, an in-flight ".gz.tmp") are ignored
+// rather than spliced into the stream.
 package capture
 
 import (
+	"compress/gzip"
 	"fmt"
 	"io"
 	"os"
@@ -52,6 +60,12 @@ import (
 // so a sequence that outgrows the width still sorts correctly.
 const seqWidth = 6
 
+// GzSuffix is appended to a closed segment's path once it has been gzip-
+// compressed: "<canonical>.NNNNNN.gz". Compression is sequential-read only
+// (readers io.Copy each segment end-to-end, never seeking), so gzip's lack of
+// a seek index is a non-issue and it adds no dependency beyond the stdlib.
+const GzSuffix = ".gz"
+
 // SegmentPath returns the deterministic closed-segment path for seq, a sibling
 // of canonical: "<canonical>.NNNNNN".
 func SegmentPath(canonical string, seq uint64) string {
@@ -62,7 +76,12 @@ func SegmentPath(canonical string, seq uint64) string {
 type Segment struct {
 	Path string
 	Seq  uint64
+	// Size is the on-disk size: for a compressed segment this is the gzip
+	// size, so byte-based retention bounds actual disk use.
 	Size int64
+	// Compressed is true when Path is a ".gz" segment that readers must
+	// decompress.
+	Compressed bool
 }
 
 // ClosedSegments returns the closed segments siblings of canonical, ordered
@@ -81,7 +100,10 @@ func ClosedSegments(canonical string) ([]Segment, error) {
 		return nil, fmt.Errorf("read capture dir %q: %w", dir, err)
 	}
 
-	var segs []Segment
+	// Collapse same-seq raw + ".gz" siblings (transient during rotation's
+	// compress step, when both copies briefly coexist) to one segment,
+	// preferring the raw copy: it is the original bytes and skips a decompress.
+	bySeq := make(map[uint64]Segment)
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
@@ -91,8 +113,13 @@ func ClosedSegments(canonical string) ([]Segment, error) {
 			continue
 		}
 		suffix := name[len(prefix):]
-		// Require an all-digit suffix so unrelated siblings (e.g. a
-		// compressed ".NNNNNN.gz") are not spliced into the stream.
+		compressed := false
+		if strings.HasSuffix(suffix, GzSuffix) {
+			suffix = suffix[:len(suffix)-len(GzSuffix)]
+			compressed = true
+		}
+		// Require an all-digit (sub)suffix so unrelated siblings (a non-digit
+		// suffix, an in-flight ".gz.tmp") are not spliced into the stream.
 		seq, perr := strconv.ParseUint(suffix, 10, 64)
 		if perr != nil {
 			continue
@@ -102,11 +129,22 @@ func ClosedSegments(canonical string) ([]Segment, error) {
 			// Raced away between ReadDir and Info; skip it.
 			continue
 		}
-		segs = append(segs, Segment{
-			Path: filepath.Join(dir, name),
-			Seq:  seq,
-			Size: info.Size(),
-		})
+		cur := Segment{
+			Path:       filepath.Join(dir, name),
+			Seq:        seq,
+			Size:       info.Size(),
+			Compressed: compressed,
+		}
+		if prev, ok := bySeq[seq]; ok && (!prev.Compressed || cur.Compressed) {
+			// Keep prev unless it is compressed and cur is raw (raw wins).
+			continue
+		}
+		bySeq[seq] = cur
+	}
+
+	segs := make([]Segment, 0, len(bySeq))
+	for _, s := range bySeq {
+		segs = append(segs, s)
 	}
 	sort.Slice(segs, func(i, j int) bool { return segs[i].Seq < segs[j].Seq })
 	return segs, nil
@@ -155,17 +193,44 @@ func ReadAll(canonical string) ([]byte, error) {
 	}
 	var out []byte
 	for _, p := range paths {
-		data, rerr := os.ReadFile(p)
+		data, rerr := readSegment(p)
 		if rerr != nil {
 			if os.IsNotExist(rerr) {
 				// Pruned or rotated away between listing and read; skip.
 				continue
 			}
-			return nil, fmt.Errorf("read capture segment %q: %w", p, rerr)
+			return nil, rerr
 		}
 		out = append(out, data...)
 	}
 	return out, nil
+}
+
+// readSegment reads one segment fully into memory, decompressing transparently
+// when the path is a ".gz" closed segment. An absent path returns an
+// os.IsNotExist error so ReadAll can skip a segment pruned between listing and
+// read.
+func readSegment(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	var r io.Reader = f
+	if strings.HasSuffix(path, GzSuffix) {
+		gz, gerr := gzip.NewReader(f)
+		if gerr != nil {
+			return nil, fmt.Errorf("open gzip segment %q: %w", path, gerr)
+		}
+		defer func() { _ = gz.Close() }()
+		r = gz
+	}
+	data, rerr := io.ReadAll(r)
+	if rerr != nil {
+		return nil, fmt.Errorf("read capture segment %q: %w", path, rerr)
+	}
+	return data, nil
 }
 
 // Dump streams the reassembled transcript to w in order: closed segments
@@ -195,8 +260,67 @@ func dumpOne(path string, w io.Writer) error {
 		return fmt.Errorf("open capture segment %q: %w", path, err)
 	}
 	defer func() { _ = f.Close() }()
-	if _, cerr := io.Copy(w, f); cerr != nil {
+
+	var r io.Reader = f
+	if strings.HasSuffix(path, GzSuffix) {
+		gz, gerr := gzip.NewReader(f)
+		if gerr != nil {
+			return fmt.Errorf("open gzip segment %q: %w", path, gerr)
+		}
+		defer func() { _ = gz.Close() }()
+		r = gz
+	}
+	if _, cerr := io.Copy(w, r); cerr != nil {
 		return fmt.Errorf("read capture segment %q: %w", path, cerr)
 	}
 	return nil
+}
+
+// CompressSegment gzip-compresses the raw closed segment at rawPath to
+// rawPath+GzSuffix and removes the raw file, returning the compressed path.
+//
+// It writes to a temporary sibling and renames atomically so a concurrent
+// reader never observes a partial ".gz", and removes the raw segment only
+// after the compressed file is in place — so at least one complete
+// representation of the segment is on disk at every instant. A non-nil error
+// with a non-empty returned path means the compressed copy landed but the raw
+// file could not be removed (harmless: ClosedSegments dedups, preferring raw).
+func CompressSegment(rawPath string) (string, error) {
+	gzPath := rawPath + GzSuffix
+	tmp := gzPath + ".tmp"
+
+	in, err := os.Open(rawPath)
+	if err != nil {
+		return "", fmt.Errorf("open raw segment %q: %w", rawPath, err)
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	if err != nil {
+		return "", fmt.Errorf("create compressed segment %q: %w", tmp, err)
+	}
+	gz := gzip.NewWriter(out)
+	if _, cerr := io.Copy(gz, in); cerr != nil {
+		_ = gz.Close()
+		_ = out.Close()
+		_ = os.Remove(tmp)
+		return "", fmt.Errorf("gzip segment %q: %w", rawPath, cerr)
+	}
+	if cerr := gz.Close(); cerr != nil {
+		_ = out.Close()
+		_ = os.Remove(tmp)
+		return "", fmt.Errorf("flush gzip segment %q: %w", tmp, cerr)
+	}
+	if cerr := out.Close(); cerr != nil {
+		_ = os.Remove(tmp)
+		return "", fmt.Errorf("close compressed segment %q: %w", tmp, cerr)
+	}
+	if rerr := os.Rename(tmp, gzPath); rerr != nil {
+		_ = os.Remove(tmp)
+		return "", fmt.Errorf("rename compressed segment %q to %q: %w", tmp, gzPath, rerr)
+	}
+	if rerr := os.Remove(rawPath); rerr != nil && !os.IsNotExist(rerr) {
+		return gzPath, fmt.Errorf("remove raw segment %q after compress: %w", rawPath, rerr)
+	}
+	return gzPath, nil
 }

--- a/internal/capture/capture_test.go
+++ b/internal/capture/capture_test.go
@@ -47,28 +47,61 @@ func TestClosedSegments_OrderAndFilter(t *testing.T) {
 	writeFile(t, SegmentPath(canonical, 2), []byte("two"))
 	writeFile(t, SegmentPath(canonical, 0), []byte("zero"))
 	writeFile(t, SegmentPath(canonical, 10), []byte("ten!!"))
+	// A compressed closed segment must be spliced in (seq 1, ".gz" form).
+	writeFile(t, SegmentPath(canonical, 1)+GzSuffix, []byte("x"))
 	// Live segment — must not appear among closed segments.
 	writeFile(t, canonical, []byte("live"))
-	// Unrelated siblings that must be ignored: non-digit suffix and a
-	// future compressed segment.
+	// Unrelated siblings that must be ignored: non-digit suffix and an
+	// in-flight compression temp file.
 	writeFile(t, canonical+".notes", []byte("x"))
-	writeFile(t, SegmentPath(canonical, 1)+".gz", []byte("x"))
+	writeFile(t, SegmentPath(canonical, 5)+GzSuffix+".tmp", []byte("x"))
 
 	segs, err := ClosedSegments(canonical)
 	if err != nil {
 		t.Fatalf("ClosedSegments: %v", err)
 	}
-	if len(segs) != 3 {
-		t.Fatalf("got %d closed segments, want 3: %+v", len(segs), segs)
+	if len(segs) != 4 {
+		t.Fatalf("got %d closed segments, want 4: %+v", len(segs), segs)
 	}
-	wantSeq := []uint64{0, 2, 10}
+	wantSeq := []uint64{0, 1, 2, 10}
 	for i, s := range segs {
 		if s.Seq != wantSeq[i] {
 			t.Fatalf("segment %d seq = %d, want %d", i, s.Seq, wantSeq[i])
 		}
 	}
-	if segs[2].Size != int64(len("ten!!")) {
-		t.Fatalf("seq 10 size = %d, want %d", segs[2].Size, len("ten!!"))
+	if !segs[1].Compressed {
+		t.Fatalf("seq 1 should be flagged compressed: %+v", segs[1])
+	}
+	if segs[0].Compressed {
+		t.Fatalf("seq 0 (raw) should not be flagged compressed: %+v", segs[0])
+	}
+	if segs[3].Size != int64(len("ten!!")) {
+		t.Fatalf("seq 10 size = %d, want %d", segs[3].Size, len("ten!!"))
+	}
+}
+
+func TestClosedSegments_RawWinsOverGzForSameSeq(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+
+	// Both raw and ".gz" exist for seq 3 — the transient window during
+	// rotation's compress step. They must collapse to a single segment,
+	// preferring the raw copy.
+	writeFile(t, SegmentPath(canonical, 3), []byte("raw-bytes"))
+	writeFile(t, SegmentPath(canonical, 3)+GzSuffix, []byte("gz-bytes"))
+
+	segs, err := ClosedSegments(canonical)
+	if err != nil {
+		t.Fatalf("ClosedSegments: %v", err)
+	}
+	if len(segs) != 1 {
+		t.Fatalf("got %d segments, want 1 (collapsed): %+v", len(segs), segs)
+	}
+	if segs[0].Compressed {
+		t.Fatalf("collapsed segment should be the raw copy: %+v", segs[0])
+	}
+	if segs[0].Path != SegmentPath(canonical, 3) {
+		t.Fatalf("collapsed path = %q, want raw %q", segs[0].Path, SegmentPath(canonical, 3))
 	}
 }
 
@@ -193,5 +226,81 @@ func TestDump_NeverWritten(t *testing.T) {
 	}
 	if buf.Len() != 0 {
 		t.Fatalf("want no output, got %q", buf.String())
+	}
+}
+
+func TestCompressSegment_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+	raw := SegmentPath(canonical, 0)
+	// Repetitive payload so gzip actually shrinks it — also exercises a
+	// payload larger than one gzip block.
+	original := bytes.Repeat([]byte("the quick brown fox jumped over\n"), 4096)
+	writeFile(t, raw, original)
+
+	gzPath, err := CompressSegment(raw)
+	if err != nil {
+		t.Fatalf("CompressSegment: %v", err)
+	}
+	if want := raw + GzSuffix; gzPath != want {
+		t.Fatalf("gzPath = %q, want %q", gzPath, want)
+	}
+	// Raw is removed; only the compressed copy remains.
+	if _, serr := os.Stat(raw); !os.IsNotExist(serr) {
+		t.Fatalf("raw segment still present after compress: %v", serr)
+	}
+	info, err := os.Stat(gzPath)
+	if err != nil {
+		t.Fatalf("stat %q: %v", gzPath, err)
+	}
+	if info.Size() >= int64(len(original)) {
+		t.Fatalf("compressed size %d not smaller than original %d", info.Size(), len(original))
+	}
+	// No in-flight temp file is left behind.
+	if _, serr := os.Stat(gzPath + ".tmp"); !os.IsNotExist(serr) {
+		t.Fatalf("temp file lingered: %v", serr)
+	}
+
+	// Round-trip: the compressed segment reads back as the original bytes.
+	got, err := ReadAll(canonical)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("round-trip mismatch: got %d bytes, want %d", len(got), len(original))
+	}
+}
+
+func TestReadAll_SpansGzClosedAndRawLive(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+
+	// Two closed segments compressed to ".gz", then a raw live segment —
+	// the steady state after rotations have compressed older segments.
+	writeFile(t, SegmentPath(canonical, 0), []byte("AAAA"))
+	if _, err := CompressSegment(SegmentPath(canonical, 0)); err != nil {
+		t.Fatalf("compress seq 0: %v", err)
+	}
+	writeFile(t, SegmentPath(canonical, 1), []byte("BBBB"))
+	if _, err := CompressSegment(SegmentPath(canonical, 1)); err != nil {
+		t.Fatalf("compress seq 1: %v", err)
+	}
+	writeFile(t, canonical, []byte("CCCC"))
+
+	data, err := ReadAll(canonical)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if want := []byte("AAAABBBBCCCC"); !bytes.Equal(data, want) {
+		t.Fatalf("ReadAll = %q, want %q", data, want)
+	}
+
+	// Dump must agree with ReadAll across the same mixed layout.
+	var buf bytes.Buffer
+	if derr := Dump(canonical, &buf); derr != nil {
+		t.Fatalf("Dump: %v", derr)
+	}
+	if buf.String() != "AAAABBBBCCCC" {
+		t.Fatalf("Dump = %q, want %q", buf.String(), "AAAABBBBCCCC")
 	}
 }

--- a/internal/terminal/terminalrunner/capture_writer.go
+++ b/internal/terminal/terminalrunner/capture_writer.go
@@ -30,9 +30,12 @@ import (
 // captureWriter is the always-on capture sink registered first in multiOutW.
 // It writes the live segment append-only at the canonical path and, once the
 // live segment crosses maxBytes, rotates: close → rename to a deterministic
-// sibling (capture.SegmentPath) → reopen a fresh canonical → prune oldest
-// closed segments by count and total bytes. Readers reassemble the full
-// transcript via the internal/capture helpers.
+// sibling (capture.SegmentPath) → gzip-compress the closed segment
+// (capture.CompressSegment) → reopen a fresh canonical → prune oldest closed
+// segments by count and total bytes. The live segment is never compressed (it
+// must stay raw and seekable); only closed segments are. Readers reassemble
+// and transparently decompress the full transcript via the internal/capture
+// helpers.
 //
 // Rotation failures never silently kill capture: the writer always restores a
 // writable live segment (reopening the canonical) and logs, so a transient
@@ -144,6 +147,20 @@ func (w *captureWriter) rotate() error {
 		return fmt.Errorf("rename live segment to %q: %w", target, rerr)
 	}
 	w.nextSeq++
+
+	// Compress the just-closed segment synchronously (gzip of a bounded
+	// segment is tens of ms). On failure the raw segment stays on disk —
+	// still spliceable by readers — so a compression error degrades to
+	// "kept raw this round", never lost capture.
+	if gzPath, cerr := capture.CompressSegment(target); cerr != nil {
+		w.logger.Warn("capture segment compression failed; keeping raw segment", "path", target, "err", cerr)
+	} else if w.applyPerms != nil {
+		if perr := w.applyPerms(gzPath); perr != nil {
+			// Perms are best-effort: a chmod/chown failure on the compressed
+			// segment must not stop rotation.
+			w.logger.Warn("capture perms reapply failed", "path", gzPath, "err", perr)
+		}
+	}
 
 	if oerr := w.reopenCanonical(); oerr != nil {
 		return oerr

--- a/internal/terminal/terminalrunner/capture_writer_test.go
+++ b/internal/terminal/terminalrunner/capture_writer_test.go
@@ -50,6 +50,26 @@ func newTestCaptureWriter(
 	return w
 }
 
+// gzSize returns the on-disk gzip size CompressSegment produces for payload.
+// Closed segments are compressed on rotation, so byte-retention caps are set
+// relative to the compressed size rather than the raw payload length.
+func gzSize(t *testing.T, payload []byte) int64 {
+	t.Helper()
+	raw := filepath.Join(t.TempDir(), "sample.000000")
+	if err := os.WriteFile(raw, payload, 0o600); err != nil {
+		t.Fatalf("write sample: %v", err)
+	}
+	gzPath, err := capture.CompressSegment(raw)
+	if err != nil {
+		t.Fatalf("compress sample: %v", err)
+	}
+	info, err := os.Stat(gzPath)
+	if err != nil {
+		t.Fatalf("stat sample gz: %v", err)
+	}
+	return info.Size()
+}
+
 func mustWrite(t *testing.T, w io.Writer, b []byte) {
 	t.Helper()
 	n, err := w.Write(b)
@@ -109,14 +129,23 @@ func TestCaptureWriter_SingleRotation(t *testing.T) {
 	if len(segs) != 1 {
 		t.Fatalf("expected 1 closed segment, got %d", len(segs))
 	}
-	closed, err := os.ReadFile(segs[0].Path)
+	// The closed segment is gzip-compressed; the canonical (live) stays raw.
+	if !segs[0].Compressed {
+		t.Fatalf("closed segment should be compressed: %+v", segs[0])
+	}
+	if filepath.Ext(segs[0].Path) != capture.GzSuffix {
+		t.Fatalf("closed segment path = %q, want a %q suffix", segs[0].Path, capture.GzSuffix)
+	}
+	// Reassembly transparently decompresses the closed segment, then the live
+	// tail: the full transcript reads back as everything written.
+	full, err := capture.ReadAll(canonical)
 	if err != nil {
-		t.Fatalf("read closed: %v", err)
+		t.Fatalf("ReadAll: %v", err)
 	}
-	if !bytes.Equal(closed, []byte("12345678")) {
-		t.Fatalf("closed segment = %q, want %q", closed, "12345678")
+	if !bytes.Equal(full, []byte("12345678tail")) {
+		t.Fatalf("reassembled = %q, want %q", full, "12345678tail")
 	}
-	// cat of the canonical shows the live tail only.
+	// cat of the canonical shows the live tail only — never compressed.
 	live, err := os.ReadFile(canonical)
 	if err != nil {
 		t.Fatalf("read canonical: %v", err)
@@ -155,12 +184,18 @@ func TestCaptureWriter_MultipleRotationsAndPrune(t *testing.T) {
 	if len(segs) != 2 {
 		t.Fatalf("expected retention to cap closed segments at 2, got %d", len(segs))
 	}
-	// The two surviving closed segments must be the newest two written
-	// before the final (empty) live segment: "EEEE" and "FFFF".
-	got0, _ := os.ReadFile(segs[0].Path)
-	got1, _ := os.ReadFile(segs[1].Path)
-	if !bytes.Equal(got0, []byte("EEEE")) || !bytes.Equal(got1, []byte("FFFF")) {
-		t.Fatalf("surviving segments = %q,%q, want EEEE,FFFF", got0, got1)
+	// The two surviving closed segments must be the newest two written before
+	// the final (empty) live segment: "EEEE" then "FFFF". They are gzip-
+	// compressed, so verify content through the decompressing reassembler.
+	if !segs[0].Compressed || !segs[1].Compressed {
+		t.Fatalf("surviving closed segments should be compressed: %+v", segs)
+	}
+	got, err := capture.ReadAll(canonical)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(got, []byte("EEEEFFFF")) {
+		t.Fatalf("reassembled survivors = %q, want %q", got, "EEEEFFFF")
 	}
 }
 
@@ -169,11 +204,14 @@ func TestCaptureWriter_MultipleRotationsAndPrune(t *testing.T) {
 func TestCaptureWriter_BytePrune(t *testing.T) {
 	dir := t.TempDir()
 	canonical := filepath.Join(dir, "capture")
-	// 4-byte segments, no count cap, keep at most 8 closed bytes (2 segments).
-	w := newTestCaptureWriter(t, canonical, 4, 0, 8)
+	// Identical 8-byte payloads each compress to a fixed size g once closed;
+	// a byte cap of 2*g (no count cap) must retain exactly the newest two.
+	payload := []byte("PAYLOAD8")
+	g := gzSize(t, payload)
+	w := newTestCaptureWriter(t, canonical, int64(len(payload)), 0, 2*g)
 
-	for _, c := range [][]byte{[]byte("AAAA"), []byte("BBBB"), []byte("CCCC"), []byte("DDDD")} {
-		mustWrite(t, w, c)
+	for range 4 {
+		mustWrite(t, w, payload) // each write hits the threshold and rotates
 	}
 	if err := w.Close(); err != nil {
 		t.Fatalf("close: %v", err)
@@ -183,12 +221,15 @@ func TestCaptureWriter_BytePrune(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ClosedSegments: %v", err)
 	}
+	if len(segs) != 2 {
+		t.Fatalf("byte retention should keep newest 2 (cap=2*%d), got %d", g, len(segs))
+	}
 	var total int64
 	for _, s := range segs {
 		total += s.Size
 	}
-	if total > 8 {
-		t.Fatalf("byte retention exceeded: total closed bytes = %d, cap 8", total)
+	if total > 2*g {
+		t.Fatalf("byte retention exceeded: total closed bytes = %d, cap %d", total, 2*g)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Closes #297 — the fourth/final phase of the capture-rendering arc (#295 → #71 → #296 → this), building on the rotation + retention landed in #296/#303.
- On rotation, the just-closed `<canonical>.NNNNNN` segment is gzip-compressed to `<canonical>.NNNNNN.gz` (stdlib `compress/gzip`, zero new dependency). The **live segment stays raw and seekable** — only closed segments are compressed.
- Readers (`--full-capture`, `sb read`, the attach parser feed) transparently decompress `.gz` closed segments. All three consumers funnel through `capture.ReadAll`/`capture.Dump`, so adding decompression there — dispatching on the `.gz` file extension — covers every reader path with no new reader.

## Implementation notes (for reviewer scrutiny)

- **`capture.CompressSegment`** writes to a temp `.gz.tmp` sibling, renames it atomically into place, then removes the raw segment. This ordering guarantees a concurrent reader never observes a partial `.gz`, and at least one complete representation of the segment is on disk at every instant.
- **Crash/transient safety:** compression is best-effort in `rotate()` — on any compression error the raw segment is left on disk (still spliceable by readers) and the writer logs and continues. A compression failure degrades to "kept raw this round," never lost capture.
- **`ClosedSegments` now matches both `.NNNNNN` and `.NNNNNN.gz`** and collapses a same-seq raw+`.gz` pair (the transient mid-rotation window) to a single segment, **preferring the raw copy** (original bytes, skips a decompress; the two are byte-identical). In-flight `.gz.tmp` files are ignored by the all-digit subsuffix check.
- **Retention accounting** uses the on-disk (compressed) size, so the byte budget bounds actual disk use.
- **Premise note:** the issue's "Suggested slicing" was correct as written; #296 landed via PR #303 (rotation + retention + the reader reassembly this extends). No premise rot — implemented as specified.

## Test plan

- [x] `make sbsh-sb` — canonical build; `file ./sbsh` confirms ELF executable
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — full suite green (incl. `e2e`, `pkg/terminal/server`)
- [x] pre-commit (golangci-lint, go fmt, addlicense) — passed
- [x] New tests: `CompressSegment` round-trip (compressed-then-read == original), reader spanning gzip-closed + raw-live segments (`ReadAll` and `Dump`), same-seq raw-wins-over-gz collapse, updated rotation/retention tests to assert compression + verify content through the decompressing reassembler

## Acceptance criteria

- [x] Closed segments are gzip-compressed to `<canonical>.NNNNNN.gz` on rotation; the live segment remains raw and seekable.
- [x] `--full-capture`, `sb read`, and the parser feed transparently decompress `.gz` closed segments during reassembly, dispatching on file extension.
- [x] Tests cover a reader spanning raw-live + gzip-closed segments, and round-trip integrity (compressed-then-read == original bytes).

Closes #297