### PR TITLE
test: phase 5 — raise supporting-internal coverage above 80%

### DIFF
--- a/internal/capture/errors_test.go
+++ b/internal/capture/errors_test.go
@@ -1,0 +1,74 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package capture
+
+import (
+	"io"
+	"path/filepath"
+	"testing"
+)
+
+// TestCompressSegment_OpenRawFails covers the open-raw error branch: a
+// nonexistent rawPath returns an error and no compressed path.
+func TestCompressSegment_OpenRawFails(t *testing.T) {
+	raw := filepath.Join(t.TempDir(), "capture.000000")
+	gzPath, err := CompressSegment(raw)
+	if err == nil {
+		t.Fatal("expected error compressing a nonexistent segment")
+	}
+	if gzPath != "" {
+		t.Fatalf("expected empty path on open failure, got %q", gzPath)
+	}
+}
+
+// TestReadAll_CorruptGzSegmentErrors covers readSegment's gzip-open error
+// branch: a ".gz" segment whose contents are not valid gzip surfaces an error
+// rather than silently yielding garbage.
+func TestReadAll_CorruptGzSegmentErrors(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+	// A .gz segment that is not actually gzip-compressed.
+	writeFile(t, SegmentPath(canonical, 0)+GzSuffix, []byte("not gzip data"))
+
+	if _, err := ReadAll(canonical); err == nil {
+		t.Fatal("expected error reading a corrupt gzip segment")
+	}
+}
+
+// TestDump_CorruptGzSegmentErrors mirrors the ReadAll case for dumpOne's
+// gzip-open error branch.
+func TestDump_CorruptGzSegmentErrors(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+	writeFile(t, SegmentPath(canonical, 0)+GzSuffix, []byte("not gzip data"))
+
+	if err := Dump(canonical, io.Discard); err == nil {
+		t.Fatal("expected error dumping a corrupt gzip segment")
+	}
+}
+
+// TestReplay_ReadError covers Replay's error propagation from ReadAll when a
+// segment cannot be decoded.
+func TestReplay_ReadError(t *testing.T) {
+	dir := t.TempDir()
+	canonical := filepath.Join(dir, "capture")
+	writeFile(t, SegmentPath(canonical, 0)+GzSuffix, []byte("not gzip data"))
+
+	if _, err := Replay(canonical); err == nil {
+		t.Fatal("expected Replay to surface the decode error")
+	}
+}

--- a/internal/discovery/print_test.go
+++ b/internal/discovery/print_test.go
@@ -1,0 +1,576 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package discovery_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/internal/discovery"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+const sampleProfile = `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: alpha
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/bash
+    cmdArgs:
+      - -l
+    env:
+      FOO: bar
+`
+
+func writeProfileFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+// writeNamedClientDoc writes a client metadata.json with a Metadata.Name set,
+// which client lookups resolve against (writeClientDoc leaves the name empty).
+func writeNamedClientDoc(t *testing.T, runPath, id, name string, state api.ClientStatusMode, pid int) {
+	t.Helper()
+	dir := filepath.Join(runPath, defaults.ClientsRunPath, id)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	doc := api.ClientDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindClient,
+		Metadata:   api.ClientMetadata{Name: name},
+		Spec:       api.ClientSpec{ID: api.ID(id), RunPath: runPath},
+		Status: api.ClientStatus{
+			State:         state,
+			Pid:           pid,
+			ClientRunPath: dir,
+		},
+	}
+	b, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if writeErr := os.WriteFile(filepath.Join(dir, "metadata.json"), b, 0o644); writeErr != nil {
+		t.Fatalf("write metadata.json: %v", writeErr)
+	}
+}
+
+func TestScanAndPrintTerminals(t *testing.T) {
+	ctx := context.Background()
+	logger := discardLogger()
+	livePid := os.Getpid()
+
+	t.Run("empty runPath prints placeholder", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := discovery.ScanAndPrintTerminals(ctx, logger, t.TempDir(), &buf, false, ""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(buf.String(), "no active or inactive terminals found") {
+			t.Fatalf("expected placeholder, got %q", buf.String())
+		}
+	})
+
+	t.Run("compact table lists active terminal", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeTerminalDoc(t, runPath, "id-1", "alpha", api.Ready, livePid)
+		var buf bytes.Buffer
+		if err := discovery.ScanAndPrintTerminals(ctx, logger, runPath, &buf, false, ""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "NAME") || !strings.Contains(out, "alpha") {
+			t.Fatalf("expected header and alpha row, got %q", out)
+		}
+	})
+
+	t.Run("wide table includes ID and labels columns", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeTerminalDoc(t, runPath, "id-1", "alpha", api.Ready, livePid)
+		var buf bytes.Buffer
+		if err := discovery.ScanAndPrintTerminals(ctx, logger, runPath, &buf, true, "wide"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "ID") || !strings.Contains(out, "LABELS") || !strings.Contains(out, "id-1") {
+			t.Fatalf("expected wide header with id-1, got %q", out)
+		}
+	})
+
+	t.Run("only exited terminals without printAll", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeTerminalDoc(t, runPath, "id-1", "alpha", api.Exited, livePid)
+		var buf bytes.Buffer
+		if err := discovery.ScanAndPrintTerminals(ctx, logger, runPath, &buf, false, ""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(buf.String(), "no active terminals found") {
+			t.Fatalf("expected no-active message, got %q", buf.String())
+		}
+	})
+}
+
+func TestScanAndPrintTerminals_Formats(t *testing.T) {
+	ctx := context.Background()
+	logger := discardLogger()
+	livePid := os.Getpid()
+
+	t.Run("json format", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeTerminalDoc(t, runPath, "id-1", "alpha", api.Ready, livePid)
+		var buf bytes.Buffer
+		if err := discovery.ScanAndPrintTerminals(ctx, logger, runPath, &buf, true, "json"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(buf.String(), "\"id-1\"") {
+			t.Fatalf("expected json with id-1, got %q", buf.String())
+		}
+	})
+
+	t.Run("yaml format", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeTerminalDoc(t, runPath, "id-1", "alpha", api.Ready, livePid)
+		var buf bytes.Buffer
+		if err := discovery.ScanAndPrintTerminals(ctx, logger, runPath, &buf, true, "yaml"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(buf.String(), "id-1") {
+			t.Fatalf("expected yaml with id-1, got %q", buf.String())
+		}
+	})
+
+	t.Run("unknown format errors", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := discovery.ScanAndPrintTerminals(ctx, logger, t.TempDir(), &buf, false, "bogus"); err == nil {
+			t.Fatal("expected error for unknown format")
+		}
+	})
+}
+
+func TestScanAndPrintClients(t *testing.T) {
+	ctx := context.Background()
+	logger := discardLogger()
+	livePid := os.Getpid()
+
+	t.Run("empty prints placeholder", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := discovery.ScanAndPrintClients(ctx, logger, t.TempDir(), &buf, false, ""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(buf.String(), "no active or inactive clients found") {
+			t.Fatalf("expected placeholder, got %q", buf.String())
+		}
+	})
+
+	t.Run("wide table lists active client", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeClientDoc(t, runPath, "id-1", api.ClientReady, livePid)
+		var buf bytes.Buffer
+		if err := discovery.ScanAndPrintClients(ctx, logger, runPath, &buf, true, "wide"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "ID") || !strings.Contains(out, "LABELS") || !strings.Contains(out, "id-1") {
+			t.Fatalf("expected wide header with id-1, got %q", out)
+		}
+	})
+
+	t.Run("only exited clients without printAll", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeClientDoc(t, runPath, "id-1", api.ClientExited, livePid)
+		var buf bytes.Buffer
+		if err := discovery.ScanAndPrintClients(ctx, logger, runPath, &buf, false, ""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(buf.String(), "no active clients found") {
+			t.Fatalf("expected no-active message, got %q", buf.String())
+		}
+	})
+
+	t.Run("json format", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeClientDoc(t, runPath, "id-1", api.ClientReady, livePid)
+		var buf bytes.Buffer
+		if err := discovery.ScanAndPrintClients(ctx, logger, runPath, &buf, true, "json"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(buf.String(), "\"id-1\"") {
+			t.Fatalf("expected json with id-1, got %q", buf.String())
+		}
+	})
+
+	t.Run("unknown format errors", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := discovery.ScanAndPrintClients(ctx, logger, t.TempDir(), &buf, false, "bogus"); err == nil {
+			t.Fatal("expected error for unknown format")
+		}
+	})
+}
+
+func TestFindAndPrintTerminalMetadata(t *testing.T) {
+	ctx := context.Background()
+	logger := discardLogger()
+	livePid := os.Getpid()
+
+	t.Run("found prints metadata", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeTerminalDoc(t, runPath, "id-1", "alpha", api.Ready, livePid)
+		var buf bytes.Buffer
+		if err := discovery.FindAndPrintTerminalMetadata(ctx, logger, runPath, &buf, "alpha", "json"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(buf.String(), "id-1") {
+			t.Fatalf("expected metadata with id-1, got %q", buf.String())
+		}
+	})
+
+	t.Run("not found returns error", func(t *testing.T) {
+		runPath := t.TempDir()
+		var buf bytes.Buffer
+		if err := discovery.FindAndPrintTerminalMetadata(ctx, logger, runPath, &buf, "missing", "json"); err == nil {
+			t.Fatal("expected error for missing terminal")
+		}
+	})
+
+	t.Run("human format", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeTerminalDoc(t, runPath, "id-1", "alpha", api.Ready, livePid)
+		var buf bytes.Buffer
+		if err := discovery.FindAndPrintTerminalMetadata(ctx, logger, runPath, &buf, "alpha", ""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if buf.Len() == 0 {
+			t.Fatal("expected human output, got empty")
+		}
+	})
+}
+
+func TestFindAndPrintClientMetadata(t *testing.T) {
+	ctx := context.Background()
+	logger := discardLogger()
+	livePid := os.Getpid()
+
+	runPath := t.TempDir()
+	writeNamedClientDoc(t, runPath, "id-1", "alpha", api.ClientReady, livePid)
+	var buf bytes.Buffer
+	if err := discovery.FindAndPrintClientMetadata(ctx, logger, runPath, &buf, "alpha", "json"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "id-1") {
+		t.Fatalf("expected metadata with id-1, got %q", buf.String())
+	}
+}
+
+func TestFindTerminalByIDAndName(t *testing.T) {
+	ctx := context.Background()
+	logger := discardLogger()
+	runPath := t.TempDir()
+	writeTerminalDoc(t, runPath, "id-1", "alpha", api.Ready, os.Getpid())
+
+	got, err := discovery.FindTerminalByID(ctx, logger, runPath, "id-1")
+	if err != nil {
+		t.Fatalf("FindTerminalByID: %v", err)
+	}
+	if got == nil || string(got.Spec.ID) != "id-1" {
+		t.Fatalf("expected id-1, got %+v", got)
+	}
+
+	got, err = discovery.FindTerminalByName(ctx, logger, runPath, "alpha")
+	if err != nil {
+		t.Fatalf("FindTerminalByName: %v", err)
+	}
+	if got == nil || got.Spec.Name != "alpha" {
+		t.Fatalf("expected alpha, got %+v", got)
+	}
+}
+
+func TestFindClientByName(t *testing.T) {
+	ctx := context.Background()
+	logger := discardLogger()
+	runPath := t.TempDir()
+	writeNamedClientDoc(t, runPath, "id-1", "alpha", api.ClientReady, os.Getpid())
+
+	got, err := discovery.FindClientByName(ctx, logger, runPath, "alpha")
+	if err != nil {
+		t.Fatalf("FindClientByName: %v", err)
+	}
+	if got == nil || got.Metadata.Name != "alpha" {
+		t.Fatalf("expected alpha, got %+v", got)
+	}
+
+	if _, missErr := discovery.FindClientByName(ctx, logger, runPath, "nonexistent"); missErr == nil {
+		t.Fatal("expected error for unknown client name")
+	}
+}
+
+func TestPrintTerminalSpec(t *testing.T) {
+	logger := discardLogger()
+
+	t.Run("nil spec is a no-op", func(t *testing.T) {
+		if err := discovery.PrintTerminalSpec(nil, logger); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("fully populated spec", func(t *testing.T) {
+		spec := &api.TerminalSpec{
+			ID:          "id-1",
+			Name:        "alpha",
+			Kind:        api.TerminalLocal,
+			Command:     "/bin/bash",
+			CommandArgs: []string{"-l"},
+			Prompt:      "$ ",
+			RunPath:     "/tmp/run",
+			CaptureFile: "/tmp/cap",
+			LogFile:     "/tmp/log",
+			LogLevel:    "debug",
+			SocketFile:  "/tmp/sock",
+			Env:         []string{"FOO=bar"},
+			Labels:      map[string]string{"team": "infra", "env": "prod"},
+		}
+		if err := discovery.PrintTerminalSpec(spec, logger); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestScanAndPrintProfiles(t *testing.T) {
+	ctx := context.Background()
+	logger := discardLogger()
+
+	t.Run("empty dir prints no-profiles", func(t *testing.T) {
+		var buf, warn bytes.Buffer
+		if err := discovery.ScanAndPrintProfiles(ctx, logger, t.TempDir(), &buf, &warn, ""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(buf.String(), "no profiles found") {
+			t.Fatalf("expected no-profiles message, got %q", buf.String())
+		}
+	})
+
+	t.Run("compact table", func(t *testing.T) {
+		dir := t.TempDir()
+		writeProfileFile(t, dir, "alpha.yaml", sampleProfile)
+		var buf, warn bytes.Buffer
+		if err := discovery.ScanAndPrintProfiles(ctx, logger, dir, &buf, &warn, ""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "alpha") || !strings.Contains(out, "/bin/bash") {
+			t.Fatalf("expected alpha profile row, got %q", out)
+		}
+	})
+
+	t.Run("wide table includes target and envvars", func(t *testing.T) {
+		dir := t.TempDir()
+		writeProfileFile(t, dir, "alpha.yaml", sampleProfile)
+		var buf, warn bytes.Buffer
+		if err := discovery.ScanAndPrintProfiles(ctx, logger, dir, &buf, &warn, "wide"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		if !strings.Contains(out, "TARGET") || !strings.Contains(out, "vars") {
+			t.Fatalf("expected wide header, got %q", out)
+		}
+	})
+}
+
+func TestScanAndPrintProfiles_FormatsAndWarnings(t *testing.T) {
+	ctx := context.Background()
+	logger := discardLogger()
+
+	t.Run("json format", func(t *testing.T) {
+		dir := t.TempDir()
+		writeProfileFile(t, dir, "alpha.yaml", sampleProfile)
+		var buf, warn bytes.Buffer
+		if err := discovery.ScanAndPrintProfiles(ctx, logger, dir, &buf, &warn, "json"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(buf.String(), "alpha") {
+			t.Fatalf("expected json with alpha, got %q", buf.String())
+		}
+	})
+
+	t.Run("unknown format errors", func(t *testing.T) {
+		var buf, warn bytes.Buffer
+		if err := discovery.ScanAndPrintProfiles(ctx, logger, t.TempDir(), &buf, &warn, "bogus"); err == nil {
+			t.Fatal("expected error for unknown format")
+		}
+	})
+
+	t.Run("warnings written to warnOut", func(t *testing.T) {
+		dir := t.TempDir()
+		// Missing apiVersion produces a warning but does not abort.
+		writeProfileFile(t, dir, "bad.yaml", "kind: TerminalProfile\nmetadata:\n  name: bad\n")
+		var buf, warn bytes.Buffer
+		if err := discovery.ScanAndPrintProfiles(ctx, logger, dir, &buf, &warn, ""); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(warn.String(), "sbsh: warning:") {
+			t.Fatalf("expected warning line, got %q", warn.String())
+		}
+	})
+}
+
+func TestFindAndPrintProfileMetadata(t *testing.T) {
+	ctx := context.Background()
+	logger := discardLogger()
+
+	t.Run("found", func(t *testing.T) {
+		dir := t.TempDir()
+		writeProfileFile(t, dir, "alpha.yaml", sampleProfile)
+		var buf, warn bytes.Buffer
+		if err := discovery.FindAndPrintProfileMetadata(ctx, logger, dir, &buf, &warn, "alpha", "json"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(buf.String(), "alpha") {
+			t.Fatalf("expected alpha in output, got %q", buf.String())
+		}
+	})
+
+	t.Run("not found errors", func(t *testing.T) {
+		dir := t.TempDir()
+		writeProfileFile(t, dir, "alpha.yaml", sampleProfile)
+		var buf, warn bytes.Buffer
+		if err := discovery.FindAndPrintProfileMetadata(ctx, logger, dir, &buf, &warn, "missing", "json"); err == nil {
+			t.Fatal("expected error for missing profile")
+		}
+	})
+}
+
+func TestLoadProfilesWrappers(t *testing.T) {
+	ctx := context.Background()
+	logger := discardLogger()
+
+	t.Run("LoadProfilesFromDir", func(t *testing.T) {
+		dir := t.TempDir()
+		writeProfileFile(t, dir, "alpha.yaml", sampleProfile)
+		profiles, warnings, err := discovery.LoadProfilesFromDir(ctx, logger, dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(profiles) != 1 || profiles[0].Metadata.Name != "alpha" {
+			t.Fatalf("expected one alpha profile, got %+v", profiles)
+		}
+		if len(warnings) != 0 {
+			t.Fatalf("expected no warnings, got %+v", warnings)
+		}
+	})
+
+	t.Run("LoadProfilesFromReaderWithContext", func(t *testing.T) {
+		profiles, err := discovery.LoadProfilesFromReaderWithContext(ctx, logger, strings.NewReader(sampleProfile))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(profiles) != 1 || profiles[0].Metadata.Name != "alpha" {
+			t.Fatalf("expected one alpha profile, got %+v", profiles)
+		}
+	})
+
+	t.Run("FindProfileByNameInDir", func(t *testing.T) {
+		dir := t.TempDir()
+		writeProfileFile(t, dir, "alpha.yaml", sampleProfile)
+		doc, _, err := discovery.FindProfileByNameInDir(ctx, logger, dir, "alpha")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if doc == nil || doc.Metadata.Name != "alpha" {
+			t.Fatalf("expected alpha, got %+v", doc)
+		}
+	})
+}
+
+func TestPrintProfileWarnings(t *testing.T) {
+	t.Run("nil writer is a no-op", func(_ *testing.T) {
+		discovery.PrintProfileWarnings(nil, []discovery.ProfileWarning{{File: "x", Reason: "y"}})
+	})
+
+	t.Run("writes one line per warning", func(t *testing.T) {
+		var buf bytes.Buffer
+		discovery.PrintProfileWarnings(&buf, []discovery.ProfileWarning{
+			{File: "a.yaml", Reason: "boom"},
+			{File: "b.yaml", DocIndex: 2, Reason: "bang"},
+		})
+		out := buf.String()
+		if strings.Count(out, "sbsh: warning:") != 2 {
+			t.Fatalf("expected two warning lines, got %q", out)
+		}
+	})
+}
+
+func TestPrintHuman(t *testing.T) {
+	type inner struct {
+		Name string
+		Tags []string
+	}
+	type outer struct {
+		Title  string
+		Count  int
+		Active bool
+		Nested inner
+		Labels map[string]string
+		Empty  []string
+		Ptr    *inner
+		NilPtr *inner
+	}
+	v := outer{
+		Title:  "  hello  ",
+		Count:  3,
+		Active: true,
+		Nested: inner{Name: "n", Tags: []string{"a", "b"}},
+		Labels: map[string]string{"k": "v"},
+		Empty:  nil,
+		Ptr:    &inner{Name: "p"},
+		NilPtr: nil,
+	}
+	var buf bytes.Buffer
+	discovery.PrintHuman(&buf, v, "")
+	out := buf.String()
+	for _, want := range []string{"Title", "hello", "Count", "3", "Active", "true", "Nested", "Labels", "k:", "[]", "<nil>"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in output, got %q", want, out)
+		}
+	}
+
+	t.Run("nil interface", func(t *testing.T) {
+		var b bytes.Buffer
+		discovery.PrintHuman(&b, nil, "")
+		if !strings.Contains(b.String(), "<nil>") {
+			t.Fatalf("expected <nil>, got %q", b.String())
+		}
+	})
+
+	t.Run("empty string renders quotes", func(t *testing.T) {
+		var b bytes.Buffer
+		discovery.PrintHuman(&b, struct{ S string }{S: "   "}, "")
+		if !strings.Contains(b.String(), "\"\"") {
+			t.Fatalf("expected empty-string marker, got %q", b.String())
+		}
+	})
+}

--- a/internal/pidutil/pidutil_extra_test.go
+++ b/internal/pidutil/pidutil_extra_test.go
@@ -1,0 +1,54 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package pidutil
+
+import "testing"
+
+// TestMatch_NonPositivePidWithToken covers the got==0 branch: StartTime
+// returns (0, nil) for a non-positive PID, so Match cannot confirm a recorded
+// token and returns false.
+func TestMatch_NonPositivePidWithToken(t *testing.T) {
+	ok, err := Match(0, 12345)
+	if err != nil {
+		t.Fatalf("Match(0, token) error: %v", err)
+	}
+	if ok {
+		t.Fatal("Match(0, token) = true; want false (cannot verify)")
+	}
+}
+
+// TestMatch_DeadPidSurfacesError covers Match's error-propagation branch: a PID
+// with no live process makes the platform reader fail, and Match surfaces
+// (false, err) so callers distinguish "gone" from "matched".
+func TestMatch_DeadPidSurfacesError(t *testing.T) {
+	// A very high PID is almost certainly not live; StartTime fails to read
+	// its per-process token.
+	const deadPid = 0x7ffffffe
+	tok, err := StartTime(deadPid)
+	if err == nil {
+		// On a platform without a per-process token, StartTime returns
+		// (0, nil) and Match degrades gracefully — nothing to assert.
+		t.Skipf("platform returned token %d with no error for dead pid; skipping", tok)
+	}
+	ok, err := Match(deadPid, 12345)
+	if err == nil {
+		t.Fatal("Match(deadPid, token) err = nil; want a reader error")
+	}
+	if ok {
+		t.Fatal("Match(deadPid, token) = true; want false")
+	}
+}

--- a/internal/profile/build_test.go
+++ b/internal/profile/build_test.go
@@ -1,0 +1,320 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package profile
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+const buildProfileYAML = `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: myprof
+  labels:
+    team: infra
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/zsh
+    cmdArgs:
+      - -l
+    env:
+      FOO: bar
+`
+
+func writeProfileDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "p.yaml"), []byte(buildProfileYAML), 0o644); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+	return dir
+}
+
+func TestBuildTerminalSpecFromProfile_LoadsNamedProfile(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	profilesDir := writeProfileDir(t)
+
+	spec, err := BuildTerminalSpecFromProfile(ctx, logger, &BuildTerminalSpecParams{
+		RunPath:     t.TempDir(),
+		ProfilesDir: profilesDir,
+		ProfileName: "myprof",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.Command != "/bin/zsh" {
+		t.Fatalf("expected /bin/zsh, got %q", spec.Command)
+	}
+	if spec.ProfileName != "myprof" {
+		t.Fatalf("expected profile name myprof, got %q", spec.ProfileName)
+	}
+	if spec.Labels["team"] != "infra" {
+		t.Fatalf("expected label team=infra, got %v", spec.Labels)
+	}
+	// applyParamDefaults must have populated ID/Name and artifact paths.
+	if spec.ID == "" || spec.Name == "" || spec.LogFile == "" || spec.SocketFile == "" {
+		t.Fatalf("expected defaults populated, got %+v", spec)
+	}
+}
+
+func TestBuildTerminalSpecFromProfile_EmptyNameResolvesDefaultHardcoded(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+
+	// Empty profilesDir + empty ProfileName -> "default" lookup misses ->
+	// hardcoded default profile fallback.
+	spec, err := BuildTerminalSpecFromProfile(ctx, logger, &BuildTerminalSpecParams{
+		RunPath: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.ProfileName != "default" {
+		t.Fatalf("expected default profile, got %q", spec.ProfileName)
+	}
+	// Hardcoded default uses the inline command default from applyParamDefaults.
+	if spec.Command != "/bin/bash" {
+		t.Fatalf("expected /bin/bash from hardcoded default, got %q", spec.Command)
+	}
+}
+
+func TestBuildTerminalSpecFromProfile_MissingNonDefaultProfileErrors(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	profilesDir := writeProfileDir(t)
+
+	_, err := BuildTerminalSpecFromProfile(ctx, logger, &BuildTerminalSpecParams{
+		RunPath:     t.TempDir(),
+		ProfilesDir: profilesDir,
+		ProfileName: "does-not-exist",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing non-default profile")
+	}
+}
+
+func TestBuildTerminalSpecFromProfile_AppliesOverrides(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	profilesDir := writeProfileDir(t)
+	gid := 42
+
+	spec, err := BuildTerminalSpecFromProfile(ctx, logger, &BuildTerminalSpecParams{
+		RunPath:       t.TempDir(),
+		ProfilesDir:   profilesDir,
+		ProfileName:   "myprof",
+		SocketMode:    "0660",
+		SocketGID:     &gid,
+		CaptureFormat: api.CaptureFormatAsciicast,
+		EnvVars:       []string{"EXTRA=1"},
+		Prompt:        "custom> ",
+		PromptSet:     true,
+		EnvInherit:    true,
+		EnvInheritSet: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.SocketMode != 0o660 {
+		t.Fatalf("expected socket mode 0660, got %o", spec.SocketMode)
+	}
+	if spec.SocketGID == nil || *spec.SocketGID != 42 {
+		t.Fatalf("expected socket gid 42, got %v", spec.SocketGID)
+	}
+	if spec.CaptureFormat != api.CaptureFormatAsciicast {
+		t.Fatalf("expected asciicast, got %q", spec.CaptureFormat)
+	}
+	if spec.Prompt != "custom> " {
+		t.Fatalf("expected custom prompt, got %q", spec.Prompt)
+	}
+	if !spec.EnvInherit {
+		t.Fatal("expected EnvInherit true")
+	}
+}
+
+func TestBuildTerminalSpecFromProfile_InvalidCaptureFormatErrors(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	profilesDir := writeProfileDir(t)
+
+	_, err := BuildTerminalSpecFromProfile(ctx, logger, &BuildTerminalSpecParams{
+		RunPath:       t.TempDir(),
+		ProfilesDir:   profilesDir,
+		ProfileName:   "myprof",
+		CaptureFormat: "bogus",
+	})
+	if !errors.Is(err, errdefs.ErrInvalidFlag) {
+		t.Fatalf("expected ErrInvalidFlag, got %v", err)
+	}
+}
+
+func TestBuildTerminalSpecFromProfile_InvalidSocketModeErrors(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	profilesDir := writeProfileDir(t)
+
+	_, err := BuildTerminalSpecFromProfile(ctx, logger, &BuildTerminalSpecParams{
+		RunPath:     t.TempDir(),
+		ProfilesDir: profilesDir,
+		ProfileName: "myprof",
+		SocketMode:  "99999",
+	})
+	if !errors.Is(err, errdefs.ErrInvalidFlag) {
+		t.Fatalf("expected ErrInvalidFlag, got %v", err)
+	}
+}
+
+func TestBuildTerminalSpecInline_FullPath(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	gid := 7
+
+	spec, err := BuildTerminalSpecInline(ctx, logger, &BuildTerminalSpecParams{
+		RunPath:           t.TempDir(),
+		TerminalCmd:       "/bin/sh",
+		TerminalCmdArgs:   []string{"-c", "true"},
+		Cwd:               "/tmp",
+		CaptureMode:       "0640",
+		CaptureGID:        &gid,
+		CaptureFormat:     api.CaptureFormatRaw,
+		Stages:            api.StagesSpec{OnInit: []api.ExecStep{{Script: "echo hi"}}},
+		OnInitOverlay:     true,
+		PostAttachOverlay: true,
+		DisableSetPrompt:  true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.Command != "/bin/sh" {
+		t.Fatalf("expected /bin/sh, got %q", spec.Command)
+	}
+	if spec.Cwd != "/tmp" {
+		t.Fatalf("expected cwd /tmp, got %q", spec.Cwd)
+	}
+	if spec.CaptureMode != 0o640 {
+		t.Fatalf("expected capture mode 0640, got %o", spec.CaptureMode)
+	}
+	if spec.CaptureGID == nil || *spec.CaptureGID != 7 {
+		t.Fatalf("expected capture gid 7, got %v", spec.CaptureGID)
+	}
+	if len(spec.Stages.OnInit) != 1 || spec.Stages.OnInit[0].Script != "echo hi" {
+		t.Fatalf("expected OnInit overlay, got %v", spec.Stages.OnInit)
+	}
+	if spec.SetPrompt {
+		t.Fatal("expected SetPrompt false when DisableSetPrompt true")
+	}
+}
+
+func TestBuildTerminalSpecInline_StagesOverlayWins(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+
+	full := api.StagesSpec{OnInit: []api.ExecStep{{Script: "a"}}, PostAttach: []api.ExecStep{{Script: "b"}}}
+	spec, err := BuildTerminalSpecInline(ctx, logger, &BuildTerminalSpecParams{
+		RunPath:       t.TempDir(),
+		Stages:        full,
+		StagesOverlay: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(spec.Stages.OnInit) != 1 || len(spec.Stages.PostAttach) != 1 {
+		t.Fatalf("expected full stages overlay, got %+v", spec.Stages)
+	}
+}
+
+func TestBuildTerminalSpecInline_InvalidCaptureFormatErrors(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+
+	_, err := BuildTerminalSpecInline(ctx, logger, &BuildTerminalSpecParams{
+		RunPath:       t.TempDir(),
+		CaptureFormat: "nope",
+	})
+	if !errors.Is(err, errdefs.ErrInvalidFlag) {
+		t.Fatalf("expected ErrInvalidFlag, got %v", err)
+	}
+}
+
+func TestGetDefaultHardcodedProfile(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+
+	doc, err := GetDefaultHardcodedProfile(ctx, logger, &BuildTerminalSpecParams{
+		TerminalCmd:     "/bin/dash",
+		TerminalCmdArgs: []string{"-i"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.Metadata.Name != "default" {
+		t.Fatalf("expected default name, got %q", doc.Metadata.Name)
+	}
+	if doc.Spec.Shell.Cmd != "/bin/dash" {
+		t.Fatalf("expected /bin/dash, got %q", doc.Spec.Shell.Cmd)
+	}
+	if !doc.Spec.Shell.EnvInherit {
+		t.Fatal("expected EnvInherit true in hardcoded default")
+	}
+}
+
+func TestCopyStringMapViaProfile(t *testing.T) {
+	// copyStringMap with a non-empty map runs through CreateTerminalFromProfile;
+	// an empty map returns nil.
+	withLabels := &api.TerminalProfileDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindTerminalProfile,
+		Metadata:   api.TerminalProfileMetadata{Name: "p", Labels: map[string]string{"a": "b"}},
+		Spec:       api.TerminalProfileSpec{Shell: api.ShellSpec{Cmd: "/bin/bash"}},
+	}
+	spec, err := CreateTerminalFromProfile(withLabels)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.Labels["a"] != "b" {
+		t.Fatalf("expected copied label, got %v", spec.Labels)
+	}
+
+	noLabels := &api.TerminalProfileDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindTerminalProfile,
+		Metadata:   api.TerminalProfileMetadata{Name: "p"},
+		Spec:       api.TerminalProfileSpec{Shell: api.ShellSpec{Cmd: "/bin/bash"}},
+	}
+	spec, err = CreateTerminalFromProfile(noLabels)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.Labels != nil {
+		t.Fatalf("expected nil labels for empty map, got %v", spec.Labels)
+	}
+}

--- a/pkg/discovery/profiles_extra_test.go
+++ b/pkg/discovery/profiles_extra_test.go
@@ -1,0 +1,139 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package discovery_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/sbsh/pkg/discovery"
+)
+
+func TestProfileWarning_String(t *testing.T) {
+	t.Parallel()
+
+	fileLevel := discovery.ProfileWarning{File: "/x/p.yaml", Reason: "open: denied"}
+	if got := fileLevel.String(); got != "/x/p.yaml: open: denied" {
+		t.Fatalf("file-level String() = %q", got)
+	}
+
+	docLevel := discovery.ProfileWarning{File: "/x/p.yaml", DocIndex: 3, Reason: "bad"}
+	if got := docLevel.String(); got != "/x/p.yaml (doc 3): bad" {
+		t.Fatalf("doc-level String() = %q", got)
+	}
+}
+
+func TestLoadProfilesFromReaderWithContext(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := testLogger()
+
+	t.Run("valid multi-doc", func(t *testing.T) {
+		t.Parallel()
+		profiles, err := discovery.LoadProfilesFromReaderWithContext(ctx, logger, strings.NewReader(multiDocProfiles))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(profiles) != 2 {
+			t.Fatalf("expected 2 profiles, got %d", len(profiles))
+		}
+	})
+
+	t.Run("skips empty/invalid doc", func(t *testing.T) {
+		t.Parallel()
+		profiles, err := discovery.LoadProfilesFromReaderWithContext(
+			ctx,
+			logger,
+			strings.NewReader(profilesWithEmptyDoc),
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// The incomplete middle document (no apiVersion/kind) is skipped.
+		if len(profiles) != 2 {
+			t.Fatalf("expected 2 valid profiles, got %d", len(profiles))
+		}
+	})
+
+	t.Run("malformed YAML returns error", func(t *testing.T) {
+		t.Parallel()
+		bad := "apiVersion: sbsh/v1beta1\nkind: TerminalProfile\n  oops:\n    -\n"
+		if _, err := discovery.LoadProfilesFromReaderWithContext(ctx, logger, strings.NewReader(bad)); err == nil {
+			t.Fatal("expected error for malformed YAML")
+		}
+	})
+}
+
+// TestValidateRequiredFields_Branches drives each rejection branch of the
+// (unexported) validateRequiredFields via LoadProfilesFromDir, asserting on
+// the warning Reason each one produces.
+func TestValidateRequiredFields_Branches(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	logger := testLogger()
+
+	cases := []struct {
+		name    string
+		yaml    string
+		wantSub string
+	}{
+		{
+			name:    "missing apiVersion",
+			yaml:    "kind: TerminalProfile\nmetadata:\n  name: x\n",
+			wantSub: "missing required apiVersion",
+		},
+		{
+			name:    "unsupported apiVersion",
+			yaml:    "apiVersion: sbsh/v2\nkind: TerminalProfile\nmetadata:\n  name: x\n",
+			wantSub: "unsupported apiVersion",
+		},
+		{
+			name:    "missing kind",
+			yaml:    "apiVersion: sbsh/v1beta1\nmetadata:\n  name: x\nspec: {}\n",
+			wantSub: "missing required kind",
+		},
+		{
+			name:    "unsupported kind",
+			yaml:    "apiVersion: sbsh/v1beta1\nkind: Widget\nmetadata:\n  name: x\n",
+			wantSub: "unsupported kind",
+		},
+		{
+			name:    "missing name",
+			yaml:    "apiVersion: sbsh/v1beta1\nkind: TerminalProfile\nspec:\n  runTarget: local\n",
+			wantSub: "missing required metadata.name",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			writeFile(t, dir, "p.yaml", tc.yaml)
+			profiles, warnings, err := discovery.LoadProfilesFromDir(ctx, logger, dir)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(profiles) != 0 {
+				t.Fatalf("expected no valid profiles, got %d", len(profiles))
+			}
+			if len(warnings) == 0 || !strings.Contains(warnings[0].Reason, tc.wantSub) {
+				t.Fatalf("expected warning containing %q, got %+v", tc.wantSub, warnings)
+			}
+		})
+	}
+}

--- a/pkg/spawn/lifecycle_test.go
+++ b/pkg/spawn/lifecycle_test.go
@@ -1,0 +1,290 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unix
+
+package spawn
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// sleeperBinary writes an executable shell script that sleeps regardless of
+// the argv the handle constructs (NewClient/NewTerminal append their own
+// attach/terminal args, so a real /bin/sleep would reject them and exit). It
+// stands in for a long-lived sb child whose control socket never appears.
+func sleeperBinary(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "sleeper.sh")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexec sleep 30\n"), 0o755); err != nil {
+		t.Fatalf("write sleeper: %v", err)
+	}
+	return path
+}
+
+// TestClientHandle_Close_NoSocketEscalates spawns a long-lived child whose
+// control socket never appears, so sendStopRPC's os.Stat fails and Close must
+// escalate through SIGTERM to reap the process.
+func TestClientHandle_Close_NoSocketEscalates(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	doc := validAttachDoc(tmp, filepath.Join(tmp, "c.sock"))
+
+	h, err := NewClient(context.Background(), doc, ClientOptions{
+		BinaryPath:      sleeperBinary(t),
+		StopGracePeriod: 150 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	// sendStopRPC against a missing socket should surface the stat error.
+	if statErr := h.sendStopRPC(context.Background()); statErr == nil {
+		t.Fatal("sendStopRPC: expected error for missing socket")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	start := time.Now()
+	_ = h.Close(ctx)
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("Close took %s; expected prompt escalation", elapsed)
+	}
+	if !h.proc.exited() {
+		t.Fatal("process still alive after Close")
+	}
+}
+
+// TestTerminalHandle_Close_NoSocketEscalates mirrors the client test on the
+// terminal handle.
+func TestTerminalHandle_Close_NoSocketEscalates(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	spec := &api.TerminalSpec{SocketFile: filepath.Join(tmp, "socket")}
+
+	h, err := NewTerminal(context.Background(), spec, TerminalOptions{
+		BinaryPath:      sleeperBinary(t),
+		StopGracePeriod: 150 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewTerminal: %v", err)
+	}
+
+	if statErr := h.sendStopRPC(context.Background()); statErr == nil {
+		t.Fatal("sendStopRPC: expected error for missing socket")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_ = h.Close(ctx)
+	if !h.proc.exited() {
+		t.Fatal("process still alive after Close")
+	}
+}
+
+// TestClientHandle_WaitReady_Timeout covers the ReadyTimeout path: the child
+// stays alive and never creates the socket, so WaitReady returns
+// ErrReadyTimeout once the internal cap elapses.
+func TestClientHandle_WaitReady_Timeout(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	doc := validAttachDoc(tmp, filepath.Join(tmp, "c.sock"))
+
+	h, err := NewClient(context.Background(), doc, ClientOptions{
+		BinaryPath:        sleeperBinary(t),
+		ReadyTimeout:      150 * time.Millisecond,
+		ReadyPollInterval: 20 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = h.Close(ctx)
+	}()
+
+	err = h.WaitReady(context.Background())
+	if !errors.Is(err, ErrReadyTimeout) {
+		t.Fatalf("WaitReady err = %v; want ErrReadyTimeout", err)
+	}
+}
+
+// TestTerminalHandle_WaitReady_Timeout mirrors the client timeout test.
+func TestTerminalHandle_WaitReady_Timeout(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	spec := &api.TerminalSpec{SocketFile: filepath.Join(tmp, "socket")}
+
+	h, err := NewTerminal(context.Background(), spec, TerminalOptions{
+		BinaryPath:        sleeperBinary(t),
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ReadyTimeout:      150 * time.Millisecond,
+		ReadyPollInterval: 20 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewTerminal: %v", err)
+	}
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = h.Close(ctx)
+	}()
+
+	err = h.WaitReady(context.Background())
+	if !errors.Is(err, ErrReadyTimeout) {
+		t.Fatalf("WaitReady err = %v; want ErrReadyTimeout", err)
+	}
+}
+
+// TestClientHandle_WaitClose_ContextCanceled covers the ctx cancellation leg
+// of WaitClose: the child stays alive, the caller's context expires.
+func TestClientHandle_WaitClose_ContextCanceled(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	doc := validAttachDoc(tmp, filepath.Join(tmp, "c.sock"))
+
+	h, err := NewClient(context.Background(), doc, ClientOptions{
+		BinaryPath: sleeperBinary(t),
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = h.Close(ctx)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if waitErr := h.WaitClose(ctx); !errors.Is(waitErr, context.DeadlineExceeded) {
+		t.Fatalf("WaitClose err = %v; want context.DeadlineExceeded", waitErr)
+	}
+}
+
+// TestSignal_AfterExitIsNoop covers process.signal's already-exited fast path.
+func TestSignal_AfterExitIsNoop(t *testing.T) {
+	t.Parallel()
+	cmd := exec.Command("/bin/true")
+	proc, err := startProcess(cmd, nil)
+	if err != nil {
+		t.Fatalf("startProcess: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if waitErr := proc.waitExit(ctx); waitErr != nil {
+		t.Fatalf("waitExit: %v", waitErr)
+	}
+	if sigErr := proc.signal(syscall.SIGTERM); sigErr != nil {
+		t.Fatalf("signal after exit = %v; want nil", sigErr)
+	}
+}
+
+// TestProcessPID_ZeroWhenUnstarted covers pid()'s nil-guard fast paths.
+func TestProcessPID_ZeroWhenUnstarted(t *testing.T) {
+	t.Parallel()
+	var nilProc *process
+	if got := nilProc.pid(); got != 0 {
+		t.Fatalf("nil process pid = %d; want 0", got)
+	}
+	if got := (&process{}).pid(); got != 0 {
+		t.Fatalf("process with nil cmd pid = %d; want 0", got)
+	}
+}
+
+// TestResolveStdio_ExplicitStreamsNotRedirected covers the else branches of
+// resolveStdio where the caller supplies its own streams (no /dev/null
+// fallback): NewClient is driven with concrete stdin/stdout/stderr.
+func TestResolveStdio_ExplicitStreamsNotRedirected(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	doc := validAttachDoc(tmp, filepath.Join(tmp, "c.sock"))
+
+	var out, errOut bytes.Buffer
+	h, err := NewClient(context.Background(), doc, ClientOptions{
+		BinaryPath: "/bin/true",
+		Stdin:      strings.NewReader(""),
+		Stdout:     &out,
+		Stderr:     &errOut,
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = h.WaitClose(ctx)
+}
+
+// TestGracefulShutdown_SIGKILLEscalation covers the final escalation step: the
+// child traps SIGTERM and ignores it, so gracefulShutdown must fall through to
+// SIGKILL to reap it.
+func TestGracefulShutdown_SIGKILLEscalation(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "trap.sh")
+	// Trap SIGTERM so the SIGTERM step times out and SIGKILL is required.
+	script := "#!/bin/sh\ntrap '' TERM\nwhile true; do sleep 1; done\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write trap script: %v", err)
+	}
+	cmd := exec.Command(path)
+	proc, err := startProcess(cmd, nil)
+	if err != nil {
+		t.Fatalf("startProcess: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_ = proc.gracefulShutdown(ctx, 200*time.Millisecond, nil)
+	if !proc.exited() {
+		t.Fatal("process still alive after SIGKILL escalation")
+	}
+}
+
+// TestGracefulShutdown_CtxCanceledMidWait covers the ctx.Err() early return:
+// the caller's context is already canceled when gracefulShutdown waits.
+func TestGracefulShutdown_CtxCanceledMidWait(t *testing.T) {
+	t.Parallel()
+	cmd := exec.Command("/bin/sleep", "30")
+	proc, err := startProcess(cmd, nil)
+	if err != nil {
+		t.Fatalf("startProcess: %v", err)
+	}
+	defer func() {
+		_ = proc.signal(syscall.SIGKILL)
+		_ = proc.waitExit(context.Background())
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already canceled
+
+	if shutdownErr := proc.gracefulShutdown(ctx, time.Second, nil); !errors.Is(shutdownErr, context.Canceled) {
+		t.Fatalf("gracefulShutdown err = %v; want context.Canceled", shutdownErr)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 5 of umbrella #304 — supporting internals. Raises statement coverage for the five supporting-internal packages to ≥80% with test-only additions (no production code touched), plus the opportunistic `internal/pidutil` fold-in the issue invited.

| Package | Before | After |
| --- | --- | --- |
| `internal/discovery` | 22.7% | **81.9%** |
| `internal/profile` | 59.4% | **90.0%** |
| `pkg/spawn` | 70.4% | **81.5%** |
| `pkg/discovery` | 71.8% | **86.4%** |
| `internal/capture` | 77.0% | **83.5%** |
| `internal/pidutil` (opportunistic) | 77.3% | **90.9%** |

Coverage targets the AC's named areas — discovery enumeration/error paths, profile resolution/validation, and spawn error handling:

- **internal/discovery** (`print_test.go`): the `ScanAndPrint{Terminals,Clients,Profiles}` table/json/yaml/unknown-format paths, `FindAndPrint*Metadata` found/not-found legs, `Find{Terminal,Client}By{ID,Name}`, `PrintTerminalSpec` (nil + fully populated), the `LoadProfiles*` / `FindProfileByNameInDir` wrappers, `PrintProfileWarnings` (nil-writer + multi-line), and the reflection-based `PrintHuman` across structs/maps/slices/pointers/nil/empty-string.
- **internal/profile** (`build_test.go`): the full `BuildTerminalSpecFromProfile` flow (named-profile load, empty-name → hardcoded-default fallback, missing-non-default error, mode/gid/capture-format overrides, invalid-format + invalid-mode errors), `BuildTerminalSpecInline` (full overlay path, `StagesOverlay` precedence, invalid-format error), `GetDefaultHardcodedProfile`, and `copyStringMap` both legs.
- **pkg/spawn** (`lifecycle_test.go`): `Close`/`sendStopRPC` on both `ClientHandle` and `TerminalHandle` (socket-absent → signal escalation), `WaitReady` ready-timeout, `WaitClose` ctx-canceled, `process.signal` after-exit no-op, `pid()` nil guards, `resolveStdio` explicit-stream branches, and `gracefulShutdown` SIGKILL escalation (SIGTERM-trapping child) + ctx-canceled early return.
- **pkg/discovery** (`profiles_extra_test.go`): `ProfileWarning.String` (file- and doc-level), `LoadProfilesFromReaderWithContext` (valid/skip-empty/malformed), and every `validateRequiredFields` rejection branch driven through `LoadProfilesFromDir`.
- **internal/capture** (`errors_test.go`): `CompressSegment` open-raw failure, and the gzip-open error branch in `readSegment`/`dumpOne`/`Replay` via a corrupt `.gz` segment.
- **internal/pidutil** (`pidutil_extra_test.go`): `Match`'s got==0 (non-positive PID with a recorded token) and reader-error (dead PID) branches.

## Notes for the reviewer

- **Single PR across all five packages.** Same shape as the merged sibling phases (#307/#322 landed three client-runtime packages test-only in one PR). Each test is independently auditable and the additions are test-only, so I judged it one reviewable unit. Happy to split if you'd prefer.
- **`internal/pidutil` folded in** per the issue's "fold pidutil in opportunistically if cheap" note — it was a two-branch add (`pidutil_extra_test.go`).
- A few `EncodeHeader`/`EncodeOutputEvent` `json.Marshal`-failure branches and some `ReadAll`/`gracefulShutdown` mid-listing-prune races remain uncovered (unreachable or non-deterministic to trigger portably); every listed package still clears 80% on the reachable branches.
- `pkg/spawn` tests use a temp `sleeper.sh` helper because `NewClient`/`NewTerminal` construct their own argv — a real `/bin/sleep` would reject the appended attach/terminal args and exit non-zero.

## Test plan

- [x] `make sbsh-sb` (ELF verified via `file ./sbsh`)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test` on all six affected packages (coverage table above)
- [x] `go test $(go list ./... | grep -v '/e2e$')` (full non-e2e suite — green)
- [x] `make test` (named CI target, includes e2e — green)
- [x] `pre-commit run --files <changed>` (golangci-lint + go fmt — green)

Part of #304.

Closes #309