### PR TITLE
fix(capture): re-resolve raw/.gz sibling on ENOENT in segment readers

### DIFF
--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -206,19 +206,59 @@ func ReadAll(canonical string) ([]byte, error) {
 	return out, nil
 }
 
-// readSegment reads one segment fully into memory, decompressing transparently
-// when the path is a ".gz" closed segment. An absent path returns an
-// os.IsNotExist error so ReadAll can skip a segment pruned between listing and
-// read.
-func readSegment(path string) ([]byte, error) {
+// siblingPath returns the alternate on-disk representation of a closed
+// segment: the ".gz" form for a raw path, or the raw form for a ".gz" path.
+func siblingPath(path string) string {
+	if strings.HasSuffix(path, GzSuffix) {
+		return strings.TrimSuffix(path, GzSuffix)
+	}
+	return path + GzSuffix
+}
+
+// openSegment opens a closed segment for reading, recovering from the raw↔".gz"
+// rename race: a segment listed by OrderedPaths as raw can be swapped to ".gz"
+// by a concurrent CompressSegment (or vice-versa) in the microsecond window
+// before the reader opens it. On ENOENT for the listed path we re-resolve the
+// sibling representation — the same retained segment under its other name —
+// rather than dropping still-retained history (issue #316). It returns the
+// opened file and whether that file is gzip-compressed (dispatch follows the
+// path actually opened, not the one requested). Only when *neither*
+// representation exists is the original os.IsNotExist returned, so callers
+// keep skipping a segment genuinely pruned or rotated away.
+func openSegment(path string) (*os.File, bool, error) {
 	f, err := os.Open(path)
+	if err == nil {
+		return f, strings.HasSuffix(path, GzSuffix), nil
+	}
+	if !os.IsNotExist(err) {
+		return nil, false, err
+	}
+	sib := siblingPath(path)
+	sf, serr := os.Open(sib)
+	if serr != nil {
+		if os.IsNotExist(serr) {
+			// Both representations gone: genuinely pruned/rotated. Return the
+			// original ENOENT (on the listed path) so the caller skips.
+			return nil, false, err
+		}
+		return nil, false, serr
+	}
+	return sf, strings.HasSuffix(sib, GzSuffix), nil
+}
+
+// readSegment reads one segment fully into memory, decompressing transparently
+// when the opened file is a ".gz" closed segment. An absent path (with no
+// sibling representation either) returns an os.IsNotExist error so ReadAll can
+// skip a segment pruned between listing and read.
+func readSegment(path string) ([]byte, error) {
+	f, compressed, err := openSegment(path)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = f.Close() }()
 
 	var r io.Reader = f
-	if strings.HasSuffix(path, GzSuffix) {
+	if compressed {
 		gz, gerr := gzip.NewReader(f)
 		if gerr != nil {
 			return nil, fmt.Errorf("open gzip segment %q: %w", path, gerr)
@@ -251,10 +291,11 @@ func Dump(canonical string, w io.Writer) error {
 }
 
 func dumpOne(path string, w io.Writer) error {
-	f, err := os.Open(path)
+	f, compressed, err := openSegment(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			// Pruned or rotated away between listing and open; skip.
+			// Pruned or rotated away (neither raw nor ".gz" representation on
+			// disk) between listing and open; skip.
 			return nil
 		}
 		return fmt.Errorf("open capture segment %q: %w", path, err)
@@ -262,7 +303,7 @@ func dumpOne(path string, w io.Writer) error {
 	defer func() { _ = f.Close() }()
 
 	var r io.Reader = f
-	if strings.HasSuffix(path, GzSuffix) {
+	if compressed {
 		gz, gerr := gzip.NewReader(f)
 		if gerr != nil {
 			return fmt.Errorf("open gzip segment %q: %w", path, gerr)

--- a/internal/capture/capture_test.go
+++ b/internal/capture/capture_test.go
@@ -271,6 +271,91 @@ func TestCompressSegment_RoundTrip(t *testing.T) {
 	}
 }
 
+// TestReadSegment_ResolvesGzSiblingOnRawENOENT is the regression for issue
+// #316: a segment listed by OrderedPaths as raw can be swapped to ".gz" by a
+// concurrent CompressSegment in the window before the reader opens it. The old
+// readSegment returned os.IsNotExist on the vanished raw path and ReadAll
+// silently dropped the still-retained segment. readSegment must instead
+// recover the ".gz" sibling and read it back as the original bytes.
+func TestReadSegment_ResolvesGzSiblingOnRawENOENT(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+	raw := SegmentPath(canonical, 0)
+	original := bytes.Repeat([]byte("retained-history\n"), 512)
+	writeFile(t, raw, original)
+	if _, err := CompressSegment(raw); err != nil {
+		t.Fatalf("CompressSegment: %v", err)
+	}
+	// Raw is gone; only raw+".gz" remains — exactly the post-race on-disk state
+	// for the stale raw path OrderedPaths handed out.
+	if _, serr := os.Stat(raw); !os.IsNotExist(serr) {
+		t.Fatalf("raw segment unexpectedly present: %v", serr)
+	}
+
+	got, err := readSegment(raw)
+	if err != nil {
+		t.Fatalf("readSegment on raced raw path: %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("recovered %d bytes, want %d", len(got), len(original))
+	}
+}
+
+// TestDumpOne_ResolvesGzSiblingOnRawENOENT is the Dump-path twin of the above:
+// dumpOne must also re-resolve the ".gz" sibling rather than skipping a
+// retained segment that was compressed out from under it.
+func TestDumpOne_ResolvesGzSiblingOnRawENOENT(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+	raw := SegmentPath(canonical, 0)
+	original := bytes.Repeat([]byte("retained-history\n"), 512)
+	writeFile(t, raw, original)
+	if _, err := CompressSegment(raw); err != nil {
+		t.Fatalf("CompressSegment: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := dumpOne(raw, &buf); err != nil {
+		t.Fatalf("dumpOne on raced raw path: %v", err)
+	}
+	if !bytes.Equal(buf.Bytes(), original) {
+		t.Fatalf("dumped %d bytes, want %d", buf.Len(), len(original))
+	}
+}
+
+// TestReadSegment_ResolvesRawSiblingOnGzENOENT covers the inverse direction the
+// fix is symmetric over: a ".gz" path that no longer exists falls back to the
+// raw sibling (strip GzSuffix) before giving up.
+func TestReadSegment_ResolvesRawSiblingOnGzENOENT(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+	raw := SegmentPath(canonical, 0)
+	original := []byte("raw-only-bytes")
+	writeFile(t, raw, original)
+
+	got, err := readSegment(raw + GzSuffix)
+	if err != nil {
+		t.Fatalf("readSegment on absent .gz with raw sibling: %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("recovered %q, want %q", got, original)
+	}
+}
+
+// TestReadSegment_BothGoneReturnsIsNotExist locks in the skip path: when
+// neither the raw nor the ".gz" representation exists the segment is genuinely
+// pruned/rotated, so readSegment must surface os.IsNotExist for ReadAll to skip
+// it — the sibling retry must not mask a real prune as some other error.
+func TestReadSegment_BothGoneReturnsIsNotExist(t *testing.T) {
+	dir := t.TempDir()
+	raw := SegmentPath(filepath.Join(dir, "capture"), 0)
+
+	_, err := readSegment(raw)
+	if !os.IsNotExist(err) {
+		t.Fatalf("readSegment on fully-pruned segment: err = %v, want os.IsNotExist", err)
+	}
+}
+
 func TestReadAll_SpansGzClosedAndRawLive(t *testing.T) {
 	dir := t.TempDir()
 	canonical := filepath.Join(dir, "capture")


### PR DESCRIPTION
## Summary

- `OrderedPaths` (via `ClosedSegments`) can list a closed segment under its raw `.NNNNNN` name an instant before a concurrent `CompressSegment` swaps it to `.NNNNNN.gz` (raw→`.gz` rename + raw removal). When `readSegment`/`dumpOne` then `os.Open` the now-vanished raw path, the old code returned `os.IsNotExist` and the caller **silently dropped a still-retained segment** — its `.gz` copy is on disk, so the transcript loses a chunk of retained history until the next read re-lists. Surfaced during review of PR #314.
- Fix: route both `readSegment` (used by `ReadAll`) and `dumpOne` (used by `Dump`) through a new `openSegment` helper. On `ENOENT` for the listed path it re-resolves the **sibling representation** — `path+GzSuffix` when the raw is gone, `strings.TrimSuffix(path, GzSuffix)` for the inverse — and reads whichever currently exists, dispatching gzip-decompression on the path actually opened (not the one requested).
- Only when *neither* representation exists does `openSegment` surface the original `os.IsNotExist`, so the legitimate skip for a genuinely pruned/rotated segment is preserved unchanged.

### Design notes for the reviewer
- The retry is symmetric (raw↔`.gz`) per the issue's "strip GzSuffix for the inverse" request. In practice `CompressSegment` only goes raw→`.gz`, so the inverse arm is defensive — a pruned `.gz` whose raw never reappears still falls through to the skip.
- `openSegment` returns the original `ENOENT` (on the listed path), not the sibling's, when both are gone — so `os.IsNotExist` stays true for the caller's skip branch and a real prune is never masked as a different error.
- The race window can't be reproduced through the public `ReadAll`/`Dump` (they re-list and find the `.gz`), so the regression tests exercise `readSegment`/`dumpOne` directly with the exact post-`CompressSegment` on-disk state (raw gone, `.gz` present).

## Test plan
- [x] `make test` (unit + integration + e2e) — pass
- [x] `go build ./...`, `go vet ./internal/capture/...` — clean
- [x] `go test ./internal/capture/... -race` — pass
- [x] `make sbsh-sb` + `file ./sbsh` — ELF executable
- [x] `pre-commit run --files <changed>` — pass
- [x] New regression tests:
  - `TestReadSegment_ResolvesGzSiblingOnRawENOENT` — raw listed, compressed away, recovered from `.gz`.
  - `TestDumpOne_ResolvesGzSiblingOnRawENOENT` — same for the `Dump` path.
  - `TestReadSegment_ResolvesRawSiblingOnGzENOENT` — inverse (strip `.gz`).
  - `TestReadSegment_BothGoneReturnsIsNotExist` — genuine prune still surfaces `os.IsNotExist` (skip preserved).

Closes #316