### PR TITLE
fix(terminalrunner): restore backpressure for interactive attachers on high-throughput output

### DIFF
--- a/internal/terminal/terminalrunner/connections.go
+++ b/internal/terminal/terminalrunner/connections.go
@@ -129,7 +129,18 @@ func (sr *Exec) handleClient(client *ioClient) {
 	// Write). Adding the writer to multiOutW *before* starting Run is safe —
 	// Write just enqueues into the ring until Run starts draining, and the
 	// seeded paint already sits ahead of any live bytes that arrive after Add.
+	//
+	// Backpressure policy (issue #312): the interactive attacher is the
+	// session's primary terminal — its screen *is* the output device — so on
+	// ring overflow the producer is paced to this attacher's drain rate
+	// (flow-control, the pre-#217 PTY behavior) rather than dropping it with a
+	// lagged sentinel. enableBackpressure bounds that pacing so a paused or
+	// abandoned attacher still falls through to drop-on-lag and never
+	// head-of-line-blocks the capture sink or sibling attachers (the #217
+	// invariant). Passive Subscribe / `sb read` consumers (subscribe.go)
+	// deliberately stay on the unbounded drop-on-lag path — see subscriber.go.
 	aw := newSubscriberWriter(client.conn, defaultSubscriberBufferBytes, detach, sr.logger)
+	aw.enableBackpressure()
 	aw.seedReplay(initial)
 	client.outWriter = aw
 	multiOutW.Add(aw)

--- a/internal/terminal/terminalrunner/subscribe.go
+++ b/internal/terminal/terminalrunner/subscribe.go
@@ -121,6 +121,12 @@ func (sr *Exec) Subscribe(req *api.SubscribeRequest, response *api.ResponseWithF
 		})
 	}
 
+	// Passive observer: keep the drop-on-lag policy (no enableBackpressure).
+	// A Subscribe / `sb read` consumer that falls behind must be disconnected
+	// with the lagged sentinel rather than pacing the producer, so it can
+	// never stall the session for the interactive attacher. The interactive
+	// attach path (connections.go) is the one that opts into backpressure;
+	// the policy split is documented on subscriberWriter. See issue #312.
 	sub = newSubscriberWriter(conn, defaultSubscriberBufferBytes, detach, sr.logger)
 	sr.addSubscriber(sub)
 	multiOutW.Add(sub)

--- a/internal/terminal/terminalrunner/subscriber.go
+++ b/internal/terminal/terminalrunner/subscriber.go
@@ -36,6 +36,21 @@ var subscriberWriteTimeout = 5 * time.Second
 // abandoned subscriber must never be able to stall the shared fan-out.
 const defaultSubscriberBufferBytes = 1 << 20 // 1 MiB
 
+// subscriberBackpressureStall bounds how long a single overflowing Write may
+// pace the producer on behalf of a backpressure-mode (interactive) attacher
+// before giving up and dropping the attacher on lag. A *live* interactive
+// reader frees ring space within microseconds, so its overflowing Writes
+// return well inside this budget and the producer is throttled to terminal
+// speed (issue #312). A *paused or abandoned* attacher frees nothing, so its
+// Write trips the budget once, drops the attacher, and frees the producer —
+// the bounded transient that keeps the #217 invariant intact (a stuck
+// attacher must not head-of-line-block the capture sink and sibling
+// attachers). Generous enough not to false-drop a momentarily slow live
+// terminal; var (not const) so tests can shorten it.
+//
+//nolint:gochecknoglobals // test-tunable knob, mirrors subscriberWriteTimeout
+var subscriberBackpressureStall = 2 * time.Second
+
 // laggedNotice is appended to a subscriber stream when the ring overflows
 // so a caller can distinguish disconnection from a clean EOF. The \r\n
 // framing is intentional: it renders cleanly in terminal mode and the
@@ -45,18 +60,38 @@ var laggedNotice = []byte("\r\n[sbsh: subscriber lagged, disconnecting]\r\n")
 
 // subscriberWriter absorbs PTY output from the multiwriter into a bounded
 // in-memory ring and forwards it to an external net.Conn on a dedicated
-// goroutine. The Write path never blocks: on overflow the subscriber is
-// marked lagged, detached, and its conn is closed.
+// goroutine.
+//
+// Two fan-out policies share this type, selected per consumer class via
+// enableBackpressure (issue #312):
+//
+//   - Passive observers (Subscribe / `sb read`, the capture writer, the
+//     vt-parser screen model) keep backpressure==false: the Write path never
+//     blocks, and on overflow the subscriber is marked lagged, detached, and
+//     its conn is closed. A passive observer must never stall the session.
+//
+//   - The interactive attacher (connections.go) sets backpressure==true: on
+//     overflow Write *paces the producer* to the attacher's drain rate
+//     instead of dropping it, so the attached terminal flow-controls the
+//     shell exactly as a real PTY does — slow but never dropped. The pacing
+//     is bounded by subscriberBackpressureStall so a stuck attacher still
+//     falls through to drop-on-lag and cannot head-of-line-block the shared
+//     fan-out (the #217 invariant).
+//
+// #217 (f6b3f4f) collapsed both classes onto the single drop-on-lag path,
+// which regressed the interactive firehose case (`cat /dev/urandom | hexdump`
+// disconnected the client); the split must not be silently re-merged again.
 type subscriberWriter struct {
-	mu       sync.Mutex
-	cond     *sync.Cond
-	buf      bytes.Buffer
-	maxBytes int
-	closed   bool
-	lagged   bool
-	conn     net.Conn
-	onDetach func()
-	logger   *slog.Logger
+	mu           sync.Mutex
+	cond         *sync.Cond
+	buf          bytes.Buffer
+	maxBytes     int
+	closed       bool
+	lagged       bool
+	backpressure bool
+	conn         net.Conn
+	onDetach     func()
+	logger       *slog.Logger
 }
 
 func newSubscriberWriter(conn net.Conn, maxBytes int, onDetach func(), logger *slog.Logger) *subscriberWriter {
@@ -73,30 +108,89 @@ func newSubscriberWriter(conn net.Conn, maxBytes int, onDetach func(), logger *s
 	return s
 }
 
+// enableBackpressure switches this writer to the interactive fan-out policy:
+// on ring overflow Write paces the producer until the drain frees space
+// instead of dropping the attacher on lag. Call before the writer is
+// registered in the fan-out. See the subscriberWriter doc and issue #312 for
+// why interactive attach uses backpressure while passive subscribe does not.
+func (s *subscriberWriter) enableBackpressure() {
+	s.mu.Lock()
+	s.backpressure = true
+	s.mu.Unlock()
+}
+
 // Write is called by DynamicMultiWriter on the PTY reader goroutine. It
-// enqueues bytes into the bounded ring and returns immediately. When the
-// ring would exceed maxBytes the subscriber is marked lagged+closed and
-// the drain goroutine is signalled; Run owns the conn lifecycle and will
-// flush any buffered bytes, emit laggedNotice, and close the conn. Write
-// always reports success to the fan-out so one bad subscriber cannot
+// enqueues bytes into the bounded ring. In passive (drop-on-lag) mode it
+// returns immediately and, when the ring would exceed maxBytes, marks the
+// subscriber lagged+closed and signals the drain; Run owns the conn lifecycle
+// and will flush any buffered bytes, emit laggedNotice, and close the conn.
+//
+// In backpressure mode (interactive attach, issue #312) an overflowing Write
+// instead waits for the drain to free space — pacing the producer to the
+// attacher's terminal speed — and only falls through to the lagged path if
+// the attacher makes no progress within subscriberBackpressureStall (a stuck
+// or abandoned peer), so it can never head-of-line-block the fan-out.
+//
+// Write always reports success to the fan-out so one bad subscriber cannot
 // abort output to other attachers or the capture file.
 func (s *subscriberWriter) Write(p []byte) (int, error) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.closed {
-		s.mu.Unlock()
 		return len(p), nil
 	}
 	if s.buf.Len()+len(p) > s.maxBytes {
+		// Backpressure mode: pace the producer to the live attacher's drain
+		// rate. waitForRoom returns true once the drain has freed enough
+		// space (throttle), or false if the writer closed or the stall
+		// budget elapsed with no progress (drop the stuck attacher below).
+		if s.backpressure && s.waitForRoom(len(p)) {
+			_, _ = s.buf.Write(p)
+			s.cond.Broadcast()
+			return len(p), nil
+		}
+		if s.closed {
+			return len(p), nil
+		}
 		s.lagged = true
 		s.closed = true
 		s.cond.Broadcast()
-		s.mu.Unlock()
 		return len(p), nil
 	}
 	_, _ = s.buf.Write(p)
-	s.cond.Signal()
-	s.mu.Unlock()
+	s.cond.Broadcast()
 	return len(p), nil
+}
+
+// waitForRoom blocks (with s.mu held) until the ring has space for need bytes
+// or the per-write stall budget elapses without the drain making progress.
+// Returns true when space is available — the caller enqueues, pacing the
+// producer to the drain — and false when the writer was closed or the budget
+// elapsed (the caller drops the attacher on lag, freeing the producer). Only
+// reached in backpressure mode. A one-shot timer broadcasts at the deadline
+// so a producer parked on a stuck (non-reading) peer wakes even though the
+// drain itself is blocked in conn.Write; for a live reader the drain's own
+// post-dequeue Broadcast wakes the producer long before the timer fires.
+func (s *subscriberWriter) waitForRoom(need int) bool {
+	deadline := time.Now().Add(subscriberBackpressureStall)
+	timer := time.AfterFunc(subscriberBackpressureStall, func() {
+		s.mu.Lock()
+		s.cond.Broadcast()
+		s.mu.Unlock()
+	})
+	defer timer.Stop()
+	for {
+		if s.closed {
+			return false
+		}
+		if s.buf.Len()+need <= s.maxBytes {
+			return true
+		}
+		if !time.Now().Before(deadline) {
+			return false
+		}
+		s.cond.Wait()
+	}
 }
 
 // seedReplay pre-loads the ring with the capture replay so the single
@@ -164,6 +258,10 @@ func (s *subscriberWriter) Run() {
 		}
 		chunk := make([]byte, s.buf.Len())
 		_, _ = s.buf.Read(chunk)
+		// Wake any producer parked in waitForRoom now that the ring has
+		// drained — this is the throttle release for backpressure mode and a
+		// harmless re-check for passive mode (no producer ever parks there).
+		s.cond.Broadcast()
 		s.mu.Unlock()
 
 		_ = s.conn.SetWriteDeadline(time.Now().Add(subscriberWriteTimeout))
@@ -171,6 +269,10 @@ func (s *subscriberWriter) Run() {
 			s.logger.Debug("subscriber conn write failed; closing", "err", err)
 			s.mu.Lock()
 			s.closed = true
+			// Broadcast so a backpressure producer parked on this now-dead
+			// peer unblocks immediately instead of waiting out its stall
+			// budget; it will take the drop-on-lag path on wake.
+			s.cond.Broadcast()
 			s.mu.Unlock()
 			return
 		}

--- a/internal/terminal/terminalrunner/subscriber_test.go
+++ b/internal/terminal/terminalrunner/subscriber_test.go
@@ -36,6 +36,15 @@ func shortenWriteTimeout(d time.Duration) func() {
 	return func() { subscriberWriteTimeout = prev }
 }
 
+// shortenBackpressureStall lowers the per-write backpressure stall budget so
+// a stuck-attacher scenario falls through to drop-on-lag quickly instead of
+// pacing the producer for the production 2s. Returns a restore func.
+func shortenBackpressureStall(d time.Duration) func() {
+	prev := subscriberBackpressureStall
+	subscriberBackpressureStall = d
+	return func() { subscriberBackpressureStall = prev }
+}
+
 // newPipeConnPair returns a (clientSide, serverSide) net.Pipe pair. The
 // subscriberWriter forwards bytes into serverSide; the test reads from
 // clientSide to verify output.
@@ -135,6 +144,137 @@ func TestSubscriber_SeededReplayPrecedesLiveOutputLargeCapture(t *testing.T) {
 	}
 	if !detached.Load() {
 		t.Fatal("detach callback not invoked after clean close")
+	}
+}
+
+// TestSubscriber_BackpressureThrottlesSlowInteractiveReader is the regression
+// for issue #312: an interactive attacher running a firehose
+// (`cat /dev/urandom | hexdump`) used to overflow the 1 MiB ring and be
+// disconnected with the lagged sentinel (regressed by #217, f6b3f4f). With
+// backpressure the producer is paced to the attacher's drain rate — slow but
+// never dropped, exactly how a real PTY flow-controls a process to its
+// terminal. The slow-but-live reader below consumes far less per tick than
+// the producer emits, forcing the ring past maxBytes repeatedly; the writer
+// must throttle (no lagged) and deliver the whole stream.
+func TestSubscriber_BackpressureThrottlesSlowInteractiveReader(t *testing.T) {
+	// Not t.Parallel: mutates package-level timeout vars.
+	clientSide, serverSide := newPipeConnPair()
+	defer clientSide.Close()
+
+	const maxBytes = 4096
+	var detached atomic.Bool
+	sub := newSubscriberWriter(serverSide, maxBytes, func() { detached.Store(true) }, slog.Default())
+	sub.enableBackpressure()
+	go sub.Run()
+
+	// total well past the ring bound: a drop-on-lag writer would disconnect
+	// here. The reader is live (always reading) but slow — small reads with a
+	// brief pause — so the producer outpaces it and the ring keeps filling.
+	const total = maxBytes * 8
+	readDone := make(chan int, 1)
+	go func() {
+		buf := make([]byte, 256)
+		got := 0
+		for got < total {
+			n, err := clientSide.Read(buf)
+			got += n
+			if err != nil {
+				break
+			}
+			time.Sleep(200 * time.Microsecond)
+		}
+		readDone <- got
+	}()
+
+	chunk := bytes.Repeat([]byte("A"), 512)
+	writeDone := make(chan struct{})
+	go func() {
+		defer close(writeDone)
+		for sent := 0; sent < total; sent += len(chunk) {
+			n, err := sub.Write(chunk)
+			if err != nil || n != len(chunk) {
+				t.Errorf("Write: n=%d err=%v", n, err)
+				return
+			}
+		}
+		_ = sub.Close()
+	}()
+
+	select {
+	case <-writeDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("producer never completed — backpressure deadlocked")
+	}
+
+	got := <-readDone
+
+	sub.mu.Lock()
+	lagged := sub.lagged
+	sub.mu.Unlock()
+	if lagged {
+		t.Fatal("interactive attacher was lagged-dropped despite actively reading (issue #312)")
+	}
+	if got < total {
+		t.Fatalf("reader received %d of %d bytes — stream truncated", got, total)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for !detached.Load() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !detached.Load() {
+		t.Fatal("detach callback not invoked after clean close")
+	}
+}
+
+// TestSubscriber_BackpressureStuckAttacherDropsAndFreesProducer locks in the
+// #217 invariant under the new policy: a backpressure attacher whose peer
+// stops reading must not pace the producer indefinitely. After the stall
+// budget elapses the writer falls through to drop-on-lag — Write returns,
+// the attacher is detached, and the shared fan-out is freed.
+func TestSubscriber_BackpressureStuckAttacherDropsAndFreesProducer(t *testing.T) {
+	// Not t.Parallel: mutates package-level timeout vars.
+	restoreStall := shortenBackpressureStall(100 * time.Millisecond)
+	defer restoreStall()
+	restoreWrite := shortenWriteTimeout(100 * time.Millisecond)
+	defer restoreWrite()
+
+	clientSide, serverSide := newPipeConnPair()
+	defer clientSide.Close()
+
+	const maxBytes = 128
+	var detached atomic.Bool
+	sub := newSubscriberWriter(serverSide, maxBytes, func() { detached.Store(true) }, slog.Default())
+	sub.enableBackpressure()
+	go sub.Run()
+
+	// Peer never reads, so the drain blocks and the ring fills. The producer's
+	// overflowing Writes must still return (after pacing out the stall budget)
+	// rather than parking forever.
+	chunk := bytes.Repeat([]byte("A"), 64)
+	writeDone := make(chan struct{})
+	go func() {
+		defer close(writeDone)
+		for range 100 {
+			if n, err := sub.Write(chunk); err != nil || n != len(chunk) {
+				t.Errorf("Write: n=%d err=%v", n, err)
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-writeDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("producer parked on a stuck attacher — #217 invariant violated")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for !detached.Load() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !detached.Load() {
+		t.Fatal("stuck backpressure attacher was not detached")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Interactive attach (`connections.go`) and passive `Subscribe`/`sb read` (`subscribe.go`) shared one **drop-on-lag** `subscriberWriter`. #217 (`f6b3f4f`) collapsed them onto that single path, regressing the firehose case: an attached `cat /dev/urandom | hexdump` overflows the 1 MiB ring and the client is disconnected with the lagged sentinel instead of being flow-controlled to terminal speed.
- This splits the fan-out policy **by consumer class** via a per-writer `backpressure` flag set at the policy site (`enableBackpressure`, called only from the interactive path):
  - **Interactive attacher** → on ring overflow, `Write` paces the producer (PTY reader) until the drain frees space — flow-control, the pre-#217 PTY behavior — instead of dropping the attacher.
  - **Passive observers** (Subscribe, `sb read`, capture writer, vt-parser screen) → keep **drop-on-lag** unchanged (no `enableBackpressure`), so a slow observer can never stall the session.
- **#217 invariant preserved.** The backpressure pacing is bounded by a new `subscriberBackpressureStall` budget (default 2s). A *live* reader frees ring space within microseconds, so its overflowing writes return well inside the budget (throttle). A *paused/abandoned* attacher frees nothing, so its `Write` trips the budget once, drops the attacher on lag, and frees the producer — a bounded transient, never an indefinite head-of-line block of the capture sink or sibling attachers. The drain also `Broadcast`s on its write-deadline close so a parked producer unblocks immediately rather than waiting out the budget.

### Design notes for the reviewer
- **Why backpressure runs through the single PTY reader:** the only way to flow-control the shell is to stop reading the ptmx, which inherently paces *all* sinks to terminal speed. That's intended PTY semantics (the session paces to its terminal). The #217 invariant is specifically about a *stuck* attacher not *permanently* blocking siblings/capture — satisfied here because a non-draining attacher is ejected after `subscriberBackpressureStall`.
- **`subscriberBackpressureStall` carries a `//nolint:gochecknoglobals`.** It mirrors the existing test-tunable `subscriberWriteTimeout` package var; that neighbor is grandfathered by pre-commit's new-issues-only golangci filter, but a *new* global trips the gate, so an explicit suppression (matching the repo's existing `//nolint:gochecknoglobals` convention) is required. Open to making it a struct field instead if preferred.
- AC5's design-rationale comment lives on the `subscriberWriter` type doc plus the two call sites (`connections.go`, `subscribe.go`), citing #217 and #312 so the policy isn't silently re-merged.

## Test plan
- [x] `make test` (unit + integration + e2e) — pass
- [x] `make test-race` (race detector across all packages) — pass, no data races
- [x] `make sbsh-sb` + `file ./sbsh` — ELF executable
- [x] `go build ./...`, `go vet ./internal/terminal/terminalrunner/...` — clean
- [x] `pre-commit run --files <changed>` — pass
- [x] New regression tests (AC4):
  - `TestSubscriber_BackpressureThrottlesSlowInteractiveReader` — slow-but-live interactive reader consuming 8× the ring bound completes without a lagged-disconnect, full stream delivered.
  - `TestSubscriber_BackpressureStuckAttacherDropsAndFreesProducer` — a non-reading backpressure attacher is dropped after the stall budget and the producer is freed (#217 invariant).
- [x] AC2 (passive drop-on-lag unchanged) covered by existing `TestSubscriber_LaggedReaderIsDropped` / `TestSubscriber_LaggedNoticeReachesClient`, which use the default (non-backpressure) policy.

## Acceptance criteria
- [x] Attached firehose is throttled, not disconnected — no lagged sentinel for an actively-reading interactive attach.
- [x] Passive `Subscribe`/`sb read` consumers still get the lagged sentinel on overflow (unchanged).
- [x] A paused/abandoned interactive attacher does not stall siblings or capture (#217 invariant holds).
- [x] Regression test locking in the firehose case.
- [x] Design-rationale comment at the policy site citing this regression and #217.

Closes #312