### PR TITLE
test: raise client-runtime coverage above 80%

### DIFF
--- a/internal/client/clientrpc/rpc_server_test.go
+++ b/internal/client/clientrpc/rpc_server_test.go
@@ -25,6 +25,52 @@ import (
 	"github.com/eminwux/sbsh/pkg/api"
 )
 
+func TestClientControllerRPC_WaitReady(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	core := &client.ControllerTest{
+		WaitReadyFunc: func() error { called = true; return nil },
+	}
+	rpc := &clientrpc.ClientControllerRPC{Core: core}
+	if err := rpc.WaitReady(&api.Empty{}, &api.Empty{}); err != nil {
+		t.Fatalf("WaitReady: %v", err)
+	}
+	if !called {
+		t.Fatal("WaitReady did not delegate to Core")
+	}
+
+	wantErr := errors.New("not ready")
+	errCore := &client.ControllerTest{WaitReadyFunc: func() error { return wantErr }}
+	errRPC := &clientrpc.ClientControllerRPC{Core: errCore}
+	if err := errRPC.WaitReady(&api.Empty{}, &api.Empty{}); !errors.Is(err, wantErr) {
+		t.Fatalf("WaitReady err = %v; want %v", err, wantErr)
+	}
+}
+
+func TestClientControllerRPC_Detach(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	core := &client.ControllerTest{
+		DetachFunc: func() error { called = true; return nil },
+	}
+	rpc := &clientrpc.ClientControllerRPC{Core: core}
+	if err := rpc.Detach(&api.Empty{}, &api.Empty{}); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+	if !called {
+		t.Fatal("Detach did not delegate to Core")
+	}
+
+	wantErr := errors.New("detach failed")
+	errCore := &client.ControllerTest{DetachFunc: func() error { return wantErr }}
+	errRPC := &clientrpc.ClientControllerRPC{Core: errCore}
+	if err := errRPC.Detach(&api.Empty{}, &api.Empty{}); !errors.Is(err, wantErr) {
+		t.Fatalf("Detach err = %v; want %v", err, wantErr)
+	}
+}
+
 func TestClientControllerRPC_Ping_Roundtrip(t *testing.T) {
 	t.Parallel()
 	core := &client.ControllerTest{

--- a/internal/client/clientrunner/control_server_test.go
+++ b/internal/client/clientrunner/control_server_test.go
@@ -1,0 +1,87 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clientrunner
+
+import (
+	"context"
+	"net"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/internal/client/clientrpc"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// TestStartServer_ServesThenStopsOnCancel binds a control socket, starts the
+// RPC accept loop, dials it to exercise the per-conn ServeCodec goroutine, and
+// confirms the loop signals ready=nil and done=nil on context cancel.
+func TestStartServer_ServesThenStopsOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runPath := t.TempDir()
+	sockPath := filepath.Join(t.TempDir(), "ctrl.sock")
+	sr := &Exec{
+		id:         api.ID("client-srv"),
+		ctx:        ctx,
+		ctxCancel:  cancel,
+		logger:     testLogger(),
+		metadataMu: sync.RWMutex{},
+		metadata: api.ClientDoc{
+			Spec: api.ClientSpec{ID: api.ID("client-srv"), RunPath: runPath, SockerCtrl: sockPath},
+		},
+	}
+
+	if err := sr.OpenSocketCtrl(); err != nil {
+		t.Fatalf("OpenSocketCtrl: %v", err)
+	}
+
+	readyCh := make(chan error, 1)
+	doneCh := make(chan error, 1)
+	go sr.StartServer(ctx, &clientrpc.ClientControllerRPC{}, readyCh, doneCh)
+
+	select {
+	case err := <-readyCh:
+		if err != nil {
+			t.Fatalf("ready signal = %v; want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("StartServer never signalled ready")
+	}
+
+	// Confirm the accept loop is live and the state advanced to ClientReady.
+	if conn, err := net.DialTimeout("unix", sockPath, time.Second); err == nil {
+		_ = conn.Close()
+	} else {
+		t.Fatalf("dial control socket: %v", err)
+	}
+	if st, _ := sr.State(); *st != api.ClientReady {
+		t.Errorf("state after ready = %v; want ClientReady", *st)
+	}
+
+	cancel()
+	select {
+	case err := <-doneCh:
+		if err != nil {
+			t.Fatalf("done signal = %v; want nil on clean cancel", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("StartServer never signalled done after cancel")
+	}
+}

--- a/internal/client/clientrunner/exec_test.go
+++ b/internal/client/clientrunner/exec_test.go
@@ -1,0 +1,215 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clientrunner
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/internal/client/clientrpc"
+	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestNewClientRunnerExec_DefaultsAndID verifies the constructor normalises a
+// sparse ClientDoc (APIVersion/Kind/Annotations) and that ID() reflects the
+// spec ID, while the default stdio falls back to the process handles.
+func TestNewClientRunnerExec_DefaultsAndID(t *testing.T) {
+	doc := &api.ClientDoc{Spec: api.ClientSpec{ID: api.ID("client-xyz")}}
+
+	cr := NewClientRunnerExec(context.Background(), testLogger(), doc, make(chan Event, 1))
+
+	if got := cr.ID(); got != api.ID("client-xyz") {
+		t.Fatalf("ID() = %q; want %q", got, "client-xyz")
+	}
+
+	ex, ok := cr.(*Exec)
+	if !ok {
+		t.Fatalf("NewClientRunnerExec returned %T; want *Exec", cr)
+	}
+	if ex.metadata.APIVersion != api.APIVersionV1Beta1 {
+		t.Errorf("APIVersion = %q; want %q", ex.metadata.APIVersion, api.APIVersionV1Beta1)
+	}
+	if ex.metadata.Kind != api.KindClient {
+		t.Errorf("Kind = %q; want %q", ex.metadata.Kind, api.KindClient)
+	}
+	if ex.metadata.Metadata.Annotations == nil {
+		t.Errorf("Annotations not initialised")
+	}
+	if ex.stdin == nil || ex.stdout == nil || ex.stderr == nil {
+		t.Errorf("stdio handles not defaulted: in=%v out=%v err=%v", ex.stdin, ex.stdout, ex.stderr)
+	}
+}
+
+// TestNewClientRunnerExecWithIO_CustomHandles verifies caller-supplied stdio
+// handles are wired through and preset doc fields are preserved.
+func TestNewClientRunnerExecWithIO_CustomHandles(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close(); _ = w.Close() })
+
+	doc := &api.ClientDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindClient,
+		Metadata:   api.ClientMetadata{Annotations: map[string]string{"k": "v"}},
+		Spec:       api.ClientSpec{ID: api.ID("c-1")},
+	}
+
+	cr := NewClientRunnerExecWithIO(context.Background(), testLogger(), doc, make(chan Event, 1), r, w, w)
+	ex := cr.(*Exec)
+
+	if ex.stdin != r || ex.stdout != w || ex.stderr != w {
+		t.Fatalf("custom stdio not wired through")
+	}
+	if ex.metadata.Metadata.Annotations["k"] != "v" {
+		t.Fatalf("preset annotations clobbered: %v", ex.metadata.Metadata.Annotations)
+	}
+}
+
+// TestTrySendEvent covers both the buffered-delivery path and the
+// drop-on-full path (the default branch of the non-blocking select).
+func TestTrySendEvent(t *testing.T) {
+	logger := testLogger()
+
+	ch := make(chan Event, 1)
+	ev := Event{ID: api.ID("t1"), Type: EvDetach, When: time.Now()}
+	trySendEvent(logger, ch, ev)
+	select {
+	case got := <-ch:
+		if got.ID != ev.ID || got.Type != ev.Type {
+			t.Fatalf("event mismatch: got %+v want %+v", got, ev)
+		}
+	default:
+		t.Fatal("expected buffered event to be delivered")
+	}
+
+	// Channel already full -> send must not block and must drop silently.
+	full := make(chan Event, 1)
+	full <- Event{ID: api.ID("pre")}
+	trySendEvent(logger, full, Event{ID: api.ID("dropped"), Type: EvError, Err: errors.New("x")})
+	if got := <-full; got.ID != api.ID("pre") {
+		t.Fatalf("full channel: got %q; want the pre-existing event", got.ID)
+	}
+}
+
+// TestTestDouble_DefaultsReturnErrFuncNotSet exercises the ClientRunner test
+// double: every stub returns ErrFuncNotSet (or a zero value) until its Func
+// field is set, and the last-call trackers capture arguments.
+func TestTestDouble_DefaultsReturnErrFuncNotSet(t *testing.T) {
+	td := NewClientRunnerTest(context.Background(), nil)
+
+	if err := td.OpenSocketCtrl(); !errors.Is(err, errdefs.ErrFuncNotSet) {
+		t.Errorf("OpenSocketCtrl default = %v; want ErrFuncNotSet", err)
+	}
+	if err := td.Attach(nil); !errors.Is(err, errdefs.ErrFuncNotSet) {
+		t.Errorf("Attach default = %v; want ErrFuncNotSet", err)
+	}
+	if err := td.CreateMetadata(); !errors.Is(err, errdefs.ErrFuncNotSet) {
+		t.Errorf("CreateMetadata default = %v; want ErrFuncNotSet", err)
+	}
+	if err := td.Detach(); !errors.Is(err, errdefs.ErrFuncNotSet) {
+		t.Errorf("Detach default = %v; want ErrFuncNotSet", err)
+	}
+	if err := td.StartTerminalCmd(nil); !errors.Is(err, errdefs.ErrFuncNotSet) {
+		t.Errorf("StartTerminalCmd default = %v; want ErrFuncNotSet", err)
+	}
+	if _, err := td.Metadata(); !errors.Is(err, errdefs.ErrFuncNotSet) {
+		t.Errorf("Metadata default = %v; want ErrFuncNotSet", err)
+	}
+	if _, err := td.State(); !errors.Is(err, errdefs.ErrFuncNotSet) {
+		t.Errorf("State default = %v; want ErrFuncNotSet", err)
+	}
+	if got := td.ID(); got != "" {
+		t.Errorf("ID default = %q; want empty", got)
+	}
+
+	// Close and Resize record their args even with no Func set.
+	reason := errors.New("bye")
+	if err := td.Close(reason); !errors.Is(err, errdefs.ErrFuncNotSet) {
+		t.Errorf("Close default = %v; want ErrFuncNotSet", err)
+	}
+	if !errors.Is(td.LastReason, reason) {
+		t.Errorf("Close did not record LastReason: %v", td.LastReason)
+	}
+	td.Resize(api.ResizeArgs{Cols: 80, Rows: 24})
+	if td.LastResize.Cols != 80 || td.LastResize.Rows != 24 {
+		t.Errorf("Resize did not record LastResize: %+v", td.LastResize)
+	}
+}
+
+// TestTestDouble_StubsAndTrackers verifies the stub functions are invoked and
+// StartServer captures ctx/controller on the trackers.
+func TestTestDouble_StubsAndTrackers(t *testing.T) {
+	called := map[string]bool{}
+	td := &Test{
+		OpenSocketCtrlFunc:   func() error { called["open"] = true; return nil },
+		IDFunc:               func() api.ID { return api.ID("stub-id") },
+		CloseFunc:            func(error) error { called["close"] = true; return nil },
+		ResizeFunc:           func(api.ResizeArgs) { called["resize"] = true },
+		AttachFunc:           func(*api.AttachedTerminal) error { called["attach"] = true; return nil },
+		CreateMetadataFunc:   func() error { called["create"] = true; return nil },
+		DetachFunc:           func() error { called["detach"] = true; return nil },
+		StartTerminalCmdFunc: func(*api.AttachedTerminal) error { called["start"] = true; return nil },
+		MetadataFunc:         func() (*api.ClientDoc, error) { return &api.ClientDoc{}, nil },
+		StateFunc: func() (*api.ClientStatusMode, error) {
+			s := api.ClientReady
+			return &s, nil
+		},
+		StartServerFunc: func(context.Context, *clientrpc.ClientControllerRPC, chan error, chan error) {},
+	}
+
+	_ = td.OpenSocketCtrl()
+	_ = td.Close(nil)
+	td.Resize(api.ResizeArgs{})
+	_ = td.Attach(nil)
+	_ = td.CreateMetadata()
+	_ = td.Detach()
+	_ = td.StartTerminalCmd(nil)
+	if _, err := td.Metadata(); err != nil {
+		t.Fatalf("Metadata stub: %v", err)
+	}
+	if _, err := td.State(); err != nil {
+		t.Fatalf("State stub: %v", err)
+	}
+	if got := td.ID(); got != api.ID("stub-id") {
+		t.Fatalf("ID stub = %q; want stub-id", got)
+	}
+	for _, k := range []string{"open", "close", "resize", "attach", "create", "detach", "start"} {
+		if !called[k] {
+			t.Errorf("stub %q was not invoked", k)
+		}
+	}
+
+	ctx := context.WithValue(context.Background(), ctxTestKey{}, "v")
+	td.StartServer(ctx, nil, nil, nil)
+	if td.LastCtx == nil || td.LastCtx.Value(ctxTestKey{}) != "v" {
+		t.Errorf("StartServer did not record LastCtx")
+	}
+}
+
+type ctxTestKey struct{}

--- a/internal/client/clientrunner/io_dial_test.go
+++ b/internal/client/clientrunner/io_dial_test.go
@@ -1,0 +1,94 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clientrunner
+
+import (
+	"net"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// fakeTerminalCtrl is a minimal jsonrpc service that answers the terminal
+// control Ping the client runner issues over the terminal's control socket.
+type fakeTerminalCtrl struct{}
+
+func (fakeTerminalCtrl) Ping(_ *api.PingMessage, out *api.PingMessage) error {
+	*out = api.PingMessage{Message: "PONG"}
+	return nil
+}
+
+// serveFakeTerminalCtrl binds a unix socket and serves a jsonrpc terminal
+// control endpoint exposing Ping. It returns the socket path.
+func serveFakeTerminalCtrl(t *testing.T) string {
+	t.Helper()
+	sockPath := filepath.Join(t.TempDir(), "term-ctrl.sock")
+	ln, errListen := net.Listen("unix", sockPath)
+	if errListen != nil {
+		t.Fatalf("listen terminal ctrl socket: %v", errListen)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	srv := rpc.NewServer()
+	if errReg := srv.RegisterName(api.TerminalService, &fakeTerminalCtrl{}); errReg != nil {
+		t.Fatalf("register fake terminal ctrl: %v", errReg)
+	}
+	go func() {
+		for {
+			conn, errAccept := ln.Accept()
+			if errAccept != nil {
+				return
+			}
+			go srv.ServeCodec(jsonrpc.NewServerCodec(conn))
+		}
+	}()
+	return sockPath
+}
+
+// TestDialTerminalCtrlSocket_Success exercises the real connection path: the
+// runner dials the terminal control socket and pings it successfully.
+func TestDialTerminalCtrlSocket_Success(t *testing.T) {
+	sockPath := serveFakeTerminalCtrl(t)
+
+	sr := newIOExec(t)
+	sr.terminal = &api.AttachedTerminal{
+		Spec: &api.TerminalSpec{ID: api.ID("term-io"), SocketFile: sockPath},
+	}
+
+	if err := sr.dialTerminalCtrlSocket(); err != nil {
+		t.Fatalf("dialTerminalCtrlSocket: %v", err)
+	}
+}
+
+// TestDialTerminalCtrlSocket_PingFailure covers the error branch when no peer
+// is serving the terminal control socket.
+func TestDialTerminalCtrlSocket_PingFailure(t *testing.T) {
+	sr := newIOExec(t)
+	sr.terminal = &api.AttachedTerminal{
+		Spec: &api.TerminalSpec{
+			ID:         api.ID("term-io"),
+			SocketFile: filepath.Join(t.TempDir(), "does-not-exist.sock"),
+		},
+	}
+
+	if err := sr.dialTerminalCtrlSocket(); err == nil {
+		t.Fatal("dialTerminalCtrlSocket returned nil error with no peer serving")
+	}
+}

--- a/internal/client/clientrunner/io_extra_test.go
+++ b/internal/client/clientrunner/io_extra_test.go
@@ -1,0 +1,178 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clientrunner
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+func newIOExec(t *testing.T) *Exec {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return &Exec{
+		id:         api.ID("client-io"),
+		ctx:        ctx,
+		ctxCancel:  cancel,
+		logger:     testLogger(),
+		events:     make(chan Event, 8),
+		metadataMu: sync.RWMutex{},
+		metadata: api.ClientDoc{
+			APIVersion: api.APIVersionV1Beta1,
+			Kind:       api.KindClient,
+			Spec:       api.ClientSpec{ID: api.ID("client-io"), RunPath: t.TempDir()},
+		},
+		terminal: &api.AttachedTerminal{Spec: &api.TerminalSpec{ID: api.ID("term-io")}},
+	}
+}
+
+// TestAttach_Success drives the attach() helper: the terminal client returns a
+// connection, the state advances to ClientAttached, and ioConn is stored.
+func TestAttach_Success(t *testing.T) {
+	sr := newIOExec(t)
+	// attach() persists metadata, which requires the per-client run dir that
+	// CreateMetadata establishes during normal startup.
+	if err := sr.CreateMetadata(); err != nil {
+		t.Fatalf("CreateMetadata: %v", err)
+	}
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() { _ = clientConn.Close(); _ = serverConn.Close() })
+
+	var gotReq *api.AttachRequest
+	sr.terminalClient = &mockTerminalClient{
+		attachFunc: func(_ context.Context, req *api.AttachRequest, _ any) (net.Conn, error) {
+			gotReq = req
+			return clientConn, nil
+		},
+	}
+	sr.metadata.Spec.FullCapture = true
+
+	if err := sr.attach(); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	if gotReq == nil || gotReq.ClientID != sr.id || !gotReq.FullCapture {
+		t.Fatalf("attach request = %+v; want ClientID=%q FullCapture=true", gotReq, sr.id)
+	}
+	if sr.ioConn != clientConn {
+		t.Fatal("attach did not store the returned connection in ioConn")
+	}
+	if st, _ := sr.State(); *st != api.ClientAttached {
+		t.Errorf("state = %v; want ClientAttached", *st)
+	}
+}
+
+// TestAttach_Error covers the branch where the terminal client fails to attach.
+func TestAttach_Error(t *testing.T) {
+	sr := newIOExec(t)
+	sr.terminalClient = &mockTerminalClient{
+		attachFunc: func(_ context.Context, _ *api.AttachRequest, _ any) (net.Conn, error) {
+			return nil, errors.New("attach refused")
+		},
+	}
+	if err := sr.attach(); err == nil {
+		t.Fatal("attach returned nil error when terminal client failed")
+	}
+}
+
+// TestForwardResize_InitialResize verifies the initial resize is forwarded for
+// a real tty stdin, then tears down the WINCH watcher via context cancel.
+func TestForwardResize_InitialResize(t *testing.T) {
+	sr := newIOExec(t)
+	sr.stdin = openTTY(t)
+
+	resized := make(chan *api.ResizeArgs, 1)
+	sr.terminalClient = &mockTerminalClient{
+		resizeFunc: func(_ context.Context, args *api.ResizeArgs) error {
+			select {
+			case resized <- args:
+			default:
+			}
+			return nil
+		},
+	}
+
+	if err := sr.forwardResize(); err != nil {
+		t.Fatalf("forwardResize: %v", err)
+	}
+	select {
+	case <-resized:
+	case <-time.After(2 * time.Second):
+		t.Fatal("initial resize was not forwarded")
+	}
+	sr.ctxCancel() // stop the WINCH watcher goroutine
+}
+
+// TestForwardResize_InitialError covers the branch where the initial resize
+// RPC fails.
+func TestForwardResize_InitialError(t *testing.T) {
+	sr := newIOExec(t)
+	sr.stdin = openTTY(t)
+	sr.terminalClient = &mockTerminalClient{
+		resizeFunc: func(_ context.Context, _ *api.ResizeArgs) error { return errors.New("resize fail") },
+	}
+	if err := sr.forwardResize(); err == nil {
+		t.Fatal("forwardResize returned nil error when initial resize failed")
+	}
+}
+
+// TestStartConnectionManager wires a real unix socketpair as ioConn and pumps
+// the dual-copier loop, exercising both the detach-keystroke-enabled help
+// banner and the manager teardown on context cancel.
+func TestStartConnectionManager(t *testing.T) {
+	sr := newIOExec(t)
+	sr.stdin = openTTY(t)
+
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open devnull: %v", err)
+	}
+	t.Cleanup(func() { _ = devNull.Close() })
+	sr.stdout = devNull
+	sr.metadata.Spec.DetachKeystroke = true
+
+	client, _ := unixSocketPair(t)
+	sr.ioConn = client
+
+	if errStart := sr.startConnectionManager(); errStart != nil {
+		t.Fatalf("startConnectionManager: %v", errStart)
+	}
+	// Let the copier goroutines settle, then tear down via context cancel.
+	time.Sleep(50 * time.Millisecond)
+	sr.ctxCancel()
+}
+
+// TestStartConnectionManager_NonUnixConn covers the guard that rejects an
+// ioConn that is not a *net.UnixConn.
+func TestStartConnectionManager_NonUnixConn(t *testing.T) {
+	sr := newIOExec(t)
+	sr.stdin = openTTY(t)
+	c1, c2 := net.Pipe()
+	t.Cleanup(func() { _ = c1.Close(); _ = c2.Close() })
+	sr.ioConn = c1 // net.Pipe conn is not a *net.UnixConn
+
+	if err := sr.startConnectionManager(); err == nil {
+		t.Fatal("startConnectionManager accepted a non-UnixConn ioConn")
+	}
+}

--- a/internal/client/clientrunner/io_test.go
+++ b/internal/client/clientrunner/io_test.go
@@ -30,24 +30,43 @@ import (
 )
 
 // mockTerminalClient is a mock implementation of terminal.Client for testing.
+// Each method consults its optional *Func field, falling back to a benign
+// default so callers only override the behaviour a given test exercises.
 type mockTerminalClient struct {
-	stateFunc func(ctx context.Context, state *api.TerminalStatusMode) error
-	closeFunc func() error
+	stateFunc    func(ctx context.Context, state *api.TerminalStatusMode) error
+	closeFunc    func() error
+	pingFunc     func(ctx context.Context, ping, pong *api.PingMessage) error
+	resizeFunc   func(ctx context.Context, args *api.ResizeArgs) error
+	detachFunc   func(ctx context.Context, id *api.ID) error
+	attachFunc   func(ctx context.Context, req *api.AttachRequest, response any) (net.Conn, error)
+	metadataFunc func(ctx context.Context, metadata *api.TerminalDoc) error
 }
 
-func (m *mockTerminalClient) Ping(_ context.Context, _ *api.PingMessage, _ *api.PingMessage) error {
+func (m *mockTerminalClient) Ping(ctx context.Context, ping *api.PingMessage, pong *api.PingMessage) error {
+	if m.pingFunc != nil {
+		return m.pingFunc(ctx, ping, pong)
+	}
 	return nil
 }
 
-func (m *mockTerminalClient) Resize(_ context.Context, _ *api.ResizeArgs) error {
+func (m *mockTerminalClient) Resize(ctx context.Context, args *api.ResizeArgs) error {
+	if m.resizeFunc != nil {
+		return m.resizeFunc(ctx, args)
+	}
 	return nil
 }
 
-func (m *mockTerminalClient) Detach(_ context.Context, _ *api.ID) error {
+func (m *mockTerminalClient) Detach(ctx context.Context, id *api.ID) error {
+	if m.detachFunc != nil {
+		return m.detachFunc(ctx, id)
+	}
 	return nil
 }
 
-func (m *mockTerminalClient) Attach(_ context.Context, _ *api.AttachRequest, _ any) (net.Conn, error) {
+func (m *mockTerminalClient) Attach(ctx context.Context, req *api.AttachRequest, response any) (net.Conn, error) {
+	if m.attachFunc != nil {
+		return m.attachFunc(ctx, req, response)
+	}
 	return nil, errors.New("not implemented in mock")
 }
 
@@ -58,7 +77,10 @@ func (m *mockTerminalClient) Close() error {
 	return nil
 }
 
-func (m *mockTerminalClient) Metadata(_ context.Context, _ *api.TerminalDoc) error {
+func (m *mockTerminalClient) Metadata(ctx context.Context, metadata *api.TerminalDoc) error {
+	if m.metadataFunc != nil {
+		return m.metadataFunc(ctx, metadata)
+	}
 	return nil
 }
 

--- a/internal/client/clientrunner/lifecycle_test.go
+++ b/internal/client/clientrunner/lifecycle_test.go
@@ -1,0 +1,223 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clientrunner
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+func newLifecycleExec(t *testing.T) (*Exec, chan Event) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	evCh := make(chan Event, 4)
+	return &Exec{
+		id:         api.ID("client-lc"),
+		ctx:        ctx,
+		ctxCancel:  cancel,
+		logger:     testLogger(),
+		events:     evCh,
+		metadataMu: sync.RWMutex{},
+		metadata: api.ClientDoc{
+			APIVersion: api.APIVersionV1Beta1,
+			Kind:       api.KindClient,
+			Spec:       api.ClientSpec{ID: api.ID("client-lc"), RunPath: t.TempDir()},
+		},
+	}, evCh
+}
+
+// TestStartTerminalCmd_Success runs a fast-exiting command and confirms the
+// reaper goroutine emits EvCmdExited.
+func TestStartTerminalCmd_Success(t *testing.T) {
+	sr, evCh := newLifecycleExec(t)
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open devnull: %v", err)
+	}
+	t.Cleanup(func() { _ = devNull.Close() })
+	sr.stdout = devNull
+	sr.stderr = devNull
+
+	term := &api.AttachedTerminal{
+		Spec:        &api.TerminalSpec{ID: api.ID("term-lc"), EnvInherit: true},
+		Command:     "/bin/sh",
+		CommandArgs: []string{"-c", "exit 0"},
+	}
+
+	if errStart := sr.StartTerminalCmd(term); errStart != nil {
+		t.Fatalf("StartTerminalCmd: %v", errStart)
+	}
+
+	select {
+	case ev := <-evCh:
+		if ev.Type != EvCmdExited {
+			t.Fatalf("event type = %v; want EvCmdExited", ev.Type)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for EvCmdExited")
+	}
+}
+
+// TestStartTerminalCmd_MissingCommand covers the validation branch for an
+// empty command / nil args.
+func TestStartTerminalCmd_MissingCommand(t *testing.T) {
+	sr, _ := newLifecycleExec(t)
+	if err := sr.StartTerminalCmd(&api.AttachedTerminal{Spec: &api.TerminalSpec{ID: "x"}}); err == nil {
+		t.Fatal("StartTerminalCmd with empty command returned nil error")
+	}
+}
+
+// TestStartTerminalCmd_NoHomeNoInherit covers the branch where env inheritance
+// is off and HOME is unset, which must fail.
+func TestStartTerminalCmd_NoHomeNoInherit(t *testing.T) {
+	sr, _ := newLifecycleExec(t)
+	t.Setenv("HOME", "")
+
+	term := &api.AttachedTerminal{
+		Spec:        &api.TerminalSpec{ID: api.ID("term-lc"), EnvInherit: false},
+		Command:     "/bin/sh",
+		CommandArgs: []string{"-c", "exit 0"},
+	}
+	if err := sr.StartTerminalCmd(term); err == nil {
+		t.Fatal("StartTerminalCmd without HOME and no inherit returned nil error")
+	}
+}
+
+// TestStartTerminalCmd_StartFailure covers the cmd.Start error branch using a
+// non-existent executable.
+func TestStartTerminalCmd_StartFailure(t *testing.T) {
+	sr, _ := newLifecycleExec(t)
+	devNull, _ := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	t.Cleanup(func() { _ = devNull.Close() })
+	sr.stdout = devNull
+	sr.stderr = devNull
+
+	term := &api.AttachedTerminal{
+		Spec:        &api.TerminalSpec{ID: api.ID("term-lc"), EnvInherit: true},
+		Command:     "/nonexistent/binary-xyz",
+		CommandArgs: []string{},
+	}
+	if err := sr.StartTerminalCmd(term); err == nil {
+		t.Fatal("StartTerminalCmd with bad executable returned nil error")
+	}
+}
+
+// TestClose_RemovesSocketAndUpdatesState verifies Close cancels the context,
+// removes the control socket, and drives the metadata state to ClientExited.
+func TestClose_RemovesSocketAndUpdatesState(t *testing.T) {
+	sr, _ := newLifecycleExec(t)
+
+	sockPath := filepath.Join(t.TempDir(), "ctrl.sock")
+	if err := os.WriteFile(sockPath, []byte{}, 0o600); err != nil {
+		t.Fatalf("seed socket file: %v", err)
+	}
+	sr.metadata.Spec.SockerCtrl = sockPath
+
+	if err := sr.Close(nil); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if sr.ctx.Err() == nil {
+		t.Error("Close did not cancel the context")
+	}
+	if _, err := os.Stat(sockPath); !os.IsNotExist(err) {
+		t.Errorf("control socket still present after Close: stat err=%v", err)
+	}
+	st, _ := sr.State()
+	if *st != api.ClientExited {
+		t.Errorf("post-Close state = %v; want ClientExited", *st)
+	}
+}
+
+// TestDetach_Success covers the happy path: the terminal client detaches and a
+// message is written to stdout.
+func TestDetach_Success(t *testing.T) {
+	sr, _ := newLifecycleExec(t)
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close(); _ = w.Close() })
+	sr.stdout = w
+
+	var gotID api.ID
+	sr.terminalClient = &mockTerminalClient{
+		detachFunc: func(_ context.Context, id *api.ID) error {
+			gotID = *id
+			return nil
+		},
+	}
+
+	// Drain the pipe so the WriteString never blocks on a full buffer.
+	go func() {
+		buf := make([]byte, 256)
+		_, _ = r.Read(buf)
+	}()
+
+	if errDetach := sr.Detach(); errDetach != nil {
+		t.Fatalf("Detach: %v", errDetach)
+	}
+	if gotID != sr.id {
+		t.Errorf("Detach passed id %q; want %q", gotID, sr.id)
+	}
+}
+
+// TestDetach_RPCError covers the branch where the terminal client returns an
+// error.
+func TestDetach_RPCError(t *testing.T) {
+	sr, _ := newLifecycleExec(t)
+	sr.terminalClient = &mockTerminalClient{
+		detachFunc: func(_ context.Context, _ *api.ID) error { return errors.New("rpc fail") },
+	}
+	if err := sr.Detach(); err == nil {
+		t.Fatal("Detach returned nil error when terminal client failed")
+	}
+}
+
+// TestDetach_StdoutWriteError covers the branch where the detach succeeds at
+// the RPC layer but writing the confirmation to stdout fails.
+func TestDetach_StdoutWriteError(t *testing.T) {
+	sr, _ := newLifecycleExec(t)
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	_ = r.Close()
+	_ = w.Close() // closed write end -> WriteString fails
+	sr.stdout = w
+	sr.terminalClient = &mockTerminalClient{} // detach succeeds by default
+
+	if errDetach := sr.Detach(); errDetach == nil {
+		t.Fatal("Detach returned nil error when stdout write failed")
+	}
+}
+
+// TestResizeAndWaitClose covers the no-op Resize and WaitClose methods.
+func TestResizeAndWaitClose(t *testing.T) {
+	sr, _ := newLifecycleExec(t)
+	sr.Resize(api.ResizeArgs{Cols: 1, Rows: 1}) // no-op, must not panic
+	if err := sr.WaitClose(nil); err != nil {
+		t.Fatalf("WaitClose: %v", err)
+	}
+}

--- a/internal/client/clientrunner/metadata_test.go
+++ b/internal/client/clientrunner/metadata_test.go
@@ -1,0 +1,192 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clientrunner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// metadataExecID is the fixed client ID used by the metadata-helper tests.
+const metadataExecID = api.ID("client-meta")
+
+// newMetadataExec builds an Exec rooted at a temp run path with a known ID,
+// suitable for exercising the metadata read/write helpers. It returns the
+// runner and its run path.
+func newMetadataExec(t *testing.T) (*Exec, string) {
+	t.Helper()
+	id := metadataExecID
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	runPath := t.TempDir()
+	return &Exec{
+		id:         id,
+		ctx:        ctx,
+		ctxCancel:  cancel,
+		logger:     testLogger(),
+		metadataMu: sync.RWMutex{},
+		metadata: api.ClientDoc{
+			APIVersion: api.APIVersionV1Beta1,
+			Kind:       api.KindClient,
+			Metadata:   api.ClientMetadata{Name: "test-client"},
+			Spec:       api.ClientSpec{ID: id, RunPath: runPath},
+		},
+	}, runPath
+}
+
+// TestCreateMetadata_WritesFileAndState verifies CreateMetadata creates the
+// per-client run dir, transitions state to Initializing, records the pid, and
+// persists a readable metadata.json.
+func TestCreateMetadata_WritesFileAndState(t *testing.T) {
+	sr, runPath := newMetadataExec(t)
+
+	if err := sr.CreateMetadata(); err != nil {
+		t.Fatalf("CreateMetadata: %v", err)
+	}
+
+	dir := filepath.Join(runPath, defaults.ClientsRunPath, "client-meta")
+	metaPath := filepath.Join(dir, "metadata.json")
+	raw, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("read metadata.json: %v", err)
+	}
+	var doc api.ClientDoc
+	if errUnmarshal := json.Unmarshal(raw, &doc); errUnmarshal != nil {
+		t.Fatalf("unmarshal metadata.json: %v", errUnmarshal)
+	}
+	if doc.Status.State != api.ClientInitializing {
+		t.Errorf("persisted state = %v; want ClientInitializing", doc.Status.State)
+	}
+	if doc.Status.Pid != os.Getpid() {
+		t.Errorf("persisted pid = %d; want %d", doc.Status.Pid, os.Getpid())
+	}
+	if doc.Status.ClientRunPath != dir {
+		t.Errorf("ClientRunPath = %q; want %q", doc.Status.ClientRunPath, dir)
+	}
+}
+
+// TestCreateMetadata_MkdirFailure forces the MkdirAll to fail by rooting the
+// run path under a regular file, exercising the error branch.
+func TestCreateMetadata_MkdirFailure(t *testing.T) {
+	sr, runPath := newMetadataExec(t)
+
+	// Replace the run dir with a regular file so MkdirAll under it fails.
+	blocker := filepath.Join(runPath, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+	sr.metadata.Spec.RunPath = blocker
+
+	if err := sr.CreateMetadata(); err == nil {
+		t.Fatal("CreateMetadata succeeded; want mkdir error")
+	}
+}
+
+// TestMetadata_ReturnsDeepCopy verifies Metadata returns a snapshot that
+// callers can mutate without racing the runner's own writes.
+func TestMetadata_ReturnsDeepCopy(t *testing.T) {
+	sr, _ := newMetadataExec(t)
+	sr.metadata.Status.State = api.ClientReady
+
+	doc, err := sr.Metadata()
+	if err != nil {
+		t.Fatalf("Metadata: %v", err)
+	}
+	if doc.Status.State != api.ClientReady {
+		t.Fatalf("snapshot state = %v; want ClientReady", doc.Status.State)
+	}
+	doc.Metadata.Name = "mutated"
+	if sr.metadata.Metadata.Name == "mutated" {
+		t.Fatal("Metadata returned a shared reference, not a copy")
+	}
+}
+
+// TestState_ReturnsCurrentState verifies State reflects the current lifecycle
+// state.
+func TestState_ReturnsCurrentState(t *testing.T) {
+	sr, _ := newMetadataExec(t)
+	sr.metadata.Status.State = api.ClientAttached
+
+	st, err := sr.State()
+	if err != nil {
+		t.Fatalf("State: %v", err)
+	}
+	if *st != api.ClientAttached {
+		t.Fatalf("State = %v; want ClientAttached", *st)
+	}
+}
+
+// TestGetTerminalState_NilClient covers the guard returning an error when no
+// terminal client has been dialled yet.
+func TestGetTerminalState_NilClient(t *testing.T) {
+	sr, _ := newMetadataExec(t)
+	if _, err := sr.getTerminalState(); err == nil {
+		t.Fatal("getTerminalState with nil client returned nil error")
+	}
+}
+
+// TestGetTerminalState_PropagatesRPCError covers the RPC-failure branch.
+func TestGetTerminalState_PropagatesRPCError(t *testing.T) {
+	sr, _ := newMetadataExec(t)
+	wantErr := errors.New("rpc down")
+	sr.terminalClient = &mockTerminalClient{
+		stateFunc: func(_ context.Context, _ *api.TerminalStatusMode) error { return wantErr },
+	}
+	if _, err := sr.getTerminalState(); err == nil {
+		t.Fatal("getTerminalState returned nil error on RPC failure")
+	}
+}
+
+// TestGetTerminalMetadata covers both the nil-client guard and the success
+// path of the (currently internal) metadata fetch helper.
+func TestGetTerminalMetadata(t *testing.T) {
+	sr, _ := newMetadataExec(t)
+
+	if _, err := sr.getTerminalMetadata(); err == nil {
+		t.Fatal("getTerminalMetadata with nil client returned nil error")
+	}
+
+	sr.terminalClient = &mockTerminalClient{
+		metadataFunc: func(_ context.Context, md *api.TerminalDoc) error {
+			md.Metadata.Name = "term-1"
+			return nil
+		},
+	}
+	md, err := sr.getTerminalMetadata()
+	if err != nil {
+		t.Fatalf("getTerminalMetadata: %v", err)
+	}
+	if md.Metadata.Name != "term-1" {
+		t.Fatalf("metadata name = %q; want term-1", md.Metadata.Name)
+	}
+
+	// RPC-failure branch.
+	sr.terminalClient = &mockTerminalClient{
+		metadataFunc: func(_ context.Context, _ *api.TerminalDoc) error { return errors.New("boom") },
+	}
+	if _, errRPC := sr.getTerminalMetadata(); errRPC == nil {
+		t.Fatal("getTerminalMetadata returned nil error on RPC failure")
+	}
+}

--- a/internal/client/clientrunner/terminal_test.go
+++ b/internal/client/clientrunner/terminal_test.go
@@ -1,0 +1,220 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clientrunner
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/creack/pty"
+)
+
+// openTTY opens a pty pair and returns the slave usable as a real terminal
+// handle. Both sides are closed on cleanup.
+func openTTY(t *testing.T) *os.File {
+	t.Helper()
+	ptmx, tty, err := pty.Open()
+	if err != nil {
+		t.Skipf("pty.Open unavailable in this environment: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = tty.Close()
+		_ = ptmx.Close()
+	})
+	return tty
+}
+
+// unixSocketPair returns a connected pair of *net.UnixConn over a temp socket.
+func unixSocketPair(t *testing.T) (*net.UnixConn, *net.UnixConn) {
+	t.Helper()
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "io.sock")
+	ln, errListen := net.Listen("unix", sockPath)
+	if errListen != nil {
+		t.Fatalf("listen: %v", errListen)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	type acc struct {
+		c   net.Conn
+		err error
+	}
+	accCh := make(chan acc, 1)
+	go func() {
+		c, errAccept := ln.Accept()
+		accCh <- acc{c, errAccept}
+	}()
+
+	dialed, errDial := net.Dial("unix", sockPath)
+	if errDial != nil {
+		t.Fatalf("dial: %v", errDial)
+	}
+	got := <-accCh
+	if got.err != nil {
+		t.Fatalf("accept: %v", got.err)
+	}
+
+	client := dialed.(*net.UnixConn)
+	server := got.c.(*net.UnixConn)
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = server.Close()
+	})
+	return client, server
+}
+
+func newTerminalExec(t *testing.T) *Exec {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return &Exec{
+		ctx:        ctx,
+		ctxCancel:  cancel,
+		logger:     testLogger(),
+		metadataMu: sync.RWMutex{},
+	}
+}
+
+// TestToRawModeAndRestore drives toBashUIMode (raw) followed by toExitShell
+// (restore) against a real pty slave, covering toRawMode and the restore path.
+func TestToRawModeAndRestore(t *testing.T) {
+	tty := openTTY(t)
+	sr := newTerminalExec(t)
+	sr.stdin = tty
+
+	if err := sr.toBashUIMode(); err != nil {
+		t.Fatalf("toBashUIMode: %v", err)
+	}
+	if sr.uiMode != UIBash {
+		t.Errorf("uiMode = %v; want UIBash", sr.uiMode)
+	}
+	if sr.lastTermState == nil {
+		t.Fatal("toBashUIMode did not capture lastTermState")
+	}
+
+	if err := sr.toExitShell(); err != nil {
+		t.Fatalf("toExitShell: %v", err)
+	}
+	if sr.uiMode != UIExitShell {
+		t.Errorf("uiMode = %v; want UIExitShell", sr.uiMode)
+	}
+}
+
+// TestToExitShell_NilState verifies toExitShell is a no-op (no panic, no error)
+// when no raw state was ever captured.
+func TestToExitShell_NilState(t *testing.T) {
+	sr := newTerminalExec(t)
+	if err := sr.toExitShell(); err != nil {
+		t.Fatalf("toExitShell with nil state: %v", err)
+	}
+	if sr.uiMode != UIExitShell {
+		t.Errorf("uiMode = %v; want UIExitShell", sr.uiMode)
+	}
+}
+
+// TestToRawMode_NonTTYFails verifies toRawMode surfaces an error for a
+// non-terminal handle (a pipe).
+func TestToRawMode_NonTTYFails(t *testing.T) {
+	r, w, errPipe := os.Pipe()
+	if errPipe != nil {
+		t.Fatalf("pipe: %v", errPipe)
+	}
+	t.Cleanup(func() { _ = r.Close(); _ = w.Close() })
+
+	if _, errRaw := toRawMode(testLogger(), r); errRaw == nil {
+		t.Fatal("toRawMode on a pipe returned nil error")
+	}
+}
+
+// TestToBashUIMode_NonTTYError covers the error branch where raw mode cannot
+// be set because stdin is not a terminal.
+func TestToBashUIMode_NonTTYError(t *testing.T) {
+	r, w, errPipe := os.Pipe()
+	if errPipe != nil {
+		t.Fatalf("pipe: %v", errPipe)
+	}
+	t.Cleanup(func() { _ = r.Close(); _ = w.Close() })
+
+	sr := newTerminalExec(t)
+	sr.stdin = r
+	if errMode := sr.toBashUIMode(); errMode == nil {
+		t.Fatal("toBashUIMode on a non-tty returned nil error")
+	}
+}
+
+// TestWriteTerminal_Error covers the retry-then-fail branch when the
+// underlying connection is closed before writing.
+func TestWriteTerminal_Error(t *testing.T) {
+	client, server := unixSocketPair(t)
+	_ = server.Close()
+	_ = client.Close() // force every write to fail
+
+	sr := newTerminalExec(t)
+	sr.ioConn = client
+	if err := sr.writeTerminal("x"); err == nil {
+		t.Fatal("writeTerminal returned nil error writing to a closed conn")
+	}
+}
+
+// TestInitTerminal is a trivial smoke of the no-op initialiser.
+func TestInitTerminal(t *testing.T) {
+	sr := newTerminalExec(t)
+	if err := sr.initTerminal(); err != nil {
+		t.Fatalf("initTerminal: %v", err)
+	}
+}
+
+// TestWriteTerminal writes a string through ioConn and confirms the peer
+// receives every byte.
+func TestWriteTerminal(t *testing.T) {
+	client, server := unixSocketPair(t)
+	sr := newTerminalExec(t)
+	sr.ioConn = client
+
+	const payload = "hello"
+	readDone := make(chan []byte, 1)
+	go func() {
+		buf := make([]byte, len(payload))
+		n, _ := readFull(server, buf)
+		readDone <- buf[:n]
+	}()
+
+	if err := sr.writeTerminal(payload); err != nil {
+		t.Fatalf("writeTerminal: %v", err)
+	}
+	got := <-readDone
+	if string(got) != payload {
+		t.Fatalf("peer received %q; want %q", got, payload)
+	}
+}
+
+// readFull reads len(buf) bytes or until error.
+func readFull(c net.Conn, buf []byte) (int, error) {
+	total := 0
+	for total < len(buf) {
+		n, err := c.Read(buf[total:])
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+	return total, nil
+}

--- a/internal/client/controller_coverage_test.go
+++ b/internal/client/controller_coverage_test.go
@@ -1,0 +1,230 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/internal/client/clientrpc"
+	"github.com/eminwux/sbsh/internal/client/clientrunner"
+	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+func coverageLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// Test_CreateAttachTerminal_NoSpecReturnsNotFound covers the branch where the
+// terminal spec carries no SocketFile, ID, or Name, so resolution yields the
+// metadata-not-found sentinel.
+func Test_CreateAttachTerminal_NoSpecReturnsNotFound(t *testing.T) {
+	sc := NewClientController(context.Background(), coverageLogger()).(*Controller)
+
+	doc := &api.ClientDoc{Spec: api.ClientSpec{TerminalSpec: &api.TerminalSpec{}}}
+	_, err := sc.createAttachTerminal(doc)
+	if !errors.Is(err, errdefs.ErrTerminalMetadataNotFound) {
+		t.Fatalf("createAttachTerminal err = %v; want ErrTerminalMetadataNotFound", err)
+	}
+}
+
+// Test_CreateAttachTerminal_ByIDNotFound covers the resolve-by-ID failure
+// branch when no terminal metadata exists under the run path.
+func Test_CreateAttachTerminal_ByIDNotFound(t *testing.T) {
+	sc := NewClientController(context.Background(), coverageLogger()).(*Controller)
+
+	doc := &api.ClientDoc{
+		Spec: api.ClientSpec{
+			RunPath:      t.TempDir(),
+			TerminalSpec: &api.TerminalSpec{ID: api.ID("missing-id")},
+		},
+	}
+	_, err := sc.createAttachTerminal(doc)
+	if !errors.Is(err, errdefs.ErrTerminalNotFoundByID) {
+		t.Fatalf("createAttachTerminal err = %v; want ErrTerminalNotFoundByID", err)
+	}
+}
+
+// Test_CreateAttachTerminal_ByNameNotFound covers the resolve-by-name failure
+// branch.
+func Test_CreateAttachTerminal_ByNameNotFound(t *testing.T) {
+	sc := NewClientController(context.Background(), coverageLogger()).(*Controller)
+
+	doc := &api.ClientDoc{
+		Spec: api.ClientSpec{
+			RunPath:      t.TempDir(),
+			TerminalSpec: &api.TerminalSpec{Name: "missing-name"},
+		},
+	}
+	_, err := sc.createAttachTerminal(doc)
+	if !errors.Is(err, errdefs.ErrTerminalNotFoundByName) {
+		t.Fatalf("createAttachTerminal err = %v; want ErrTerminalNotFoundByName", err)
+	}
+}
+
+// Test_Run_AttachToTerminalLifecycle drives Run end-to-end through the
+// AttachToTerminal mode (resolving the terminal by SocketFile), reaching the
+// main event loop and then exiting via an EvCmdExited-triggered close. This
+// covers the attach-mode branch of the orchestration loop the other Run tests
+// (RunNewTerminal mode) leave uncovered.
+func Test_Run_AttachToTerminalLifecycle(t *testing.T) {
+	sc := NewClientController(context.Background(), coverageLogger()).(*Controller)
+
+	closed := make(chan struct{}, 1)
+	sc.NewClientRunner = func(ctx context.Context, logger *slog.Logger, _ *api.ClientDoc, _ chan<- clientrunner.Event) clientrunner.ClientRunner {
+		return &clientrunner.Test{
+			Ctx:                ctx,
+			Logger:             logger,
+			CreateMetadataFunc: func() error { return nil },
+			OpenSocketCtrlFunc: func() error { return nil },
+			StartServerFunc: func(_ context.Context, _ *clientrpc.ClientControllerRPC, readyCh chan error, _ chan error) {
+				select {
+				case readyCh <- nil:
+				default:
+				}
+			},
+			AttachFunc: func(_ *api.AttachedTerminal) error { return nil },
+			IDFunc:     func() api.ID { return "term-attach" },
+			CloseFunc: func(_ error) error {
+				select {
+				case closed <- struct{}{}:
+				default:
+				}
+				return nil
+			},
+		}
+	}
+
+	doc := &api.ClientDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindClient,
+		Metadata:   api.ClientMetadata{Annotations: map[string]string{}},
+		Spec: api.ClientSpec{
+			ID:           api.ID("client-attach"),
+			RunPath:      t.TempDir(),
+			ClientMode:   api.AttachToTerminal,
+			TerminalSpec: &api.TerminalSpec{SocketFile: "/tmp/sbsh-test/attach.sock"},
+		},
+	}
+
+	exitCh := make(chan error, 1)
+	go func() { exitCh <- sc.Run(doc) }()
+
+	<-sc.ctrlReadyCh
+	sc.eventsCh <- clientrunner.Event{ID: api.ID("term-attach"), Type: clientrunner.EvCmdExited, When: time.Now()}
+
+	select {
+	case <-closed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("close was not triggered after EvCmdExited in attach mode")
+	}
+	<-exitCh
+}
+
+// Test_ClassifySessionEnd covers both the peer-closed and detach-requested
+// sentinels, including the nil-cause path that returns the bare sentinel.
+func Test_ClassifySessionEnd(t *testing.T) {
+	sc := NewClientController(context.Background(), coverageLogger()).(*Controller)
+
+	if err := sc.classifySessionEnd(nil); !errors.Is(err, errdefs.ErrPeerClosed) {
+		t.Fatalf("classifySessionEnd(nil) = %v; want ErrPeerClosed", err)
+	}
+	if err := sc.classifySessionEnd(errors.New("hangup")); !errors.Is(err, errdefs.ErrPeerClosed) {
+		t.Fatalf("classifySessionEnd(cause) = %v; want wrapped ErrPeerClosed", err)
+	}
+
+	sc.detachRequested.Store(true)
+	if err := sc.classifySessionEnd(nil); !errors.Is(err, errdefs.ErrClientDetached) {
+		t.Fatalf("classifySessionEnd(nil) after detach = %v; want ErrClientDetached", err)
+	}
+}
+
+// Test_ControllerTestDouble_Defaults verifies the ControllerTest double
+// returns ErrFuncNotSet from every stub until a Func field is set.
+func Test_ControllerTestDouble_Defaults(t *testing.T) {
+	td := &ControllerTest{}
+
+	checks := map[string]func() error{
+		"Run":       func() error { return td.Run(nil) },
+		"WaitReady": func() error { return td.WaitReady() },
+		"Start":     func() error { return td.Start() },
+		"Close":     func() error { return td.Close(nil) },
+		"WaitClose": func() error { return td.WaitClose() },
+		"Detach":    func() error { return td.Detach() },
+		"Stop":      func() error { return td.Stop(nil) },
+		"Ping":      func() error { _, err := td.Ping(nil); return err },
+		"Metadata":  func() error { _, err := td.Metadata(); return err },
+		"State":     func() error { _, err := td.State(); return err },
+	}
+	for name, fn := range checks {
+		if err := fn(); !errors.Is(err, errdefs.ErrFuncNotSet) {
+			t.Errorf("%s default = %v; want ErrFuncNotSet", name, err)
+		}
+	}
+}
+
+// Test_ControllerTestDouble_StubsInvoked verifies NewClientControllerTest wires
+// succeeding defaults for Run/WaitReady/Start and that the remaining stubs are
+// invoked when their Func fields are set.
+func Test_ControllerTestDouble_StubsInvoked(t *testing.T) {
+	td := NewClientControllerTest()
+	if err := td.Run(&api.ClientDoc{}); err != nil {
+		t.Errorf("Run default = %v; want nil", err)
+	}
+	if err := td.WaitReady(); err != nil {
+		t.Errorf("WaitReady default = %v; want nil", err)
+	}
+	if err := td.Start(); err != nil {
+		t.Errorf("Start default = %v; want nil", err)
+	}
+
+	state := api.ClientReady
+	td.CloseFunc = func(error) error { return nil }
+	td.WaitCloseFunc = func() error { return nil }
+	td.DetachFunc = func() error { return nil }
+	td.StopFunc = func(*api.StopArgs) error { return nil }
+	td.PingFunc = func(in *api.PingMessage) (*api.PingMessage, error) { return in, nil }
+	td.MetadataFunc = func() (*api.ClientDoc, error) { return &api.ClientDoc{}, nil }
+	td.StateFunc = func() (*api.ClientStatusMode, error) { return &state, nil }
+
+	if err := td.Close(nil); err != nil {
+		t.Errorf("Close stub: %v", err)
+	}
+	if err := td.WaitClose(); err != nil {
+		t.Errorf("WaitClose stub: %v", err)
+	}
+	if err := td.Detach(); err != nil {
+		t.Errorf("Detach stub: %v", err)
+	}
+	if err := td.Stop(&api.StopArgs{}); err != nil {
+		t.Errorf("Stop stub: %v", err)
+	}
+	if _, err := td.Ping(&api.PingMessage{Message: "PING"}); err != nil {
+		t.Errorf("Ping stub: %v", err)
+	}
+	if _, err := td.Metadata(); err != nil {
+		t.Errorf("Metadata stub: %v", err)
+	}
+	if st, err := td.State(); err != nil || *st != api.ClientReady {
+		t.Errorf("State stub = %v, %v; want ClientReady, nil", st, err)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #307 (phase 3 of umbrella #304 — client runtime).

Raises statement coverage for the three client-runtime packages to ≥80% with test-only additions (no production code touched):

| Package | Before | After |
| --- | --- | --- |
| `internal/client/clientrunner` | 10.1% | **85.1%** |
| `internal/client` | 58.6% | **80.7%** |
| `internal/client/clientrpc` | 77.8% | **88.9%** |

The tests cover the runtime's lifecycle, connection/attach paths, and error handling — not just constructors — per the AC:

- **clientrunner**: constructors + stdio defaulting, the `ClientRunner` test double, `trySendEvent` (buffered + drop-on-full), metadata read/write helpers (`CreateMetadata` incl. mkdir failure, `Metadata` deep-copy, `State`, `getTerminalState`/`getTerminalMetadata`), terminal raw-mode transitions over a real pty, `writeTerminal`, `StartTerminalCmd` (success + missing-command/no-HOME/start-failure branches), `Close`, `Detach`, the `StartServer` RPC accept loop (serve→cancel→done), the `attach()`/`forwardResize()`/`startConnectionManager()` IO helpers, and `dialTerminalCtrlSocket()` against a real fake terminal control socket.
- **client**: the `ControllerTest` double (all methods), `createAttachTerminal` resolve-by-ID / by-name / no-spec error branches, `classifySessionEnd` both sentinels, and a full `Run` lifecycle through `AttachToTerminal` mode (the other `Run` tests exercise only `RunNewTerminal` mode).
- **clientrpc**: the previously-uncovered `WaitReady` and `Detach` RPC delegations (success + error propagation).

## Notes for the reviewer

- **Single PR rather than the sub-PR split the issue invited.** #307 flags that clientrunner's 11 source files "may push this past a single PR" and permits resizing into sub-PRs. I judged a single test-only PR across these three sibling packages reviewable, since each test is independently auditable and the three form one coherent "client runtime" unit. Happy to split if you'd prefer.
- **`Run` lands at ~60% by construction.** Many of `Run`'s `if errC := s.Close(...); errC != nil` wrapping branches are unreachable because `Controller.Close` always returns `nil`. Coverage is driven by the reachable branches; the package still clears 80%.
- The shared `mockTerminalClient` in `io_test.go` gained optional `*Func` fields (Ping/Resize/Detach/Attach/Metadata) so the IO helpers can be driven; existing behaviour is unchanged (defaults preserved).

## Test plan

- [x] `make sbsh-sb` (ELF verified via `file ./sbsh`)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test $(go list ./... | grep -v '/e2e$')` (full non-e2e CI suite — green)
- [x] `go test -race -count=1 ./internal/client/...` (no races)
- [x] `go test -tags=integration ./cmd/sb/get/...`
- [x] `make e2e`
- [x] `pre-commit run golangci-lint` on changed files

Closes #307