### PR TITLE
feat(capture): add asciicast capture format selector

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -170,6 +170,8 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SBSH_ROOT_TERM_CAPTURE_GID = DefineKV("SBSH_ROOT_TERM_CAPTURE_GID", "sbsh.root.terminal.captureGid")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SBSH_ROOT_TERM_CAPTURE_FORMAT = DefineKV("SBSH_ROOT_TERM_CAPTURE_FORMAT", "sbsh.root.terminal.captureFormat")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SBSH_ROOT_TERM_LOG_FILE_MODE = DefineKV("SBSH_ROOT_TERM_LOG_FILE_MODE", "sbsh.root.terminal.logFileMode")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SBSH_ROOT_TERM_LOG_FILE_GID = DefineKV("SBSH_ROOT_TERM_LOG_FILE_GID", "sbsh.root.terminal.logFileGid")
@@ -206,6 +208,8 @@ var (
 	SBSH_TERM_CAPTURE_MODE = DefineKV("SBSH_TERM_CAPTURE_MODE", "sbsh.terminal.captureMode")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SBSH_TERM_CAPTURE_GID = DefineKV("SBSH_TERM_CAPTURE_GID", "sbsh.terminal.captureGid")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SBSH_TERM_CAPTURE_FORMAT = DefineKV("SBSH_TERM_CAPTURE_FORMAT", "sbsh.terminal.captureFormat")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SBSH_TERM_LOG_FILE_MODE = DefineKV("SBSH_TERM_LOG_FILE_MODE", "sbsh.terminal.logFileMode")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/sb/read/read.go
+++ b/cmd/sb/read/read.go
@@ -151,12 +151,24 @@ func runRead(
 	return streamLive(conn, stdout, stderr)
 }
 
-// dumpCapture streams the full transcript to stdout. The recorded capture
-// path is the live segment; capture.Dump reassembles closed rotated segments
-// oldest-first, then the live segment, into one logical stream. An absent
-// capture (never written to) produces no output and no error.
+// dumpCapture writes the full transcript to stdout. The recorded capture path
+// is the live segment; capture.Replay reassembles closed rotated segments
+// oldest-first, then the live segment, into one logical stream and sniffs the
+// format — a raw capture passes through byte-for-byte, an asciicast capture is
+// decoded to its output bytes so `sb read` (and the parser feed behind it)
+// always sees terminal output, matching the live stream that follows. An
+// absent capture (never written to) produces no output and no error. Total
+// transcript size is bounded by capture retention, so buffering it to sniff
+// the format is acceptable for a CLI read.
 func dumpCapture(path string, stdout io.Writer) error {
-	return capture.Dump(path, stdout)
+	data, err := capture.Replay(path)
+	if err != nil {
+		return err
+	}
+	if _, werr := stdout.Write(data); werr != nil {
+		return fmt.Errorf("write capture transcript: %w", werr)
+	}
+	return nil
 }
 
 // laggedNotice mirrors the bracketed core of the server sentinel (see

--- a/cmd/sbsh/sbsh.go
+++ b/cmd/sbsh/sbsh.go
@@ -170,6 +170,7 @@ You can also use sbsh with parameters. For example:
 					SocketGID:        readRootSocketGID(cmd),
 					CaptureMode:      viper.GetString(config.SBSH_ROOT_TERM_CAPTURE_MODE.ViperKey),
 					CaptureGID:       readRootCaptureGID(cmd),
+					CaptureFormat:    viper.GetString(config.SBSH_ROOT_TERM_CAPTURE_FORMAT.ViperKey),
 					LogFileMode:      viper.GetString(config.SBSH_ROOT_TERM_LOG_FILE_MODE.ViperKey),
 					LogFileGID:       readRootLogFileGID(cmd),
 					DisableSetPrompt: viper.GetBool(config.SBSH_ROOT_TERM_DISABLE_SET_PROMPT.ViperKey),
@@ -401,6 +402,18 @@ func setTerminalFlags(rootCmd *cobra.Command) error {
 		return err
 	}
 	if err := viper.BindEnv(config.SBSH_ROOT_TERM_CAPTURE_GID.ViperKey, config.SBSH_ROOT_TERM_CAPTURE_GID.EnvVar()); err != nil {
+		return err
+	}
+
+	rootCmd.Flags().String(
+		"terminal-capture-format",
+		"",
+		`On-disk capture format: "raw" (default, byte-exact PTY bytes) or "asciicast" (asciicast v2 for replay/seek/portability)`,
+	)
+	if err := viper.BindPFlag(config.SBSH_ROOT_TERM_CAPTURE_FORMAT.ViperKey, rootCmd.Flags().Lookup("terminal-capture-format")); err != nil {
+		return err
+	}
+	if err := viper.BindEnv(config.SBSH_ROOT_TERM_CAPTURE_FORMAT.ViperKey, config.SBSH_ROOT_TERM_CAPTURE_FORMAT.EnvVar()); err != nil {
 		return err
 	}
 

--- a/cmd/sbsh/terminal/terminal.go
+++ b/cmd/sbsh/terminal/terminal.go
@@ -159,6 +159,7 @@ func buildTerminalSpecFromFlags(
 			SocketGID:        readSocketGID(cmd),
 			CaptureMode:      viper.GetString(config.SBSH_TERM_CAPTURE_MODE.ViperKey),
 			CaptureGID:       readCaptureGID(cmd),
+			CaptureFormat:    viper.GetString(config.SBSH_TERM_CAPTURE_FORMAT.ViperKey),
 			LogFileMode:      viper.GetString(config.SBSH_TERM_LOG_FILE_MODE.ViperKey),
 			LogFileGID:       readLogFileGID(cmd),
 			DisableSetPrompt: viper.GetBool(config.SBSH_TERM_DISABLE_SET_PROMPT.ViperKey),
@@ -488,6 +489,14 @@ func setupTerminalCmdFlags(terminalCmd *cobra.Command) {
 	)
 	_ = viper.BindPFlag(config.SBSH_TERM_CAPTURE_GID.ViperKey, terminalCmd.Flags().Lookup("capture-gid"))
 	_ = viper.BindEnv(config.SBSH_TERM_CAPTURE_GID.ViperKey, config.SBSH_TERM_CAPTURE_GID.EnvVar())
+
+	terminalCmd.Flags().String(
+		"capture-format",
+		"",
+		`On-disk capture format: "raw" (default, byte-exact PTY bytes) or "asciicast" (asciicast v2 for replay/seek/portability)`,
+	)
+	_ = viper.BindPFlag(config.SBSH_TERM_CAPTURE_FORMAT.ViperKey, terminalCmd.Flags().Lookup("capture-format"))
+	_ = viper.BindEnv(config.SBSH_TERM_CAPTURE_FORMAT.ViperKey, config.SBSH_TERM_CAPTURE_FORMAT.EnvVar())
 
 	terminalCmd.Flags().String(
 		"log-file-mode",

--- a/internal/capture/asciicast.go
+++ b/internal/capture/asciicast.go
@@ -1,0 +1,159 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package capture
+
+// asciicast v2 support for the capture format selector (see
+// pkg/api.CaptureFormat). The on-disk shape is the asciicast v2 stream:
+// https://docs.asciinema.org/manual/asciicast/v2/ — a JSON header object on
+// the first line, then one event line `[t, code, data]` per record, where t is
+// the absolute offset in seconds from session start.
+//
+// The capture writer emits exactly one output ("o") event per Write call, so a
+// record line is never bisected by segment rotation (which lands on write
+// boundaries). To keep every segment self-describing — and so a reassembled
+// capture stays decodable after retention prunes segment 0 — the writer
+// re-emits the header at the top of each segment. DecodeAsciicast therefore
+// tolerates a header line anywhere in the stream, not just at the very top.
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// AsciicastVersion is the asciicast format version this package reads/writes.
+const AsciicastVersion = 2
+
+// eventOutput is the asciicast event code for terminal output. Other codes
+// (input "i", resize "r", marker "m") are not emitted by the writer and are
+// skipped by the decoder.
+const eventOutput = "o"
+
+// maxEventLine bounds a single scanned record line. The capture writer emits
+// one event per PTY read (currently 8 KiB), and a JSON-escaped payload at most
+// quadruples that, so 1 MiB is comfortably above any real line while still
+// guarding the decoder against an unbounded allocation on a corrupt segment.
+const maxEventLine = 1 << 20
+
+// scanBufInit is the initial (pre-grow) decoder scan buffer; bufio.Scanner
+// grows it up to maxEventLine as needed.
+const scanBufInit = 64 * 1024
+
+// Header is the asciicast v2 header — the first line of the stream.
+type Header struct {
+	Version   int   `json:"version"`
+	Width     int   `json:"width"`
+	Height    int   `json:"height"`
+	Timestamp int64 `json:"timestamp,omitempty"`
+}
+
+// EncodeHeader marshals an asciicast v2 header line (newline-terminated).
+// width/height record the terminal's initial geometry; timestamp is the unix
+// epoch (seconds) of session start, used by players to label the recording.
+func EncodeHeader(width, height int, timestamp int64) ([]byte, error) {
+	b, err := json.Marshal(Header{
+		Version:   AsciicastVersion,
+		Width:     width,
+		Height:    height,
+		Timestamp: timestamp,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal asciicast header: %w", err)
+	}
+	return append(b, '\n'), nil
+}
+
+// EncodeOutputEvent marshals one asciicast v2 output record line:
+// `[<elapsed-seconds>, "o", <data>]\n`. data is wrapped in a JSON string, so
+// arbitrary bytes are escaped (and non-UTF-8 bytes coerced by the encoder —
+// raw is the byte-exact format; asciicast trades that for replay/portability).
+func EncodeOutputEvent(elapsed float64, data []byte) ([]byte, error) {
+	b, err := json.Marshal([]any{elapsed, eventOutput, string(data)})
+	if err != nil {
+		return nil, fmt.Errorf("marshal asciicast event: %w", err)
+	}
+	return append(b, '\n'), nil
+}
+
+// IsAsciicast reports whether data begins with an asciicast v2 header line —
+// the format sniff readers use to decide between decode and raw passthrough.
+// It inspects only the first line, so it is cheap on a large reassembled
+// transcript.
+func IsAsciicast(data []byte) bool {
+	line := data
+	if i := bytes.IndexByte(data, '\n'); i >= 0 {
+		line = data[:i]
+	}
+	line = bytes.TrimSpace(line)
+	if len(line) == 0 || line[0] != '{' {
+		return false
+	}
+	var h Header
+	if err := json.Unmarshal(line, &h); err != nil {
+		return false
+	}
+	return h.Version == AsciicastVersion
+}
+
+// DecodeAsciicast extracts the concatenated terminal-output bytes from an
+// asciicast v2 stream: it skips header lines (one per segment in a reassembled
+// multi-segment capture) and decodes each `[t, "o", data]` record to its data
+// payload, dropping non-"o" events. A malformed line is skipped rather than
+// failing the whole replay, so a torn tail (e.g. a half-written live segment)
+// never denies an attach — it just stops contributing bytes.
+func DecodeAsciicast(data []byte) []byte {
+	var out []byte
+	sc := bufio.NewScanner(bytes.NewReader(data))
+	sc.Buffer(make([]byte, 0, scanBufInit), maxEventLine)
+	for sc.Scan() {
+		line := bytes.TrimSpace(sc.Bytes())
+		if len(line) == 0 || line[0] != '[' {
+			continue // header object, blank line, or non-record content
+		}
+		var rec []json.RawMessage
+		if err := json.Unmarshal(line, &rec); err != nil || len(rec) < 3 {
+			continue
+		}
+		var code string
+		if err := json.Unmarshal(rec[1], &code); err != nil || code != eventOutput {
+			continue
+		}
+		var payload string
+		if err := json.Unmarshal(rec[2], &payload); err != nil {
+			continue
+		}
+		out = append(out, payload...)
+	}
+	return out
+}
+
+// Replay reassembles the full transcript at canonical and returns the bytes a
+// reader should blast to a client PTY: raw captures pass through byte-for-byte;
+// asciicast captures are decoded to their output bytes. It is the single
+// sniff-and-decode entry point shared by `--full-capture` attach and `sb read`
+// so both readers agree on format handling.
+func Replay(canonical string) ([]byte, error) {
+	data, err := ReadAll(canonical)
+	if err != nil {
+		return nil, err
+	}
+	if IsAsciicast(data) {
+		return DecodeAsciicast(data), nil
+	}
+	return data, nil
+}

--- a/internal/capture/asciicast_test.go
+++ b/internal/capture/asciicast_test.go
@@ -1,0 +1,201 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package capture
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+// A header line plus a couple of output events round-trips: IsAsciicast sniffs
+// true, DecodeAsciicast yields the concatenated payloads, and the header line
+// itself is valid asciicast v2 JSON.
+func TestAsciicast_HeaderAndEvents(t *testing.T) {
+	hdr, err := EncodeHeader(80, 24, 1700000000)
+	if err != nil {
+		t.Fatalf("EncodeHeader: %v", err)
+	}
+	if !bytes.HasSuffix(hdr, []byte("\n")) {
+		t.Fatalf("header not newline-terminated: %q", hdr)
+	}
+	var h Header
+	if uerr := json.Unmarshal(bytes.TrimSpace(hdr), &h); uerr != nil {
+		t.Fatalf("header not valid JSON: %v", uerr)
+	}
+	if h.Version != AsciicastVersion || h.Width != 80 || h.Height != 24 || h.Timestamp != 1700000000 {
+		t.Fatalf("header fields = %+v", h)
+	}
+
+	var stream []byte
+	stream = append(stream, hdr...)
+	for _, payload := range [][]byte{[]byte("hello "), []byte("world\r\n")} {
+		ev, eerr := EncodeOutputEvent(0.5, payload)
+		if eerr != nil {
+			t.Fatalf("EncodeOutputEvent: %v", eerr)
+		}
+		stream = append(stream, ev...)
+	}
+
+	if !IsAsciicast(stream) {
+		t.Fatalf("IsAsciicast(asciicast stream) = false")
+	}
+	if got, want := DecodeAsciicast(stream), []byte("hello world\r\n"); !bytes.Equal(got, want) {
+		t.Fatalf("DecodeAsciicast = %q, want %q", got, want)
+	}
+}
+
+// Raw bytes (no header) are not sniffed as asciicast; Replay passes them
+// through byte-for-byte.
+func TestAsciicast_RawNotSniffed(t *testing.T) {
+	raw := []byte("$ ls -la\r\ntotal 0\r\n")
+	if IsAsciicast(raw) {
+		t.Fatalf("IsAsciicast(raw bytes) = true")
+	}
+	// A line that merely starts with '{' but is not a v2 header is still raw.
+	if IsAsciicast([]byte("{not json\n")) {
+		t.Fatalf("IsAsciicast(non-header brace) = true")
+	}
+	if IsAsciicast([]byte(`{"version":1}` + "\n")) {
+		t.Fatalf("IsAsciicast(v1 header) = true")
+	}
+}
+
+// EncodeOutputEvent escapes arbitrary bytes through a JSON string and the
+// decoder restores valid-UTF-8 payloads exactly (control bytes, quotes,
+// backslashes). This is the round-trip the writer/reader pair relies on.
+func TestAsciicast_PayloadEscaping(t *testing.T) {
+	payload := []byte("a\tb\"c\\d\x1b[0m\n")
+	ev, err := EncodeOutputEvent(1.25, payload)
+	if err != nil {
+		t.Fatalf("EncodeOutputEvent: %v", err)
+	}
+	// The encoded line must itself be valid JSON.
+	var rec []json.RawMessage
+	if uerr := json.Unmarshal(bytes.TrimSpace(ev), &rec); uerr != nil {
+		t.Fatalf("event not valid JSON: %v", uerr)
+	}
+	if got := DecodeAsciicast(ev); !bytes.Equal(got, payload) {
+		t.Fatalf("DecodeAsciicast = %q, want %q", got, payload)
+	}
+}
+
+// Multiple header lines (one per segment in a reassembled multi-segment
+// capture) and non-output event codes are skipped; only "o" payloads survive.
+func TestAsciicast_MultiHeaderAndForeignEvents(t *testing.T) {
+	hdr, _ := EncodeHeader(80, 24, 1)
+	out1, _ := EncodeOutputEvent(0.1, []byte("AAA"))
+	out2, _ := EncodeOutputEvent(0.2, []byte("BBB"))
+
+	var stream []byte
+	stream = append(stream, hdr...)                                       // segment 0 header
+	stream = append(stream, out1...)                                      //
+	stream = append(stream, []byte(`[0.15,"i","ignored input"]`+"\n")...) // foreign event
+	stream = append(stream, hdr...)                                       // segment 1 header (reassembled)
+	stream = append(stream, out2...)                                      //
+	stream = append(stream, []byte("\n")...)                              // blank line tolerated
+
+	if got, want := DecodeAsciicast(stream), []byte("AAABBB"); !bytes.Equal(got, want) {
+		t.Fatalf("DecodeAsciicast = %q, want %q", got, want)
+	}
+}
+
+// A torn final event line (e.g. a half-flushed live segment) is skipped rather
+// than failing the decode, so a replay never denies an attach over a partial
+// tail.
+func TestAsciicast_TornTailSkipped(t *testing.T) {
+	hdr, _ := EncodeHeader(80, 24, 1)
+	good, _ := EncodeOutputEvent(0.1, []byte("ok"))
+	var stream []byte
+	stream = append(stream, hdr...)
+	stream = append(stream, good...)
+	stream = append(stream, []byte(`[0.2,"o","truncat`)...) // no closing/newline
+
+	if got, want := DecodeAsciicast(stream), []byte("ok"); !bytes.Equal(got, want) {
+		t.Fatalf("DecodeAsciicast = %q, want %q", got, want)
+	}
+}
+
+// Replay over on-disk segments: an asciicast capture rotated into a closed
+// segment + live segment reassembles and decodes to the full output, and a raw
+// capture passes through unchanged. Mirrors how the readers call Replay.
+func TestReplay_AsciicastAndRaw(t *testing.T) {
+	t.Run("asciicast across rotation", func(t *testing.T) {
+		dir := t.TempDir()
+		canonical := filepath.Join(dir, "capture")
+		hdr, _ := EncodeHeader(80, 24, 1)
+		ev0, _ := EncodeOutputEvent(0.1, []byte("seg0-"))
+		ev1, _ := EncodeOutputEvent(0.2, []byte("live"))
+		// Closed segment 0: its own header + an event (self-describing).
+		writeFile(t, SegmentPath(canonical, 0), append(append([]byte{}, hdr...), ev0...))
+		// Live segment: header + an event.
+		writeFile(t, canonical, append(append([]byte{}, hdr...), ev1...))
+
+		got, err := Replay(canonical)
+		if err != nil {
+			t.Fatalf("Replay: %v", err)
+		}
+		if want := []byte("seg0-live"); !bytes.Equal(got, want) {
+			t.Fatalf("Replay = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("raw passthrough", func(t *testing.T) {
+		dir := t.TempDir()
+		canonical := filepath.Join(dir, "capture")
+		writeFile(t, SegmentPath(canonical, 0), []byte("closed-"))
+		writeFile(t, canonical, []byte("live"))
+		got, err := Replay(canonical)
+		if err != nil {
+			t.Fatalf("Replay: %v", err)
+		}
+		if want := []byte("closed-live"); !bytes.Equal(got, want) {
+			t.Fatalf("Replay = %q, want %q", got, want)
+		}
+	})
+}
+
+// After segment 0 is pruned by retention, the reassembled asciicast stream is
+// still valid: the surviving oldest segment carries its own header, so
+// IsAsciicast stays true and decoding still works. This is the load-bearing
+// header-survival criterion.
+func TestReplay_HeaderSurvivesPruning(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+	hdr, _ := EncodeHeader(80, 24, 1)
+	ev1, _ := EncodeOutputEvent(0.2, []byte("kept1-"))
+	evLive, _ := EncodeOutputEvent(0.3, []byte("live"))
+	// Segment 0 has been pruned; segment 1 (now oldest) keeps its own header.
+	writeFile(t, SegmentPath(canonical, 1), append(append([]byte{}, hdr...), ev1...))
+	writeFile(t, canonical, append(append([]byte{}, hdr...), evLive...))
+
+	data, err := ReadAll(canonical)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !IsAsciicast(data) {
+		t.Fatalf("reassembled stream not sniffed as asciicast after segment 0 pruned")
+	}
+	got, err := Replay(canonical)
+	if err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	if want := []byte("kept1-live"); !bytes.Equal(got, want) {
+		t.Fatalf("Replay = %q, want %q", got, want)
+	}
+}

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -213,6 +213,10 @@ type BuildTerminalSpecParams struct {
 	// CaptureGID is the numeric GID flag value for the capture file, or
 	// nil to fall through to the profile / leave the group unchanged.
 	CaptureGID *int
+	// CaptureFormat selects the on-disk capture format ("raw" default, or
+	// "asciicast"). Empty means raw; an invalid value is rejected at
+	// spec-build time. See pkg/api.NormalizeCaptureFormat.
+	CaptureFormat string
 	// LogFileMode is the raw octal flag value applied to the log file.
 	// Empty means "no override; fall through to the profile or the runner
 	// default".
@@ -404,6 +408,9 @@ func BuildTerminalSpecFromProfile(
 	if errOv := applyPermOverrides(terminalSpec, input); errOv != nil {
 		return nil, errOv
 	}
+	if errFmt := applyCaptureFormat(terminalSpec, input); errFmt != nil {
+		return nil, errFmt
+	}
 
 	return terminalSpec, nil
 }
@@ -445,8 +452,26 @@ func BuildTerminalSpecInline(
 	if errOv := applyPermOverrides(terminalSpec, input); errOv != nil {
 		return nil, errOv
 	}
+	if errFmt := applyCaptureFormat(terminalSpec, input); errFmt != nil {
+		return nil, errFmt
+	}
 
 	return terminalSpec, nil
+}
+
+// applyCaptureFormat validates an explicit capture-format override and copies
+// it onto the spec. Empty is left untouched so the zero value (raw, with no
+// serialized field) is preserved; a non-empty value must be raw or asciicast.
+func applyCaptureFormat(spec *api.TerminalSpec, input *BuildTerminalSpecParams) error {
+	if input.CaptureFormat == "" {
+		return nil
+	}
+	cf, err := api.NormalizeCaptureFormat(input.CaptureFormat)
+	if err != nil {
+		return fmt.Errorf("%w: %w", errdefs.ErrInvalidFlag, err)
+	}
+	spec.CaptureFormat = cf
+	return nil
 }
 
 // applyPermOverrides resolves the mode/gid precedence for the socket,

--- a/internal/terminal/terminalrunner/capture_writer.go
+++ b/internal/terminal/terminalrunner/capture_writer.go
@@ -22,10 +22,22 @@ import (
 	"log/slog"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/eminwux/sbsh/internal/capture"
 	"github.com/eminwux/sbsh/internal/defaults"
 )
+
+// captureFormatOpts configures the on-disk capture format for a captureWriter.
+// The zero value is raw (append-only PTY bytes — byte-exact, no per-write
+// overhead). When Asciicast is true the writer emits asciicast v2: a header
+// line at the top of every segment plus one timed `[t,"o",data]` event per
+// Write. Cols/Rows seed the asciicast header's initial geometry.
+type captureFormatOpts struct {
+	Asciicast bool
+	Cols      int
+	Rows      int
+}
 
 // captureWriter is the always-on capture sink registered first in multiOutW.
 // It writes the live segment append-only at the canonical path and, once the
@@ -53,6 +65,15 @@ type captureWriter struct {
 	retainSegments int
 	retainBytes    int64
 
+	// asciicast records the asciicast v2 format instead of raw bytes. When
+	// set, every freshly opened (empty) segment gets a header line and each
+	// Write is emitted as one timed output event. cols/rows seed the header
+	// geometry; start anchors the t=0 origin and seeds the header timestamp.
+	asciicast bool
+	cols      int
+	rows      int
+	start     time.Time
+
 	// applyPerms re-applies the resolved capture mode/group to a freshly
 	// opened segment path. nil leaves perms at the open default.
 	applyPerms func(path string) error
@@ -68,6 +89,7 @@ func newCaptureWriter(
 	canonical string,
 	logger *slog.Logger,
 	applyPerms func(path string) error,
+	format captureFormatOpts,
 ) (*captureWriter, error) {
 	if logger == nil {
 		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -82,27 +104,63 @@ func newCaptureWriter(
 			return nil, perr
 		}
 	}
-	info, err := f.Stat()
-	if err != nil {
-		_ = f.Close()
-		return nil, fmt.Errorf("stat capture file: %w", err)
-	}
 	nextSeq, err := capture.NextSeq(canonical)
 	if err != nil {
 		_ = f.Close()
 		return nil, fmt.Errorf("seed capture sequence: %w", err)
 	}
-	return &captureWriter{
+	w := &captureWriter{
 		canonical:      canonical,
 		f:              f,
-		size:           info.Size(),
 		nextSeq:        nextSeq,
 		maxBytes:       defaults.CaptureSegmentMaxBytes,
 		retainSegments: defaults.CaptureRetentionMaxSegments,
 		retainBytes:    defaults.CaptureRetentionMaxBytes,
+		asciicast:      format.Asciicast,
+		cols:           format.Cols,
+		rows:           format.Rows,
+		start:          time.Now(),
 		applyPerms:     applyPerms,
 		logger:         logger,
-	}, nil
+	}
+	// Seed size from the opened inode and, in asciicast mode, write the header
+	// when the segment is empty (a fresh capture, or a fresh canonical after a
+	// restart that pruned everything). A resumed non-empty segment already
+	// carries its header, so we must not prepend a second one.
+	if oerr := w.onSegmentOpened(); oerr != nil {
+		_ = f.Close()
+		return nil, oerr
+	}
+	return w, nil
+}
+
+// onSegmentOpened syncs w.size to the just-opened segment's on-disk size and,
+// in asciicast mode, writes the format header when that segment is empty. It
+// runs at construction and after every reopenCanonical so each segment is
+// self-describing — the header-survives-pruning mechanism: even once retention
+// drops segment 0, the new oldest segment still starts with a header, so the
+// reassembled stream stays decodable. A non-empty segment (resumed canonical,
+// or a rename-failed rotation that left the old bytes in place) keeps its
+// existing header and is not re-prepended.
+func (w *captureWriter) onSegmentOpened() error {
+	info, err := w.f.Stat()
+	if err != nil {
+		return fmt.Errorf("stat capture file: %w", err)
+	}
+	w.size = info.Size()
+	if !w.asciicast || w.size > 0 {
+		return nil
+	}
+	hdr, herr := capture.EncodeHeader(w.cols, w.rows, w.start.Unix())
+	if herr != nil {
+		return herr
+	}
+	n, werr := w.f.Write(hdr)
+	w.size += int64(n)
+	if werr != nil {
+		return fmt.Errorf("write asciicast header: %w", werr)
+	}
+	return nil
 }
 
 // Write appends to the live segment and rotates once it crosses maxBytes. A
@@ -114,9 +172,25 @@ func (w *captureWriter) Write(p []byte) (int, error) {
 	if w.f == nil {
 		return 0, os.ErrClosed
 	}
-	n, err := w.f.Write(p)
+	// In asciicast mode each Write becomes exactly one timed output record, so
+	// rotation (which checks size after the write) never bisects a record line
+	// — the whole-event-writes guarantee the decoder relies on.
+	rec := p
+	if w.asciicast {
+		ev, eerr := capture.EncodeOutputEvent(time.Since(w.start).Seconds(), p)
+		if eerr != nil {
+			return 0, eerr
+		}
+		rec = ev
+	}
+	n, err := w.f.Write(rec)
 	w.size += int64(n)
 	if err != nil {
+		// Raw: n is the count of p actually written. Asciicast: a partial
+		// event line is unusable, so report nothing of p durably recorded.
+		if w.asciicast {
+			return 0, err
+		}
 		return n, err
 	}
 	if w.maxBytes > 0 && w.size >= w.maxBytes {
@@ -124,7 +198,9 @@ func (w *captureWriter) Write(p []byte) (int, error) {
 			w.logger.Warn("capture rotation failed; continuing on current segment", "err", rerr)
 		}
 	}
-	return n, nil
+	// io.Writer contract: report bytes consumed from p, not bytes written to
+	// disk — an asciicast event line is longer than its payload.
+	return len(p), nil
 }
 
 // rotate closes the live segment, renames it to its deterministic sibling,
@@ -186,7 +262,13 @@ func (w *captureWriter) reopenCanonical() error {
 		}
 	}
 	w.f = f
-	w.size = 0
+	// Sync size to the (normally empty) fresh segment and, in asciicast mode,
+	// write its header so the segment is self-describing. A header failure is
+	// non-fatal: the fd is writable, so degrade to "no header this segment"
+	// rather than stopping capture.
+	if herr := w.onSegmentOpened(); herr != nil {
+		w.logger.Warn("capture segment header init failed", "path", w.canonical, "err", herr)
+	}
 	return nil
 }
 

--- a/internal/terminal/terminalrunner/capture_writer_test.go
+++ b/internal/terminal/terminalrunner/capture_writer_test.go
@@ -40,7 +40,7 @@ func newTestCaptureWriter(
 ) *captureWriter {
 	t.Helper()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	w, err := newCaptureWriter(canonical, logger, nil)
+	w, err := newCaptureWriter(canonical, logger, nil, captureFormatOpts{})
 	if err != nil {
 		t.Fatalf("newCaptureWriter: %v", err)
 	}
@@ -300,5 +300,113 @@ func TestCaptureWriter_SeqResumesAcrossRestart(t *testing.T) {
 	}
 	if want := []byte("AAAABBBBCCCC"); !bytes.Equal(got, want) {
 		t.Fatalf("after restart ReadAll = %q, want %q", got, want)
+	}
+}
+
+// newTestAsciicastWriter mirrors newTestCaptureWriter but selects the
+// asciicast format, so rotation/header-survival is exercisable with small
+// thresholds.
+func newTestAsciicastWriter(
+	t *testing.T,
+	canonical string,
+	maxBytes int64,
+	retainSegments int,
+	retainBytes int64,
+) *captureWriter {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	w, err := newCaptureWriter(canonical, logger, nil, captureFormatOpts{
+		Asciicast: true,
+		Cols:      80,
+		Rows:      24,
+	})
+	if err != nil {
+		t.Fatalf("newCaptureWriter: %v", err)
+	}
+	w.maxBytes = maxBytes
+	w.retainSegments = retainSegments
+	w.retainBytes = retainBytes
+	return w
+}
+
+// In asciicast mode the live file is valid asciicast v2 (header line + one
+// timed "o" record per Write) and decodes back to exactly the bytes written.
+func TestCaptureWriter_AsciicastLiveFileValid(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+	w := newTestAsciicastWriter(t, canonical, 1<<20, 8, 1<<30)
+
+	mustWrite(t, w, []byte("hello "))
+	mustWrite(t, w, []byte("world\r\n"))
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	data, err := os.ReadFile(canonical)
+	if err != nil {
+		t.Fatalf("read canonical: %v", err)
+	}
+	if !capture.IsAsciicast(data) {
+		t.Fatalf("live file not valid asciicast v2: %q", data)
+	}
+	// One header line + one record per write = 3 lines.
+	if got := bytes.Count(data, []byte("\n")); got != 3 {
+		t.Fatalf("line count = %d, want 3 (header + 2 records)", got)
+	}
+	if got, want := capture.DecodeAsciicast(data), []byte("hello world\r\n"); !bytes.Equal(got, want) {
+		t.Fatalf("decoded live file = %q, want %q", got, want)
+	}
+}
+
+// Asciicast rotation writes a header at the top of every segment, so the
+// reassembled transcript decodes correctly across a rotation boundary and
+// stays valid even after the oldest segment (segment 0) is pruned.
+func TestCaptureWriter_AsciicastRotationHeaderPerSegment(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+	// Tiny threshold so each write rotates, producing several closed segments.
+	w := newTestAsciicastWriter(t, canonical, 1, 8, 1<<30)
+
+	for _, p := range [][]byte{[]byte("AAA"), []byte("BBB"), []byte("CCC")} {
+		mustWrite(t, w, p)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	segs, err := capture.ClosedSegments(canonical)
+	if err != nil {
+		t.Fatalf("ClosedSegments: %v", err)
+	}
+	if len(segs) == 0 {
+		t.Fatalf("expected rotation to produce closed segments")
+	}
+
+	// Full reassembly decodes to all payloads in order across rotations.
+	full, err := capture.Replay(canonical)
+	if err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	if want := []byte("AAABBBCCC"); !bytes.Equal(full, want) {
+		t.Fatalf("reassembled+decoded = %q, want %q", full, want)
+	}
+
+	// Header survives pruning: drop the oldest closed segment (segment 0) and
+	// the reassembled stream is still sniffed as asciicast and still decodes.
+	if rmErr := os.Remove(segs[0].Path); rmErr != nil {
+		t.Fatalf("prune segment 0: %v", rmErr)
+	}
+	reassembled, err := capture.ReadAll(canonical)
+	if err != nil {
+		t.Fatalf("ReadAll after prune: %v", err)
+	}
+	if !capture.IsAsciicast(reassembled) {
+		t.Fatalf("stream not asciicast after pruning segment 0: %q", reassembled)
+	}
+	decoded := capture.DecodeAsciicast(reassembled)
+	// The first payload ("AAA") was in segment 0 and is gone; the remainder
+	// survives and still decodes.
+	if !bytes.Contains(decoded, []byte("CCC")) {
+		t.Fatalf("post-prune decode lost the live tail: %q", decoded)
 	}
 }

--- a/internal/terminal/terminalrunner/io.go
+++ b/internal/terminal/terminalrunner/io.go
@@ -22,13 +22,15 @@ import (
 
 // readCaptureFile reassembles the full transcript for a --full-capture attach:
 // closed rotated segments oldest-first, then the live segment. The canonical
-// path recorded in Status.CaptureFile is the live segment; capture.ReadAll
-// walks its closed siblings to reconstruct full history.
+// path recorded in Status.CaptureFile is the live segment; capture.Replay
+// walks its closed siblings to reconstruct full history and sniffs the format
+// — a raw capture passes through byte-for-byte, an asciicast capture is decoded
+// to its output bytes so the client PTY receives the same bytes either way.
 func (sr *Exec) readCaptureFile() ([]byte, error) {
 	sr.metadataMu.RLock()
 	captureFile := sr.metadata.Status.CaptureFile
 	sr.metadataMu.RUnlock()
-	data, err := capture.ReadAll(captureFile)
+	data, err := capture.Replay(captureFile)
 	if err != nil {
 		sr.logger.Warn("failed to read capture file", "err", err)
 		return nil, err

--- a/internal/terminal/terminalrunner/terminal.go
+++ b/internal/terminal/terminalrunner/terminal.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/creack/pty"
 	"github.com/eminwux/sbsh/cmd/config"
+	"github.com/eminwux/sbsh/pkg/api"
 )
 
 const (
@@ -186,6 +187,7 @@ func (sr *Exec) startPty() error {
 	sr.metadataMu.RLock()
 	captureFile := sr.metadata.Spec.CaptureFile
 	captureMode := sr.metadata.Spec.CaptureMode
+	captureFormat := sr.metadata.Spec.CaptureFormat
 	var captureGID *int
 	if g := sr.metadata.Spec.CaptureGID; g != nil {
 		gv := *g
@@ -200,6 +202,13 @@ func (sr *Exec) startPty() error {
 	// covers reopens of a pre-existing inode (see issue #200).
 	capWriter, errO := newCaptureWriter(captureFile, sr.logger, func(path string) error {
 		return sr.applyArtifactPerms("capture", path, captureMode, captureGID)
+	}, captureFormatOpts{
+		// The initial PTY geometry is the VT100 standard set above; resizes
+		// after launch do not rewrite the asciicast header (the recorded
+		// geometry is the session's starting size, per asciicast v2).
+		Asciicast: captureFormat == api.CaptureFormatAsciicast,
+		Cols:      vt100Cols,
+		Rows:      vt100Rows,
 	})
 	if errO != nil {
 		return fmt.Errorf("open log file: %w", errO)

--- a/pkg/api/terminal.go
+++ b/pkg/api/terminal.go
@@ -17,6 +17,7 @@
 package api
 
 import (
+	"fmt"
 	"os"
 	"time"
 )
@@ -106,6 +107,15 @@ type TerminalSpec struct {
 	// after Open. nil leaves the group unchanged.
 	CaptureGID *int `json:"captureGid,omitempty"`
 
+	// CaptureFormat selects the on-disk capture format. "" / "raw" (default)
+	// records raw PTY bytes append-only — byte-exact, zero-overhead, but no
+	// timing. "asciicast" records asciicast v2 (a JSON header line, then one
+	// timed `[t,"o",data]` event per write) so the capture replays at speed,
+	// seeks by time, and feeds standard tooling (asciinema player, agg).
+	// Mutually exclusive per terminal: one capture file, one format. This is
+	// orthogonal to CaptureMode, which is the capture file's chmod.
+	CaptureFormat string `json:"captureFormat,omitempty"`
+
 	// LogFileMode is the chmod applied to the per-terminal log file after
 	// it is opened. Zero means "use the runner default" (0600), preserving
 	// owner-only behavior for callers that never set the field.
@@ -121,6 +131,34 @@ type TerminalSpec struct {
 	// exit after SIGTERM before escalating to SIGKILL. Zero means "use the
 	// runner's default" (30s, matching Kubernetes terminationGracePeriodSeconds).
 	ShutdownGrace time.Duration `json:"shutdownGrace,omitempty"`
+}
+
+// Capture format selectors for TerminalSpec.CaptureFormat. The empty string
+// is treated as CaptureFormatRaw so a spec that never sets the field keeps the
+// legacy raw-bytes behavior and the zero-overhead path.
+const (
+	CaptureFormatRaw       = "raw"
+	CaptureFormatAsciicast = "asciicast"
+)
+
+// NormalizeCaptureFormat resolves a (possibly empty) capture-format string to
+// its canonical value and rejects anything that is neither raw nor asciicast.
+// "" and "raw" both normalize to CaptureFormatRaw. Validate at spec-build time
+// so a typo surfaces before the terminal launches rather than mid-session.
+func NormalizeCaptureFormat(s string) (string, error) {
+	switch s {
+	case "", CaptureFormatRaw:
+		return CaptureFormatRaw, nil
+	case CaptureFormatAsciicast:
+		return CaptureFormatAsciicast, nil
+	default:
+		return "", fmt.Errorf(
+			"invalid capture format %q: must be %q or %q",
+			s,
+			CaptureFormatRaw,
+			CaptureFormatAsciicast,
+		)
+	}
 }
 
 type TerminalStatus struct {

--- a/pkg/builder/terminal.go
+++ b/pkg/builder/terminal.go
@@ -44,6 +44,7 @@ type terminalConfig struct {
 	captureFile       string
 	captureMode       string
 	captureGID        *int
+	captureFormat     string
 	logFile           string
 	logFileMode       string
 	logFileGID        *int
@@ -207,6 +208,14 @@ func WithCaptureGID(gid int) TerminalOption {
 		g := gid
 		c.captureGID = &g
 	}
+}
+
+// WithCaptureFormat selects the on-disk capture format: "raw" (default,
+// byte-exact PTY bytes) or "asciicast" (asciicast v2 — header + timed output
+// events, for replay/seek/portability). Empty means raw. An invalid value is
+// rejected at spec-build time (BuildTerminalSpec / BuildTerminalSpecFromProfile).
+func WithCaptureFormat(format string) TerminalOption {
+	return func(c *terminalConfig) { c.captureFormat = format }
 }
 
 // WithLogFileMode sets the chmod mode applied to the log file
@@ -400,6 +409,7 @@ func paramsFromConfig(cfg *terminalConfig, runPath string) *profile.BuildTermina
 		SocketGID:         cfg.socketGID,
 		CaptureMode:       cfg.captureMode,
 		CaptureGID:        cfg.captureGID,
+		CaptureFormat:     cfg.captureFormat,
 		LogFileMode:       cfg.logFileMode,
 		LogFileGID:        cfg.logFileGID,
 		EnvVars:           cfg.envVars,


### PR DESCRIPTION
## Summary

- Adds `Spec.CaptureFormat` (`raw` default | `asciicast`), the new per-terminal on-disk capture-format selector requested in #298. Raw stays the default and the zero-overhead path, so existing behavior and serialization are unchanged (the field is `omitempty` and is left empty unless explicitly set).
- In asciicast mode the capture writer emits **asciicast v2**: a JSON header line at the top of every segment, then exactly one timed `[t,"o",data]` record per `Write`. One-record-per-write means rotation (which checks size *after* the write) never bisects a record line — the whole-event-writes guarantee the decoder relies on.
- **Header survives pruning (the load-bearing new AC):** the header is re-emitted at the top of *every* segment (chosen over "exempt segment 0" / "synthesize in reader" because it composes cleanly with #314's per-segment gzip and keeps each segment self-describing). Once retention prunes segment 0, the new oldest segment still starts with a header, so the reassembled stream stays sniffable and decodable.
- Both readers funnel through a new `capture.Replay` (sniff + decode): `--full-capture` attach (`io.go`) and `sb read` (`read.go`). Raw passes through byte-for-byte; asciicast is decoded to its output bytes on the reassembled (gzip-closed + raw-live) stream, so a client PTY / parser feed sees terminal output either way. The decoder tolerates a header line anywhere (multi-segment reassembly), skips foreign event codes, and skips a torn tail rather than failing the whole replay.
- Wired end-to-end so the field is usable by both consumers: `builder.WithCaptureFormat` (embedder API), and a `--capture-format` / `--terminal-capture-format` CLI flag + env/viper binding mirroring `--capture-mode`. Invalid values are rejected at spec-build time via `api.NormalizeCaptureFormat` (verified: `invalid capture format "bogus": must be "raw" or "asciicast"`).

## Design notes for review

- **Geometry:** the asciicast header records the session's *initial* PTY geometry (VT100 80×24, the size `terminal.go` sets at launch). Resizes after launch do not rewrite the header — that is asciicast v2's model (the header is the starting size).
- **Byte-fidelity tradeoff (per the issue's non-goals):** asciicast wraps `data` in JSON strings (valid-UTF-8 assumption), so non-UTF-8 PTY output may not round-trip byte-exactly. Asciicast is chosen for replay/portability, not byte-exact archival; raw remains the byte-exact format. No additive dual-write (explicit non-goal in #298).
- **`sb read` buffering:** `dumpCapture` switched from streaming `capture.Dump` to `capture.Replay` (buffers the full transcript to sniff/decode). Total transcript size is bounded by retention (~64 MiB closed + 8 MiB live), so buffering once for a CLI read is acceptable. `capture.Dump` is retained (still has tests) for any future streaming raw consumer.
- **Deferred (not required by the AC, kept out to bound scope):** a profile-YAML `captureFormat` field. The CLI flag + builder option cover both consumers today; a profile-spec field can follow if profiles need to pin a format.

## Test plan

- [x] `make sbsh-sb` + ELF verify (via ELF magic; `file` not installed on host)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test` over all non-e2e packages
- [x] `go test -tags=integration ./cmd/sb/get/...`
- [x] `make e2e` (E2E_BIN_DIR=$(pwd) go test ./e2e)
- [x] `docs/examples/library-consumer` build + vet (additive `WithCaptureFormat`)
- [x] `pre-commit run --files` (golangci-lint, go fmt, addlicense, …)
- [x] New unit tests: asciicast encode/sniff/decode round-trip, payload escaping, multi-header + foreign-event skip, torn-tail skip, `Replay` raw+asciicast, header-survives-pruning; writer-level asciicast live-file validity, one-record-per-write, rotation-with-per-segment-header + post-prune validity
- [x] Real-binary smoke: `sbsh terminal --capture-format asciicast …` produced a valid asciicast v2 file (`{"version":2,"width":80,"height":24,...}` + `[t,"o",...]` events); raw mode unchanged (no header, raw bytes); invalid format rejected at spec build

Acceptance criteria (#298):
- [x] `Spec.CaptureFormat` selects asciicast; default raw; distinct from `CaptureMode`
- [x] asciicast mode produces a valid asciicast v2 live file, one record per write
- [x] Readers sniff format and decode asciicast / pass raw through byte-for-byte, on the reassembled stream
- [x] `--full-capture` attach replays asciicast (decode → PTY bytes), incl. across a rotation boundary
- [x] Reassembled asciicast stays valid after segment 0 is pruned (per-segment header)
- [x] Tests cover raw-unchanged, asciicast-valid, reader-handles-both, reassembly-across-rotation, header-survives-pruning

Closes #298