### PR TITLE
test: skip e2e on missing binaries and cover full lifecycle flow

### DIFF
--- a/e2e/e2e_lifecycle_test.go
+++ b/e2e/e2e_lifecycle_test.go
@@ -1,0 +1,148 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e_test
+
+import (
+	"bytes"
+	"os"
+	"regexp"
+	"testing"
+	"time"
+)
+
+// TestLifecycle_SpawnAttachWriteReadDetachStop drives the full core flow end
+// to end through the real CLI: a terminal is spawned under sbsh, a second
+// client attaches with `sb attach`, a command is injected with `sb write` and
+// read back via both `sb read` and the live attach stream, the attach client
+// detaches with the ^]^] keystroke, and the terminal is stopped gracefully
+// with `sb stop`.
+func TestLifecycle_SpawnAttachWriteReadDetachStop(t *testing.T) {
+	requireBinaries(t, sb, sbsh)
+
+	runPath := newRunPath(t)
+	runPathEnv := buildSbRunPathEnv(t, runPath)
+	termName := "e2e-lifecycle"
+
+	t.Cleanup(func() {
+		runReturningBinary(t, []string{runPathEnv}, sb, "prune", "terminals", "--verbose", "--log-level", "debug")
+		runReturningBinary(t, []string{runPathEnv}, sb, "prune", "clients", "--verbose", "--log-level", "debug")
+	})
+
+	// --- spawn: boot an interactive shell under sbsh and wait for its prompt.
+	ptmx, pts := setupPty(t)
+	defer func() { _ = ptmx.Close() }()
+
+	pipeLogR, pipeLogW, _ := os.Pipe()
+	defer pipeLogR.Close()
+	defer pipeLogW.Close()
+	multiW := setupMultiWriter(t, ptmx, pipeLogW)
+	go logTerminal(t, pipeLogR)
+
+	pipeExpectR, pipeExpectW, _ := os.Pipe()
+	defer pipeExpectR.Close()
+	defer pipeExpectW.Close()
+	promptCh := setupPromptDetector(t, pipeExpectR, regexp.MustCompile(`\(sbsh-[^)]+\)`))
+	multiW.Add(pipeExpectW)
+
+	retSpawn := make(chan error, 1)
+	spawnEnv := append([]string{}, getRandomSbshRunPath(t, runPath))
+	runPersistentBinaryPty(t, pts, cmdWaitFunc(t, &retSpawn), spawnEnv, sbsh, "--terminal-name", termName)
+
+	select {
+	case <-promptCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for sbsh prompt (spawn)")
+	}
+	multiW.Remove(pipeExpectW)
+	time.Sleep(200 * time.Millisecond)
+
+	// --- attach: a second client connects via `sb attach`. On connect it
+	// repaints the current screen, which carries the sbsh prompt — detecting
+	// it confirms the attach client is wired to the controller's fan-out.
+	ptmxA, ptsA := setupPty(t)
+	defer func() { _ = ptmxA.Close() }()
+
+	pipeLogRA, pipeLogWA, _ := os.Pipe()
+	defer pipeLogRA.Close()
+	defer pipeLogWA.Close()
+	multiWA := setupMultiWriter(t, ptmxA, pipeLogWA)
+	go logTerminal(t, pipeLogRA)
+
+	pipeExpectRA, pipeExpectWA, _ := os.Pipe()
+	defer pipeExpectRA.Close()
+	defer pipeExpectWA.Close()
+	attachPromptCh := setupPromptDetector(t, pipeExpectRA, regexp.MustCompile(`\(sbsh-[^)]+\)`))
+	multiWA.Add(pipeExpectWA)
+
+	retAttach := make(chan error, 1)
+	runPersistentBinaryPty(t, ptsA, cmdWaitFunc(t, &retAttach), []string{runPathEnv}, sb, "attach", termName)
+
+	select {
+	case <-attachPromptCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for sb attach to repaint the prompt")
+	}
+	multiWA.Remove(pipeExpectWA)
+	time.Sleep(200 * time.Millisecond)
+
+	// --- write/read: inject a command, confirm it round-trips through the
+	// capture file (`sb read`) and the live attach stream.
+	const marker = "e2e-lifecycle-marker"
+	pipeMarkerRA, pipeMarkerWA, _ := os.Pipe()
+	defer pipeMarkerRA.Close()
+	defer pipeMarkerWA.Close()
+	attachMarkerCh := setupPromptDetector(t, pipeMarkerRA, regexp.MustCompile(regexp.QuoteMeta(marker)))
+	multiWA.Add(pipeMarkerWA)
+
+	runSilentBinary(t, []string{runPathEnv}, sb, "write", termName, "echo "+marker+"^M")
+	time.Sleep(500 * time.Millisecond)
+
+	out := runReturningBinary(t, []string{runPathEnv}, sb, "read", termName)
+	if !bytes.Contains(out, []byte(marker)) {
+		t.Fatalf("sb read output missing marker %q; got:\n%s", marker, string(out))
+	}
+
+	select {
+	case <-attachMarkerCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("attach client never observed the live command output")
+	}
+	multiWA.Remove(pipeMarkerWA)
+
+	// --- detach: the ^]^] keystroke detaches the attach client; the sb
+	// attach process should exit while the terminal keeps running.
+	if _, err := ptmxA.WriteString("\x1d\x1d"); err != nil {
+		t.Logf("could not send detach keystroke: %v", err)
+	}
+	select {
+	case <-retAttach:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for sb attach to detach and exit")
+	}
+
+	// --- stop: graceful stop of the terminal controller. The spawning sbsh
+	// is the recorded process, so it exits once the Stop RPC lands.
+	stopOut := runReturningBinary(t, []string{runPathEnv}, sb, "stop", "terminal", termName)
+	if !bytes.Contains(stopOut, []byte("stopped")) {
+		t.Fatalf("sb stop did not report the terminal stopped; got:\n%s", string(stopOut))
+	}
+	select {
+	case <-retSpawn:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for the terminal controller to exit after stop")
+	}
+}

--- a/e2e/e2e_sb_write_read_test.go
+++ b/e2e/e2e_sb_write_read_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"regexp"
 	"testing"
 	"time"
@@ -32,6 +31,7 @@ import (
 // command's output appears in both the capture file (`sb read`) and the
 // live stream (`sb read -f`).
 func TestSb_WriteRead_Roundtrip(t *testing.T) {
+	requireBinaries(t, sb, sbsh)
 	runPath := newRunPath(t)
 
 	termName := "e2e-writeread"
@@ -128,14 +128,7 @@ func TestSb_Write_CaretParsingErrors(t *testing.T) {
 // output (e.g. `sb write`, which is quiet on success).
 func runSilentBinary(t *testing.T, env []string, command string, args ...string) {
 	t.Helper()
-	dir := os.Getenv("E2E_BIN_DIR")
-	if dir == "" {
-		dir = ".."
-	}
-	bin := filepath.Join(dir, command)
-	if _, err := os.Stat(bin); os.IsNotExist(err) {
-		t.Fatalf("binary %s not found", bin)
-	}
+	bin := resolveBinary(t, command)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, bin, args...)
@@ -152,14 +145,7 @@ func runSilentBinary(t *testing.T, env []string, command string, args ...string)
 // instead of failing the test when the binary exits non-zero.
 func runExpectingFailure(t *testing.T, env []string, command string, args ...string) error {
 	t.Helper()
-	dir := os.Getenv("E2E_BIN_DIR")
-	if dir == "" {
-		dir = ".."
-	}
-	bin := filepath.Join(dir, command)
-	if _, err := os.Stat(bin); os.IsNotExist(err) {
-		t.Fatalf("binary %s not found", bin)
-	}
+	bin := resolveBinary(t, command)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, bin, args...)

--- a/e2e/e2e_sbsh_test.go
+++ b/e2e/e2e_sbsh_test.go
@@ -33,6 +33,7 @@ func TestSbsh_Help(t *testing.T) {
 }
 
 func TestSbsh_Default(t *testing.T) {
+	requireBinaries(t, sb, sbsh)
 	runPath := newRunPath(t)
 
 	t.Cleanup(func() {
@@ -110,6 +111,7 @@ func TestSbsh_Default(t *testing.T) {
 }
 
 func TestSbsh_CustomId(t *testing.T) {
+	requireBinaries(t, sb, sbsh)
 	runPath := newRunPath(t)
 
 	t.Cleanup(func() {
@@ -187,6 +189,7 @@ func TestSbsh_CustomId(t *testing.T) {
 }
 
 func TestSbsh_Detach(t *testing.T) {
+	requireBinaries(t, sb, sbsh)
 	runPath := newRunPath(t)
 
 	t.Cleanup(func() {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -35,9 +35,12 @@ const (
 	sb   = "sb"
 )
 
-// runReturningBinary runs the provided binary with args, fails the test on non-zero exit or empty output.
-// If the binary file does not exist, the test is skipped.
-func runReturningBinary(t *testing.T, env []string, command string, args ...string) []byte {
+// resolveBinary returns the absolute path to the named binary under
+// E2E_BIN_DIR (defaulting to the repo root). When the binary has not been
+// built it skips the calling test rather than failing it: a clean checkout
+// has no binaries, and `go test ./...` must stay green there. Build with
+// `make sbsh-sb` (produces sbsh and hardlinks sb) to run the suite for real.
+func resolveBinary(t *testing.T, command string) string {
 	t.Helper()
 
 	dir := os.Getenv("E2E_BIN_DIR")
@@ -47,8 +50,27 @@ func runReturningBinary(t *testing.T, env []string, command string, args ...stri
 	bin := filepath.Join(dir, command)
 
 	if _, err := os.Stat(bin); os.IsNotExist(err) {
-		t.Fatalf("binary %s not found, skipping", bin)
+		t.Skipf("binary %s not built; run `make sbsh-sb` to enable e2e (skipping)", bin)
 	}
+	return bin
+}
+
+// requireBinaries skips the calling test unless every named binary is built.
+// Call it before registering cleanups that shell out to a binary, so a clean
+// checkout skips up front instead of triggering a skip from within a cleanup.
+func requireBinaries(t *testing.T, commands ...string) {
+	t.Helper()
+	for _, command := range commands {
+		_ = resolveBinary(t, command)
+	}
+}
+
+// runReturningBinary runs the provided binary with args, fails the test on non-zero exit or empty output.
+// If the binary file does not exist, the test is skipped.
+func runReturningBinary(t *testing.T, env []string, command string, args ...string) []byte {
+	t.Helper()
+
+	bin := resolveBinary(t, command)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
@@ -79,15 +101,7 @@ func runPersistentBinaryPty(
 ) {
 	t.Helper()
 
-	dir := os.Getenv("E2E_BIN_DIR")
-	if dir == "" {
-		dir = ".." // or detect repo root
-	}
-	bin := filepath.Join(dir, command)
-
-	if _, err := os.Stat(bin); os.IsNotExist(err) {
-		t.Fatalf("binary %s not found, skipping", bin)
-	}
+	bin := resolveBinary(t, command)
 
 	env = append(env,
 		`PS1="__P__ "`,


### PR DESCRIPTION
## Summary
- The `e2e` package `t.Fatal`'d when the `sb`/`sbsh` binaries weren't built, making `go test ./...` red on a clean checkout and masking real e2e results. The four harness helpers (`runReturningBinary`, `runPersistentBinaryPty`, `runSilentBinary`, `runExpectingFailure`) now resolve the binary through a shared `resolveBinary` helper that `t.Skip`s when the binary is absent.
- Added `requireBinaries(t, ...)` as the first line of the four tests that register prune cleanups, so a clean checkout skips *before* a binary-using cleanup is registered (a `t.Skip` from within a cleanup is unsafe).
- Added `TestLifecycle_SpawnAttachWriteReadDetachStop` exercising the full core flow end-to-end through the real CLI: spawn under `sbsh` → `sb attach` (second client) → `sb write`/`sb read` (verified via both the capture file and the live attach stream) → `^]^]` detach → `sb stop` graceful stop (verified by the controller process exiting).

## Notes
- CI's unit job already excludes `/e2e` (`go list ./... | grep -v '/e2e$'`) and the e2e job builds binaries first, so CI was green; the failure surfaced only on a developer's local `go test ./...`. AC#4 ("green on a clean checkout") is about that local path, which this fixes.
- `sb attach` and `sb stop terminal` are driven with the existing PTY harness; the lifecycle test reuses `runPersistentBinaryPty`/`setupPromptDetector` rather than introducing new infrastructure.

## Test plan
- [x] `go test ./e2e/...` with binaries absent → all 9 tests SKIP cleanly, suite `ok` (simulated via `E2E_BIN_DIR=/tmp/empty`)
- [x] `make e2e` (binaries built) → all tests PASS, including the new lifecycle test; stable across repeated runs
- [x] `go test ./...` green on a simulated clean checkout (no binaries → e2e skips)
- [x] `make sbsh-sb` produces an ELF executable (verified via ELF magic; `file` not installed on host)
- [x] `go build ./...`, `go vet ./...`
- [x] Unit tests `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` and integration `go test -tags=integration ./cmd/sb/get/...`
- [x] `pre-commit run --files <changed>` (golangci-lint, go fmt, addlicense, etc.) passes

Closes #311