### PR TITLE
test: phase 1 — leaf utility packages (≥80%)

### DIFF
--- a/cmd/types/types_test.go
+++ b/cmd/types/types_test.go
@@ -1,0 +1,58 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"context"
+	"testing"
+)
+
+// The types package declares only context-key constants and a key type; it
+// has no executable statements, so `go test -cover` reports "no statements"
+// for it (exempt from the ≥80% bar per the issue). These assertions guard
+// that the keys stay distinct and round-trip through context.WithValue —
+// the property logging.SetupFileLogger relies on.
+
+func TestCtxKeys_Distinct(t *testing.T) {
+	keys := []CtxLoggerType{CtxLogger, CtxLevelVar, CtxHandler, CtxCloser, CtxTerminalSpec}
+	seen := make(map[CtxLoggerType]bool, len(keys))
+	for _, k := range keys {
+		if seen[k] {
+			t.Errorf("duplicate context key %q", k)
+		}
+		seen[k] = true
+	}
+	if len(seen) != len(keys) {
+		t.Errorf("got %d distinct keys, want %d", len(seen), len(keys))
+	}
+}
+
+func TestCtxKeys_RoundTripThroughContext(t *testing.T) {
+	ctx := context.WithValue(context.Background(), CtxLogger, "logger-value")
+	ctx = context.WithValue(ctx, CtxCloser, "closer-value")
+
+	if got := ctx.Value(CtxLogger); got != "logger-value" {
+		t.Errorf("ctx.Value(CtxLogger) = %v, want logger-value", got)
+	}
+	if got := ctx.Value(CtxCloser); got != "closer-value" {
+		t.Errorf("ctx.Value(CtxCloser) = %v, want closer-value", got)
+	}
+	// A bare string with the same text must NOT collide with the typed key.
+	if got := ctx.Value("logger"); got != nil {
+		t.Errorf("ctx.Value(\"logger\") = %v, want nil (typed key must not collide)", got)
+	}
+}

--- a/internal/defaults/defaults_test.go
+++ b/internal/defaults/defaults_test.go
@@ -1,0 +1,51 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package defaults
+
+import "testing"
+
+// The defaults package declares only constants and has no executable
+// statements, so `go test -cover` reports "no statements" for it (exempt
+// from the ≥80% bar per the issue). These assertions guard the on-disk and
+// rotation/retention contract that internal/capture and the terminalrunner
+// depend on, so an accidental edit to the values is caught here.
+
+func TestRunPathConstants(t *testing.T) {
+	if TerminalsRunPath != "terminals" {
+		t.Errorf("TerminalsRunPath = %q, want terminals", TerminalsRunPath)
+	}
+	if ClientsRunPath != "clients" {
+		t.Errorf("ClientsRunPath = %q, want clients", ClientsRunPath)
+	}
+}
+
+func TestCaptureRotationRetentionKnobs(t *testing.T) {
+	if CaptureSegmentMaxBytes != 8<<20 {
+		t.Errorf("CaptureSegmentMaxBytes = %d, want %d (8 MiB)", CaptureSegmentMaxBytes, 8<<20)
+	}
+	if CaptureRetentionMaxSegments != 8 {
+		t.Errorf("CaptureRetentionMaxSegments = %d, want 8", CaptureRetentionMaxSegments)
+	}
+	if CaptureRetentionMaxBytes != 64<<20 {
+		t.Errorf("CaptureRetentionMaxBytes = %d, want %d (64 MiB)", CaptureRetentionMaxBytes, 64<<20)
+	}
+	// Retention must bound at least one full segment, else rotation churns.
+	if CaptureRetentionMaxBytes < CaptureSegmentMaxBytes {
+		t.Errorf("retention (%d) < segment size (%d): retention cannot hold a segment",
+			CaptureRetentionMaxBytes, CaptureSegmentMaxBytes)
+	}
+}

--- a/internal/dualcopier/copier_test.go
+++ b/internal/dualcopier/copier_test.go
@@ -1,0 +1,302 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dualcopier
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/sbsh/internal/filter"
+)
+
+func noopLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// scriptReader returns scripted (chunk, err) pairs, then io.EOF.
+type scriptReader struct {
+	chunks [][]byte
+	errs   []error
+	i      int
+}
+
+func (s *scriptReader) Read(p []byte) (int, error) {
+	if s.i >= len(s.chunks) {
+		return 0, io.EOF
+	}
+	n := copy(p, s.chunks[s.i])
+	err := s.errs[s.i]
+	s.i++
+	return n, err
+}
+
+// faultyWriter returns a scripted (n, err) for every Write.
+type faultyWriter struct {
+	n   int
+	err error
+}
+
+func (w faultyWriter) Write(p []byte) (int, error) { return w.n, w.err }
+
+// scriptedFilter returns a fixed Process result on every call.
+type scriptedFilter struct {
+	out    []byte
+	nwrite int
+	ncons  int
+	err    error
+}
+
+func (f scriptedFilter) Process([]byte, int) ([]byte, int, int, error) {
+	return f.out, f.nwrite, f.ncons, f.err
+}
+
+func TestNewCopier(t *testing.T) {
+	c := NewCopier(context.Background(), noopLogger())
+	if c == nil || c.ctx == nil || c.errGroup == nil {
+		t.Fatalf("NewCopier returned incomplete Copier: %+v", c)
+	}
+}
+
+func TestReadWriteBytes_NoFilterPassthrough(t *testing.T) {
+	c := NewCopier(context.Background(), noopLogger())
+	r := &scriptReader{chunks: [][]byte{[]byte("hello")}, errs: []error{nil}}
+	var w bytes.Buffer
+	if err := c.readWriteBytes(r, &w, nil); err != nil {
+		t.Fatalf("readWriteBytes error: %v", err)
+	}
+	if w.String() != "hello" {
+		t.Errorf("written = %q, want hello", w.String())
+	}
+}
+
+func TestReadWriteBytes_FilterPassthrough(t *testing.T) {
+	c := NewCopier(context.Background(), noopLogger())
+	// ClientEscapeFilter on plain text returns out=nil, nwrite=n → in-place
+	// window write path.
+	f := filter.NewClientEscapeFilter(0, false, nil)
+	r := &scriptReader{chunks: [][]byte{[]byte("plain text")}, errs: []error{nil}}
+	var w bytes.Buffer
+	if err := c.readWriteBytes(r, &w, f); err != nil {
+		t.Fatalf("readWriteBytes error: %v", err)
+	}
+	if w.String() != "plain text" {
+		t.Errorf("written = %q, want 'plain text'", w.String())
+	}
+}
+
+func TestReadWriteBytes_FilterEmitsAlternateSlice(t *testing.T) {
+	c := NewCopier(context.Background(), noopLogger())
+	// Single ^] then a second ^] should make the filter emit a BEL (alternate
+	// slice, out != nil) on the second byte.
+	f := filter.NewClientEscapeFilter(0, false, func() {})
+	r := &scriptReader{chunks: [][]byte{{0x1d, 0x1d}}, errs: []error{nil}}
+	var w bytes.Buffer
+	if err := c.readWriteBytes(r, &w, f); err != nil {
+		t.Fatalf("readWriteBytes error: %v", err)
+	}
+	// First ^] forwarded, second swallowed and replaced with BEL.
+	if !bytes.Equal(w.Bytes(), []byte{0x1d, 0x07}) {
+		t.Errorf("written = %v, want [0x1d 0x07]", w.Bytes())
+	}
+}
+
+func TestReadWriteBytes_FilterConsumesWithoutWriting(t *testing.T) {
+	c := NewCopier(context.Background(), noopLogger())
+	// nwrite == 0, ncons == n → advance without writing.
+	f := scriptedFilter{out: nil, nwrite: 0, ncons: 4}
+	r := &scriptReader{chunks: [][]byte{[]byte("abcd")}, errs: []error{nil}}
+	var w bytes.Buffer
+	if err := c.readWriteBytes(r, &w, f); err != nil {
+		t.Fatalf("readWriteBytes error: %v", err)
+	}
+	if w.Len() != 0 {
+		t.Errorf("written %d bytes, want 0 (consume-only)", w.Len())
+	}
+}
+
+func TestReadWriteBytes_ZeroConsumeSafetyFallback(t *testing.T) {
+	c := NewCopier(context.Background(), noopLogger())
+	// Filter that consumes and writes nothing → infinite-loop guard forwards
+	// 1 byte at a time.
+	f := scriptedFilter{out: nil, nwrite: 0, ncons: 0}
+	r := &scriptReader{chunks: [][]byte{[]byte("xy")}, errs: []error{nil}}
+	var w bytes.Buffer
+	if err := c.readWriteBytes(r, &w, f); err != nil {
+		t.Fatalf("readWriteBytes error: %v", err)
+	}
+	if w.String() != "xy" {
+		t.Errorf("written = %q, want xy (fallback 1-byte forwarding)", w.String())
+	}
+}
+
+func TestReadWriteBytes_FilterError(t *testing.T) {
+	c := NewCopier(context.Background(), noopLogger())
+	boom := errors.New("filter boom")
+	f := scriptedFilter{err: boom}
+	r := &scriptReader{chunks: [][]byte{[]byte("data")}, errs: []error{nil}}
+	if err := c.readWriteBytes(r, io.Discard, f); !errors.Is(err, boom) {
+		t.Fatalf("readWriteBytes err = %v, want filter boom", err)
+	}
+}
+
+func TestReadWriteBytes_NwriteExceedsOutLength(t *testing.T) {
+	c := NewCopier(context.Background(), noopLogger())
+	f := scriptedFilter{out: []byte{1, 2}, nwrite: 5, ncons: 1}
+	r := &scriptReader{chunks: [][]byte{[]byte("data")}, errs: []error{nil}}
+	err := c.readWriteBytes(r, io.Discard, f)
+	if err == nil {
+		t.Fatal("expected error for nwrite exceeding out length")
+	}
+}
+
+func TestReadWriteBytes_NwriteExceedsAvailableInput(t *testing.T) {
+	c := NewCopier(context.Background(), noopLogger())
+	// out == nil but nwrite > remaining input → "exceeds available input".
+	f := scriptedFilter{out: nil, nwrite: 99, ncons: 1}
+	r := &scriptReader{chunks: [][]byte{[]byte("ab")}, errs: []error{nil}}
+	err := c.readWriteBytes(r, io.Discard, f)
+	if err == nil {
+		t.Fatal("expected error for nwrite exceeding available input")
+	}
+}
+
+func TestReadWriteBytes_WriteError(t *testing.T) {
+	c := NewCopier(context.Background(), noopLogger())
+	boom := errors.New("write boom")
+	r := &scriptReader{chunks: [][]byte{[]byte("data")}, errs: []error{nil}}
+	if err := c.readWriteBytes(r, faultyWriter{n: 0, err: boom}, nil); !errors.Is(err, boom) {
+		t.Fatalf("readWriteBytes err = %v, want write boom", err)
+	}
+}
+
+func TestReadWriteBytes_ShortWriteNoProgress(t *testing.T) {
+	c := NewCopier(context.Background(), noopLogger())
+	r := &scriptReader{chunks: [][]byte{[]byte("data")}, errs: []error{nil}}
+	err := c.readWriteBytes(r, faultyWriter{n: 0, err: nil}, nil)
+	if err == nil || err.Error() != "short write with no progress" {
+		t.Fatalf("readWriteBytes err = %v, want 'short write with no progress'", err)
+	}
+}
+
+func TestReadWriteBytes_ReadError(t *testing.T) {
+	c := NewCopier(context.Background(), noopLogger())
+	boom := errors.New("read boom")
+	// n == 0 with a read error → error returned without writing.
+	r := &scriptReader{chunks: [][]byte{nil}, errs: []error{boom}}
+	if err := c.readWriteBytes(r, io.Discard, nil); !errors.Is(err, boom) {
+		t.Fatalf("readWriteBytes err = %v, want read boom", err)
+	}
+}
+
+func TestRunReadWriter_ContextCancelledReturnsCtxErr(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+	c := NewCopier(ctx, noopLogger())
+
+	ready := make(chan struct{})
+	// A blocking reader so the only way out is the ctx.Done() select arm.
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	defer pr.Close()
+
+	err := c.runReadWriter(pr, io.Discard, ready, func() {}, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("runReadWriter err = %v, want context.Canceled", err)
+	}
+	select {
+	case <-ready:
+	default:
+		t.Error("ready channel was not closed")
+	}
+}
+
+func TestRunReadWriter_ReadErrorInvokesErrFunc(t *testing.T) {
+	c := NewCopier(context.Background(), noopLogger())
+	ready := make(chan struct{})
+	called := false
+	boom := errors.New("read boom")
+	r := &scriptReader{chunks: [][]byte{nil}, errs: []error{boom}}
+
+	err := c.runReadWriter(r, io.Discard, ready, func() { called = true }, nil)
+	if !errors.Is(err, boom) {
+		t.Fatalf("runReadWriter err = %v, want read boom", err)
+	}
+	if !called {
+		t.Error("errFunc was not invoked on read error")
+	}
+}
+
+func TestRunCopier_AndCopierManager_ErrGroupPath(t *testing.T) {
+	c := NewCopier(context.Background(), noopLogger())
+	ready := make(chan struct{})
+	// Reader yields one chunk then EOF → runReadWriter writes it, then the
+	// EOF read terminates the goroutine via the error path.
+	r := &scriptReader{chunks: [][]byte{[]byte("payload")}, errs: []error{nil}}
+	var w bytes.Buffer
+
+	c.RunCopier(r, &w, ready, func() {}, nil)
+	<-ready // goroutine started
+
+	// CopierManager blocks until the errgroup finishes (the EOF error path).
+	c.CopierManager(nil, func() {})
+	if w.String() != "payload" {
+		t.Errorf("written = %q, want payload", w.String())
+	}
+}
+
+func TestCopierManager_ContextCancelledNilConn(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	c := NewCopier(ctx, noopLogger())
+	cancel()
+
+	finished := false
+	c.CopierManager(nil, func() { finished = true })
+	if !finished {
+		t.Error("finish() was not called on context cancellation with nil conn")
+	}
+}
+
+func TestCopierManager_ContextCancelledRealConn(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	c := NewCopier(ctx, noopLogger())
+
+	sock := filepath.Join(t.TempDir(), "s.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	dialed, err := net.Dial("unix", sock)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	uc := dialed.(*net.UnixConn)
+	defer uc.Close()
+
+	cancel()
+	finished := false
+	c.CopierManager(uc, func() { finished = true })
+	if !finished {
+		t.Error("finish() was not called on context cancellation with real conn")
+	}
+}

--- a/internal/errdefs/errdefs_test.go
+++ b/internal/errdefs/errdefs_test.go
@@ -1,0 +1,75 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package errdefs
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// The errdefs package declares only sentinel error values and has no
+// executable statements, so `go test -cover` reports "no statements" for it
+// (exempt from the ≥80% bar per the issue). These assertions guard the two
+// properties callers rely on: every sentinel is non-nil with a stable
+// message, and errors.Is matches through a %w wrap.
+
+func TestSentinels_NonNilWithMessage(t *testing.T) {
+	sentinels := []error{
+		ErrFuncNotSet, ErrContextDone, ErrWaitOnReady, ErrWaitOnClose, ErrChildExit,
+		ErrSpecCmdMissing, ErrOpenSocketCtrl, ErrStartRPCServer, ErrStartTerminal, ErrAttach,
+		ErrClientMode, ErrRPCServerExited, ErrOnClose, ErrCloseReq, ErrTerminalCmdStart,
+		ErrWriteMetadata, ErrStartCmd, ErrDetachTerminal, ErrSetupShell, ErrInitShell,
+		ErrProgramExited, ErrNoSpecDefined, ErrAttachNoTerminalSpec, ErrTerminalNotFoundByID,
+		ErrTerminalNotFoundByName, ErrTerminalNameInUse, ErrTerminalMetadataNotFound,
+		ErrNoTerminalSpec, ErrConfig, ErrLoggerNotFound, ErrInvalidFlag, ErrInvalidOption,
+		ErrStdinStat, ErrStdinEmpty, ErrInvalidArgument, ErrOpenSpecFile, ErrInvalidJSONSpec,
+		ErrTerminalSpecNotFound, ErrBuildTerminalSpec, ErrNoTerminalIdentifier,
+		ErrTooManyArguments, ErrCreateClientDir, ErrResolveTerminalName,
+		ErrNoTerminalIdentification, ErrNoClientIdentifier, ErrConflictingFlags,
+		ErrBuildSocketPath, ErrDetermineRunPath, ErrRunPathRequired, ErrNoClientIdentification,
+		ErrPositionalWithFlags, ErrInvalidOutputFormat, ErrGetRunPath, ErrNoTerminalsFound,
+		ErrNoClientsFound, ErrTerminalNotFound, ErrClientNotFound, ErrStopTerminal,
+		ErrStopTimeout, ErrSignalProcess, ErrTerminalStdinClosed, ErrSubscriberLagged,
+		ErrInvalidProfiles, ErrClientDetached, ErrPeerClosed,
+	}
+	seen := make(map[string]bool, len(sentinels))
+	for i, e := range sentinels {
+		if e == nil {
+			t.Errorf("sentinel index %d is nil", i)
+			continue
+		}
+		msg := e.Error()
+		if msg == "" {
+			t.Errorf("sentinel index %d has empty message", i)
+		}
+		if seen[msg] {
+			t.Errorf("duplicate sentinel message %q", msg)
+		}
+		seen[msg] = true
+	}
+}
+
+func TestSentinels_MatchThroughWrap(t *testing.T) {
+	wrapped := fmt.Errorf("context: %w", ErrTerminalNotFound)
+	if !errors.Is(wrapped, ErrTerminalNotFound) {
+		t.Error("errors.Is(wrapped, ErrTerminalNotFound) = false, want true")
+	}
+	if errors.Is(wrapped, ErrClientNotFound) {
+		t.Error("errors.Is matched the wrong sentinel")
+	}
+}

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -1,0 +1,255 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package filter
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestNewClientEscapeFilter_DefaultsEscToCtrlRBracket(t *testing.T) {
+	f := NewClientEscapeFilter(0, false, nil)
+	if f.Esc != 0x1d {
+		t.Fatalf("Esc = %#x, want 0x1d (default Ctrl+])", f.Esc)
+	}
+	if f.PasteAware {
+		t.Errorf("PasteAware = true, want false")
+	}
+
+	custom := NewClientEscapeFilter('q', true, func() {})
+	if custom.Esc != 'q' {
+		t.Errorf("Esc = %#x, want 'q'", custom.Esc)
+	}
+	if !custom.PasteAware {
+		t.Errorf("PasteAware = false, want true")
+	}
+	if custom.OnDetach == nil {
+		t.Errorf("OnDetach = nil, want non-nil")
+	}
+}
+
+func TestProcess_EmptyInput(t *testing.T) {
+	f := NewClientEscapeFilter(0, false, nil)
+	out, nwrite, ncons, err := f.Process(nil, 0)
+	if err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if out != nil || nwrite != 0 || ncons != 0 {
+		t.Fatalf("Process(empty) = (%v, %d, %d); want (nil, 0, 0)", out, nwrite, ncons)
+	}
+}
+
+func TestProcess_NoEscapePassesThrough(t *testing.T) {
+	f := NewClientEscapeFilter(0, false, nil)
+	buf := []byte("hello world")
+	out, nwrite, ncons, err := f.Process(buf, len(buf))
+	if err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if out != nil {
+		t.Errorf("out = %v, want nil (write buf[:ncons] in place)", out)
+	}
+	if nwrite != len(buf) || ncons != len(buf) {
+		t.Errorf("Process = (nwrite=%d, ncons=%d); want both %d", nwrite, ncons, len(buf))
+	}
+}
+
+func TestProcess_PrefixBeforeEscapeWrittenFirst(t *testing.T) {
+	f := NewClientEscapeFilter(0, false, nil)
+	buf := []byte("abc\x1d")
+	out, nwrite, ncons, err := f.Process(buf, len(buf))
+	if err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if out != nil {
+		t.Errorf("out = %v, want nil", out)
+	}
+	if nwrite != 3 || ncons != 3 {
+		t.Errorf("Process = (nwrite=%d, ncons=%d); want (3, 3) — prefix before Esc", nwrite, ncons)
+	}
+}
+
+func TestProcess_SingleEscapeForwardedAndArmed(t *testing.T) {
+	f := NewClientEscapeFilter(0, false, nil)
+	buf := []byte{0x1d}
+	out, nwrite, ncons, err := f.Process(buf, len(buf))
+	if err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if !bytes.Equal(out, []byte{0x1d}) || nwrite != 1 || ncons != 1 {
+		t.Fatalf("Process = (out=%v, nwrite=%d, ncons=%d); want (0x1d, 1, 1)", out, nwrite, ncons)
+	}
+	if !f.sawEsc {
+		t.Errorf("sawEsc = false after a single Esc; want true (armed for adjacency)")
+	}
+}
+
+func TestProcess_AdjacentEscapeWithinChunkTriggersDetach(t *testing.T) {
+	detached := false
+	f := NewClientEscapeFilter(0, false, func() { detached = true })
+
+	// First Esc forwarded, arms adjacency.
+	buf := []byte{0x1d, 0x1d}
+	out, nwrite, ncons, err := f.Process(buf, len(buf))
+	if err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if !bytes.Equal(out, []byte{0x1d}) || nwrite != 1 || ncons != 1 {
+		t.Fatalf("first Esc = (out=%v, nwrite=%d, ncons=%d); want (0x1d, 1, 1)", out, nwrite, ncons)
+	}
+
+	// Second Esc (now buf[0]) is swallowed, BEL emitted, detach fires.
+	out, nwrite, ncons, err = f.Process(buf[1:], 1)
+	if err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if !bytes.Equal(out, []byte{0x07}) || nwrite != 1 || ncons != 1 {
+		t.Fatalf("second Esc = (out=%v, nwrite=%d, ncons=%d); want (BEL 0x07, 1, 1)", out, nwrite, ncons)
+	}
+	if !detached {
+		t.Errorf("OnDetach not invoked on adjacent ^]^]")
+	}
+	if f.sawEsc {
+		t.Errorf("sawEsc = true after detach; want false (cleared)")
+	}
+}
+
+func TestProcess_AdjacentEscapeWithNilOnDetach(t *testing.T) {
+	f := NewClientEscapeFilter(0, false, nil)
+	f.Process([]byte{0x1d}, 1) // arm
+	out, nwrite, ncons, err := f.Process([]byte{0x1d}, 1)
+	if err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if !bytes.Equal(out, []byte{0x07}) || nwrite != 1 || ncons != 1 {
+		t.Fatalf("second Esc with nil OnDetach = (out=%v, nwrite=%d, ncons=%d); want (BEL, 1, 1)", out, nwrite, ncons)
+	}
+}
+
+func TestProcess_ArmedButNextByteNotEscapeClearsPending(t *testing.T) {
+	f := NewClientEscapeFilter(0, false, func() { t.Fatal("OnDetach should not fire") })
+	f.Process([]byte{0x1d}, 1) // arm
+	if !f.sawEsc {
+		t.Fatal("expected armed after single Esc")
+	}
+	// Next chunk does not start with Esc → pending cleared, bytes pass through.
+	out, nwrite, ncons, err := f.Process([]byte("xyz"), 3)
+	if err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if out != nil || nwrite != 3 || ncons != 3 {
+		t.Fatalf("Process = (out=%v, nwrite=%d, ncons=%d); want (nil, 3, 3)", out, nwrite, ncons)
+	}
+	if f.sawEsc {
+		t.Errorf("sawEsc = true; want false (cleared by non-Esc next byte)")
+	}
+}
+
+func TestProcess_PasteModeWritesThroughUntilEndMarker(t *testing.T) {
+	f := NewClientEscapeFilter(0, true, func() { t.Fatal("OnDetach should not fire inside paste") })
+
+	// Paste start before any Esc → enter paste mode, write through marker.
+	start := []byte{0x1b, '[', '2', '0', '0', '~'}
+	out, nwrite, ncons, err := f.Process(start, len(start))
+	if err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if out != nil || nwrite != len(start) || ncons != len(start) {
+		t.Fatalf("paste start = (out=%v, nwrite=%d, ncons=%d); want (nil, %d, %d)", out, nwrite, ncons, len(start), len(start))
+	}
+	if !f.pasteMode {
+		t.Fatal("pasteMode = false after start marker; want true")
+	}
+
+	// Inside paste, an escape byte must NOT trigger detach — passes through.
+	body := []byte{0x1d, 'a', 'b'}
+	out, nwrite, ncons, err = f.Process(body, len(body))
+	if err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if out != nil || nwrite != len(body) || ncons != len(body) {
+		t.Fatalf("paste body = (out=%v, nwrite=%d, ncons=%d); want full passthrough", out, nwrite, ncons)
+	}
+
+	// Paste end marker exits paste mode.
+	end := []byte{0x1b, '[', '2', '0', '1', '~'}
+	out, nwrite, ncons, err = f.Process(end, len(end))
+	if err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if out != nil || nwrite != len(end) || ncons != len(end) {
+		t.Fatalf("paste end = (out=%v, nwrite=%d, ncons=%d); want full passthrough", out, nwrite, ncons)
+	}
+	if f.pasteMode {
+		t.Errorf("pasteMode = true after end marker; want false")
+	}
+}
+
+func TestProcess_PasteModeNoEndMarkerWritesAll(t *testing.T) {
+	f := NewClientEscapeFilter(0, true, nil)
+	f.pasteMode = true
+	buf := []byte("no end marker here")
+	out, nwrite, ncons, err := f.Process(buf, len(buf))
+	if err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	if out != nil || nwrite != len(buf) || ncons != len(buf) {
+		t.Fatalf("Process = (out=%v, nwrite=%d, ncons=%d); want full passthrough", out, nwrite, ncons)
+	}
+	if !f.pasteMode {
+		t.Errorf("pasteMode = false; want still true (no end marker seen)")
+	}
+}
+
+func TestProcess_EscapeBeforePasteStartTakesEscapePath(t *testing.T) {
+	// PasteAware on, but an Esc appears before the paste-start marker.
+	// The start marker must NOT win — the Esc path is taken.
+	f := NewClientEscapeFilter(0, true, nil)
+	buf := append([]byte{0x1d}, 0x1b, '[', '2', '0', '0', '~')
+	out, nwrite, ncons, err := f.Process(buf, len(buf))
+	if err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	// buf[0] is Esc and we are not armed → forward the single Esc, arm.
+	if !bytes.Equal(out, []byte{0x1d}) || nwrite != 1 || ncons != 1 {
+		t.Fatalf("Process = (out=%v, nwrite=%d, ncons=%d); want single Esc forwarded", out, nwrite, ncons)
+	}
+	if f.pasteMode {
+		t.Errorf("pasteMode = true; want false (Esc precedes paste start)")
+	}
+}
+
+func TestIndexOf(t *testing.T) {
+	cases := []struct {
+		name string
+		s    []byte
+		pat  []byte
+		want int
+	}{
+		{"empty pattern returns 0", []byte("abc"), nil, 0},
+		{"found", []byte("hello"), []byte("ll"), 2},
+		{"not found", []byte("hello"), []byte("zz"), -1},
+		{"at start", []byte("abc"), []byte("a"), 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := indexOf(tc.s, tc.pat); got != tc.want {
+				t.Errorf("indexOf(%q, %q) = %d, want %d", tc.s, tc.pat, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,120 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/sbsh/cmd/types"
+	"github.com/spf13/cobra"
+)
+
+func TestParseLevel(t *testing.T) {
+	cases := []struct {
+		in   string
+		want slog.Level
+	}{
+		{"debug", slog.LevelDebug},
+		{"info", slog.LevelInfo},
+		{"warn", slog.LevelWarn},
+		{"error", slog.LevelError},
+		{"nonsense", slog.LevelInfo},
+	}
+	for _, tc := range cases {
+		if got := ParseLevel(tc.in); got != tc.want {
+			t.Errorf("ParseLevel(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNewNoopLogger_NeverEnabledAndNoPanic(t *testing.T) {
+	l := NewNoopLogger()
+	if l == nil {
+		t.Fatal("NewNoopLogger() = nil")
+	}
+	if l.Enabled(context.Background(), slog.LevelError) {
+		t.Errorf("noop logger reports Enabled = true; want false at every level")
+	}
+	// Logging through the noop handler must be a safe no-op.
+	l.Info("dropped", "k", "v")
+	l.Error("dropped", "k", "v")
+}
+
+func TestNoopHandler_Methods(t *testing.T) {
+	h := noopHandler{}
+	ctx := context.Background()
+	if h.Enabled(ctx, slog.LevelDebug) {
+		t.Errorf("Enabled = true; want false")
+	}
+	if err := h.Handle(ctx, slog.Record{}); err != nil {
+		t.Errorf("Handle error = %v; want nil", err)
+	}
+	if got := h.WithAttrs([]slog.Attr{slog.String("a", "b")}); got == nil {
+		t.Errorf("WithAttrs = nil; want a handler")
+	}
+	if got := h.WithGroup("g"); got == nil {
+		t.Errorf("WithGroup = nil; want a handler")
+	}
+}
+
+func TestSetupFileLogger_RejectsEmptyArgs(t *testing.T) {
+	cmd := &cobra.Command{}
+	cases := []struct {
+		name     string
+		cmd      *cobra.Command
+		logfile  string
+		loglevel string
+	}{
+		{"nil cmd", nil, "x.log", "info"},
+		{"empty logfile", cmd, "", "info"},
+		{"empty loglevel", cmd, "x.log", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := SetupFileLogger(tc.cmd, tc.logfile, tc.loglevel); err == nil {
+				t.Errorf("SetupFileLogger(%v, %q, %q) = nil; want error", tc.cmd, tc.logfile, tc.loglevel)
+			}
+		})
+	}
+}
+
+func TestSetupFileLogger_PopulatesContext(t *testing.T) {
+	logfile := filepath.Join(t.TempDir(), "sub", "test.log")
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	if err := SetupFileLogger(cmd, logfile, "debug"); err != nil {
+		t.Fatalf("SetupFileLogger error: %v", err)
+	}
+
+	ctx := cmd.Context()
+	if ctx.Value(types.CtxLogger) == nil {
+		t.Errorf("CtxLogger not set in context")
+	}
+	if ctx.Value(types.CtxLevelVar) == nil {
+		t.Errorf("CtxLevelVar not set in context")
+	}
+	if ctx.Value(types.CtxHandler) == nil {
+		t.Errorf("CtxHandler not set in context")
+	}
+	if _, ok := ctx.Value(types.CtxLogger).(*slog.Logger); !ok {
+		t.Errorf("CtxLogger is not a *slog.Logger")
+	}
+}

--- a/internal/naming/naming_test.go
+++ b/internal/naming/naming_test.go
@@ -1,0 +1,95 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package naming
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func TestRandomName_FormatAndWordlists(t *testing.T) {
+	leftSet := make(map[string]bool, len(left))
+	for _, w := range left {
+		leftSet[w] = true
+	}
+	rightSet := make(map[string]bool, len(right))
+	for _, w := range right {
+		rightSet[w] = true
+	}
+
+	for i := 0; i < 200; i++ {
+		name := RandomName()
+		parts := strings.SplitN(name, "_", 2)
+		if len(parts) != 2 {
+			t.Fatalf("RandomName() = %q; want exactly one '_' separator", name)
+		}
+		if !leftSet[parts[0]] {
+			t.Errorf("RandomName() left token %q not in left wordlist", parts[0])
+		}
+		if !rightSet[parts[1]] {
+			t.Errorf("RandomName() right token %q not in right wordlist", parts[1])
+		}
+	}
+}
+
+func TestRandomName_ProducesVariety(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		seen[RandomName()] = true
+	}
+	// With ~100x100 combinations, 100 draws should yield well more than one
+	// distinct value; a single value would signal a broken seed.
+	if len(seen) < 2 {
+		t.Fatalf("RandomName() produced %d distinct values over 100 draws; want variety", len(seen))
+	}
+}
+
+func TestRandomID_LengthAndHex(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		id := RandomID()
+		// 4 random bytes hex-encoded → 8 hex chars.
+		if len(id) != 8 {
+			t.Fatalf("RandomID() = %q (len %d); want 8 hex chars", id, len(id))
+		}
+		if _, err := hex.DecodeString(id); err != nil {
+			t.Errorf("RandomID() = %q is not valid hex: %v", id, err)
+		}
+	}
+}
+
+func TestRandomID_ProducesVariety(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		seen[RandomID()] = true
+	}
+	if len(seen) < 2 {
+		t.Fatalf("RandomID() produced %d distinct values over 100 draws; want variety", len(seen))
+	}
+}
+
+func TestRandSeed_NonTrivial(t *testing.T) {
+	// randSeed reads from crypto/rand; over several calls it should not return
+	// a constant value. This exercises the success path of the helper.
+	seeds := make(map[int64]bool)
+	for i := 0; i < 20; i++ {
+		seeds[randSeed()] = true
+	}
+	if len(seeds) < 2 {
+		t.Fatalf("randSeed() returned %d distinct values over 20 calls; want variety", len(seeds))
+	}
+}

--- a/internal/shared/shared_test.go
+++ b/internal/shared/shared_test.go
@@ -1,0 +1,319 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shared
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestWriteMetadata_RoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	type meta struct {
+		Name string `json:"name"`
+		N    int    `json:"n"`
+	}
+	in := meta{Name: "term-1", N: 7}
+
+	if err := WriteMetadata(context.Background(), in, dir); err != nil {
+		t.Fatalf("WriteMetadata error: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, "metadata.json"))
+	if err != nil {
+		t.Fatalf("read metadata.json: %v", err)
+	}
+	if raw[len(raw)-1] != '\n' {
+		t.Errorf("metadata.json does not end with a trailing newline")
+	}
+	var out meta
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("unmarshal metadata.json: %v", err)
+	}
+	if out != in {
+		t.Errorf("round-trip = %+v, want %+v", out, in)
+	}
+
+	// File mode should be 0o644.
+	info, err := os.Stat(filepath.Join(dir, "metadata.json"))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o644 {
+		t.Errorf("metadata.json mode = %o, want 0644", perm)
+	}
+}
+
+func TestWriteMetadata_MarshalError(t *testing.T) {
+	// A channel cannot be JSON-marshaled → marshal error path.
+	if err := WriteMetadata(context.Background(), make(chan int), t.TempDir()); err == nil {
+		t.Errorf("WriteMetadata(chan) = nil; want marshal error")
+	}
+}
+
+func TestWriteMetadata_WriteErrorOnMissingDir(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	if err := WriteMetadata(context.Background(), map[string]int{"a": 1}, missing); err == nil {
+		t.Errorf("WriteMetadata into missing dir = nil; want write error")
+	}
+}
+
+func TestAtomicWriteFile_OverwritesExisting(t *testing.T) {
+	dst := filepath.Join(t.TempDir(), "f.txt")
+	if err := atomicWriteFile(dst, []byte("first"), 0o600); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := atomicWriteFile(dst, []byte("second"), 0o600); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "second" {
+		t.Errorf("contents = %q, want %q", got, "second")
+	}
+}
+
+func TestAtomicWriteFile_CreateTempError(t *testing.T) {
+	dst := filepath.Join(t.TempDir(), "no-such-dir", "f.txt")
+	if err := atomicWriteFile(dst, []byte("x"), 0o600); err == nil {
+		t.Errorf("atomicWriteFile into missing dir = nil; want CreateTemp error")
+	}
+}
+
+// debugWriter captures slog text output so logging helpers can be exercised.
+func newDebugLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func TestLogBytes_EmptyAndNonEmpty(t *testing.T) {
+	logger := newDebugLogger()
+	// Empty data exercises the empty branches of logASCII and logHEX.
+	LogBytes("p", nil, logger)
+	// Non-empty multi-line data exercises the hex-dump loop and ASCII filter,
+	// including non-printable bytes (rendered as '.') and a length > 16.
+	data := make([]byte, 20)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	data[5] = 'A' // a printable byte mixed in
+	LogBytes("p", data, logger)
+}
+
+func TestLoggingConn_ReadWrite(t *testing.T) {
+	logger := newDebugLogger()
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	lc := &LoggingConn{Conn: c1, Logger: logger, PrefixWrite: "w", PrefixRead: "r"}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, 16)
+		n, err := c2.Read(buf)
+		if err != nil {
+			t.Errorf("peer read: %v", err)
+			return
+		}
+		if string(buf[:n]) != "hello" {
+			t.Errorf("peer read = %q, want hello", buf[:n])
+		}
+		if _, err := c2.Write([]byte("ack")); err != nil {
+			t.Errorf("peer write: %v", err)
+		}
+	}()
+
+	if _, err := lc.Write([]byte("hello")); err != nil {
+		t.Fatalf("LoggingConn.Write: %v", err)
+	}
+	buf := make([]byte, 16)
+	n, err := lc.Read(buf)
+	if err != nil {
+		t.Fatalf("LoggingConn.Read: %v", err)
+	}
+	if string(buf[:n]) != "ack" {
+		t.Errorf("LoggingConn.Read = %q, want ack", buf[:n])
+	}
+	wg.Wait()
+}
+
+// unixConnPair returns a connected pair of *net.UnixConn over a temp socket.
+func unixConnPair(t *testing.T) (server, client *net.UnixConn) {
+	t.Helper()
+	sock := filepath.Join(t.TempDir(), "s.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	defer ln.Close()
+
+	accepted := make(chan *net.UnixConn, 1)
+	go func() {
+		c, aerr := ln.Accept()
+		if aerr != nil {
+			accepted <- nil
+			return
+		}
+		accepted <- c.(*net.UnixConn)
+	}()
+
+	dialed, err := net.Dial("unix", sock)
+	if err != nil {
+		t.Fatalf("dial unix: %v", err)
+	}
+	server = <-accepted
+	if server == nil {
+		t.Fatal("accept failed")
+	}
+	client = dialed.(*net.UnixConn)
+	t.Cleanup(func() { server.Close(); client.Close() })
+	return server, client
+}
+
+func TestLoggingConnUnix_ReadWrite(t *testing.T) {
+	logger := newDebugLogger()
+	server, client := unixConnPair(t)
+
+	lc := &LoggingConnUnix{UnixConn: client, Logger: logger, PrefixWrite: "w", PrefixRead: "r"}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, 16)
+		n, err := server.Read(buf)
+		if err != nil {
+			t.Errorf("server read: %v", err)
+			return
+		}
+		if _, err := server.Write(buf[:n]); err != nil {
+			t.Errorf("server echo: %v", err)
+		}
+	}()
+
+	if _, err := lc.Write([]byte("ping")); err != nil {
+		t.Fatalf("LoggingConnUnix.Write: %v", err)
+	}
+	buf := make([]byte, 16)
+	n, err := lc.Read(buf)
+	if err != nil {
+		t.Fatalf("LoggingConnUnix.Read: %v", err)
+	}
+	if string(buf[:n]) != "ping" {
+		t.Errorf("LoggingConnUnix.Read = %q, want ping", buf[:n])
+	}
+	wg.Wait()
+}
+
+func TestLoggingConnUnix_MsgRoundTrip(t *testing.T) {
+	logger := newDebugLogger()
+	server, client := unixConnPair(t)
+
+	lc := &LoggingConnUnix{UnixConn: client, Logger: logger, PrefixWrite: "w", PrefixRead: "r"}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// Reflect a message back (no OOB).
+		if _, err := server.Write([]byte("msg")); err != nil {
+			t.Errorf("server write: %v", err)
+		}
+	}()
+
+	// Write a message with empty OOB (exercises the no-OOB branch).
+	if _, _, err := lc.WriteMsgUnix([]byte("out"), nil, nil); err != nil {
+		t.Fatalf("WriteMsgUnix: %v", err)
+	}
+
+	buf := make([]byte, 16)
+	oob := make([]byte, 16)
+	n, _, _, err := lc.ReadMsgUnix(buf, oob)
+	if err != nil {
+		t.Fatalf("ReadMsgUnix: %v", err)
+	}
+	if string(buf[:n]) != "msg" {
+		t.Errorf("ReadMsgUnix payload = %q, want msg", buf[:n])
+	}
+	wg.Wait()
+}
+
+func TestLoggingConnUnix_MsgWithFDPassing(t *testing.T) {
+	logger := newDebugLogger()
+	server, client := unixConnPair(t)
+
+	sender := &LoggingConnUnix{UnixConn: client, Logger: logger, PrefixWrite: "w", PrefixRead: "r"}
+	receiver := &LoggingConnUnix{UnixConn: server, Logger: logger, PrefixWrite: "w", PrefixRead: "r"}
+
+	// Open a file whose descriptor we send over the socket as OOB rights —
+	// this exercises the control-message (FD) branches of both methods.
+	f, err := os.CreateTemp(t.TempDir(), "fd-*.txt")
+	if err != nil {
+		t.Fatalf("temp file: %v", err)
+	}
+	defer f.Close()
+
+	rights := unix.UnixRights(int(f.Fd()))
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if _, _, err := sender.WriteMsgUnix([]byte("fd"), rights, nil); err != nil {
+			t.Errorf("WriteMsgUnix with rights: %v", err)
+		}
+	}()
+
+	buf := make([]byte, 16)
+	oob := make([]byte, 1024)
+	n, oobn, _, err := receiver.ReadMsgUnix(buf, oob)
+	if err != nil {
+		t.Fatalf("ReadMsgUnix: %v", err)
+	}
+	if string(buf[:n]) != "fd" {
+		t.Errorf("payload = %q, want fd", buf[:n])
+	}
+	if oobn == 0 {
+		t.Fatalf("oobn = 0; expected control message bytes")
+	}
+	// Close any received descriptors to avoid leaks.
+	cmsgs, err := unix.ParseSocketControlMessage(oob[:oobn])
+	if err != nil {
+		t.Fatalf("ParseSocketControlMessage: %v", err)
+	}
+	for _, m := range cmsgs {
+		if fds, perr := unix.ParseUnixRights(&m); perr == nil {
+			for _, fd := range fds {
+				unix.Close(fd)
+			}
+		}
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary
- Adds unit tests for the leaf utility packages enumerated in #305, establishing the table-test conventions subsequent phases of #304 reuse.
- Each package with executable statements now exceeds the ≥80% statement-coverage bar; tests exercise error/edge paths, not just happy-path constructors.

## Coverage achieved
| Package | Coverage |
| --- | --- |
| `internal/dualcopier` | 94.7% |
| `internal/filter` | 97.7% |
| `internal/logging` | 89.5% |
| `internal/naming` | 92.3% |
| `internal/shared` | 92.7% |
| `internal/defaults` | `[no statements]` — exempt |
| `internal/errdefs` | `[no statements]` — exempt |
| `cmd/types` | `[no statements]` — exempt |

**Exempt packages (per the issue's "no statements" note):** `internal/defaults`, `internal/errdefs`, and `cmd/types` declare only constants, sentinel `error` values, and a context-key type — no executable statements — so `go test -cover` reports `[no statements]` for each. The issue calls out `internal/errdefs` explicitly; `internal/defaults` and `cmd/types` are the same declaration-only shape. I still added validating test files for all three (sentinel non-nil/`errors.Is`-through-wrap, const-value guards, distinct context-key round-trip) so an accidental edit to the values is caught, even though they generate no coverage.

## Notes on edge-path coverage
- `internal/dualcopier`: covers the filter zero-consume infinite-loop guard, `nwrite` overflow errors (both `out != nil` and in-place-window branches), short-write-no-progress, read/write errors, and `CopierManager` across the ctx-cancelled (nil and real `*net.UnixConn`) and errgroup paths.
- `internal/filter`: covers the adjacent `^]^]` detach + BEL emission, bracketed-paste enter/exit, and the Esc-precedes-paste-start precedence rule.
- `internal/shared`: covers `WriteMetadata` marshal/write error paths, `atomicWriteFile` overwrite + `CreateTemp` failure, the hex/ASCII dump helpers, and `LoggingConnUnix` OOB FD-passing via a real unix socket pair.

## Test plan
- [x] `make sbsh-sb` (canonical build; verified ELF via `od` header `177ELF`)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `make test` (full CI suite incl. `-tags=integration` and e2e)

Closes #305