### PR TITLE
test: phase 4a — terminalrpc coverage (≥80%)

### DIFF
--- a/internal/terminal/terminalrpc/codec_test.go
+++ b/internal/terminal/terminalrpc/codec_test.go
@@ -17,6 +17,7 @@
 package terminalrpc
 
 import (
+	"encoding/json"
 	"io"
 	"log/slog"
 	"net"
@@ -24,8 +25,257 @@ import (
 	"os"
 	"testing"
 
+	"github.com/eminwux/sbsh/pkg/api"
 	"golang.org/x/sys/unix"
 )
+
+func newTestCodec(t *testing.T, srv *net.UnixConn) *unixJSONServerCodec {
+	t.Helper()
+	return NewUnixJSONServerCodec(srv, slog.New(slog.NewTextHandler(io.Discard, nil))).(*unixJSONServerCodec)
+}
+
+// readWireResponse reads one JSON object the codec wrote to the client side.
+func readWireResponse(t *testing.T, cli *net.UnixConn) struct {
+	ID     any             `json:"id"`
+	Result json.RawMessage `json:"result"`
+	Error  any             `json:"error"`
+} {
+	t.Helper()
+	var resp struct {
+		ID     any             `json:"id"`
+		Result json.RawMessage `json:"result"`
+		Error  any             `json:"error"`
+	}
+	if err := json.NewDecoder(cli).Decode(&resp); err != nil {
+		t.Fatalf("decode wire response: %v", err)
+	}
+	return resp
+}
+
+// TestReadRequestHeader_DecodeError covers the decode-failure branch: a
+// truncated/garbage frame must surface the decoder error rather than route a
+// bogus request.
+func TestReadRequestHeader_DecodeError(t *testing.T) {
+	cli, srv := mustSocketpair(t)
+	defer cli.Close()
+	defer srv.Close()
+
+	codec := newTestCodec(t, srv)
+	mustWriteJSON(t, cli, `not-json`)
+	_ = cli.Close()
+
+	var r rpc.Request
+	if err := codec.ReadRequestHeader(&r); err == nil {
+		t.Fatal("ReadRequestHeader: want decode error, got nil")
+	}
+}
+
+// TestWriteResponse_NormalResolvesWireID drives a request through the header
+// reader so WriteResponse can resolve the original wire id, then asserts the
+// response carries that id and the encoded result.
+func TestWriteResponse_NormalResolvesWireID(t *testing.T) {
+	cli, srv := mustSocketpair(t)
+	defer cli.Close()
+	defer srv.Close()
+
+	codec := newTestCodec(t, srv)
+	mustWriteJSON(t, cli, `{"id":7,"method":"Svc.M","params":[{}]}`)
+
+	var req rpc.Request
+	if err := codec.ReadRequestHeader(&req); err != nil {
+		t.Fatalf("ReadRequestHeader: %v", err)
+	}
+
+	body := struct {
+		Message string `json:"Message"`
+	}{Message: "ok"}
+	resp := &rpc.Response{ServiceMethod: "Svc.M", Seq: req.Seq}
+	if err := codec.WriteResponse(resp, &body); err != nil {
+		t.Fatalf("WriteResponse: %v", err)
+	}
+
+	wire := readWireResponse(t, cli)
+	if id, ok := wire.ID.(float64); !ok || id != 7 {
+		t.Fatalf("wire id = %v; want 7", wire.ID)
+	}
+	if wire.Error != nil {
+		t.Fatalf("wire error = %v; want nil", wire.Error)
+	}
+}
+
+// TestWriteResponse_ErrorSetsErrorField asserts a non-empty resp.Error yields
+// the jsonrpc error shape: null result, error string set.
+func TestWriteResponse_ErrorSetsErrorField(t *testing.T) {
+	cli, srv := mustSocketpair(t)
+	defer cli.Close()
+	defer srv.Close()
+
+	codec := newTestCodec(t, srv)
+	mustWriteJSON(t, cli, `{"id":"abc","method":"Svc.M","params":[{}]}`)
+
+	var req rpc.Request
+	if err := codec.ReadRequestHeader(&req); err != nil {
+		t.Fatalf("ReadRequestHeader: %v", err)
+	}
+
+	resp := &rpc.Response{ServiceMethod: "Svc.M", Seq: req.Seq, Error: "boom"}
+	if err := codec.WriteResponse(resp, struct{}{}); err != nil {
+		t.Fatalf("WriteResponse: %v", err)
+	}
+
+	wire := readWireResponse(t, cli)
+	if wire.ID != "abc" {
+		t.Fatalf("wire id = %v; want abc", wire.ID)
+	}
+	if string(wire.Result) != "null" {
+		t.Fatalf("wire result = %s; want null", wire.Result)
+	}
+	if wire.Error != "boom" {
+		t.Fatalf("wire error = %v; want boom", wire.Error)
+	}
+}
+
+// TestWriteResponse_UnknownSeqFallsBackToServerSeq covers the !hasID branch:
+// when no wire id was stashed for the seq, the server seq is used as the id.
+func TestWriteResponse_UnknownSeqFallsBackToServerSeq(t *testing.T) {
+	cli, srv := mustSocketpair(t)
+	defer cli.Close()
+	defer srv.Close()
+
+	codec := newTestCodec(t, srv)
+	resp := &rpc.Response{ServiceMethod: "Svc.M", Seq: 42}
+	if err := codec.WriteResponse(resp, struct{}{}); err != nil {
+		t.Fatalf("WriteResponse: %v", err)
+	}
+
+	wire := readWireResponse(t, cli)
+	if id, ok := wire.ID.(float64); !ok || id != 42 {
+		t.Fatalf("wire id = %v; want 42 (server-seq fallback)", wire.ID)
+	}
+}
+
+// TestWriteResponse_EncodeError covers the marshal-failure branch: an
+// unencodable body (a channel) makes the JSON encoder fail and the error
+// propagates out.
+func TestWriteResponse_EncodeError(t *testing.T) {
+	cli, srv := mustSocketpair(t)
+	defer cli.Close()
+	defer srv.Close()
+
+	codec := newTestCodec(t, srv)
+	resp := &rpc.Response{ServiceMethod: "Svc.M", Seq: 1}
+	if err := codec.WriteResponse(resp, make(chan int)); err == nil {
+		t.Fatal("WriteResponse: want encode error for unencodable body, got nil")
+	}
+}
+
+// TestWriteResponse_FDPassing covers the SCM_RIGHTS path: a *ResponseWithFD
+// with a live fd is sent via WriteMsgUnix, the received message carries both
+// the JSON payload and a dup'd fd, and the codec clears r.FDs so a retry can't
+// double-close.
+func TestWriteResponse_FDPassing(t *testing.T) {
+	cli, srv := mustSocketpair(t)
+	defer cli.Close()
+	defer srv.Close()
+
+	codec := newTestCodec(t, srv)
+	mustWriteJSON(t, cli, `{"id":3,"method":"Svc.Attach","params":[{}]}`)
+	var req rpc.Request
+	if err := codec.ReadRequestHeader(&req); err != nil {
+		t.Fatalf("ReadRequestHeader: %v", err)
+	}
+
+	// A throwaway pipe gives us a real fd to pass.
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer pr.Close()
+	defer pw.Close()
+
+	r := &api.ResponseWithFD{JSON: map[string]string{"k": "v"}, FDs: []int{int(pr.Fd())}}
+	resp := &rpc.Response{ServiceMethod: "Svc.Attach", Seq: req.Seq}
+	if err := codec.WriteResponse(resp, r); err != nil {
+		t.Fatalf("WriteResponse: %v", err)
+	}
+	if r.FDs != nil {
+		t.Fatalf("r.FDs = %v; want nil after send", r.FDs)
+	}
+
+	buf := make([]byte, 4096)
+	oob := make([]byte, 256)
+	n, oobn, _, _, err := cli.ReadMsgUnix(buf, oob)
+	if err != nil {
+		t.Fatalf("ReadMsgUnix: %v", err)
+	}
+	if oobn == 0 {
+		t.Fatal("ReadMsgUnix: no OOB data; want passed fd")
+	}
+	scms, err := unix.ParseSocketControlMessage(oob[:oobn])
+	if err != nil {
+		t.Fatalf("ParseSocketControlMessage: %v", err)
+	}
+	fds, err := unix.ParseUnixRights(&scms[0])
+	if err != nil {
+		t.Fatalf("ParseUnixRights: %v", err)
+	}
+	for _, fd := range fds {
+		_ = unix.Close(fd)
+	}
+	if len(fds) != 1 {
+		t.Fatalf("received %d fds; want 1", len(fds))
+	}
+
+	var wire struct {
+		ID     any             `json:"id"`
+		Result json.RawMessage `json:"result"`
+	}
+	if err := json.Unmarshal(buf[:n], &wire); err != nil {
+		t.Fatalf("unmarshal fd-path payload: %v", err)
+	}
+	if id, ok := wire.ID.(float64); !ok || id != 3 {
+		t.Fatalf("wire id = %v; want 3", wire.ID)
+	}
+	if string(wire.Result) != `{"k":"v"}` {
+		t.Fatalf("wire result = %s; want {\"k\":\"v\"}", wire.Result)
+	}
+}
+
+// TestWriteResponse_FDPassingEncodeError covers the encode-failure branch
+// inside the FD path: an unencodable JSON payload makes the encoder fail, and
+// the deferred fd-close still runs (no leak, no double-close).
+func TestWriteResponse_FDPassingEncodeError(t *testing.T) {
+	cli, srv := mustSocketpair(t)
+	defer cli.Close()
+	defer srv.Close()
+
+	codec := newTestCodec(t, srv)
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer pr.Close()
+	defer pw.Close()
+
+	r := &api.ResponseWithFD{JSON: make(chan int), FDs: []int{int(pr.Fd())}}
+	resp := &rpc.Response{ServiceMethod: "Svc.Attach", Seq: 1}
+	if err := codec.WriteResponse(resp, r); err == nil {
+		t.Fatal("WriteResponse: want encode error for unencodable FD payload, got nil")
+	}
+	if r.FDs != nil {
+		t.Fatalf("r.FDs = %v; want nil even on encode error", r.FDs)
+	}
+}
+
+func TestCodecClose(t *testing.T) {
+	cli, srv := mustSocketpair(t)
+	defer cli.Close()
+
+	codec := newTestCodec(t, srv)
+	if err := codec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
 
 // TestReadRequestBody_NilDoesNotCrossTalk drives the codec through the same
 // header/body sequence net/rpc uses when it sees an unknown method: read the

--- a/internal/terminal/terminalrpc/rpc_server_test.go
+++ b/internal/terminal/terminalrpc/rpc_server_test.go
@@ -1,0 +1,250 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrpc
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+var errCore = errors.New("core failure")
+
+// fakeController is a configurable api.TerminalController stub. Each method
+// records its argument and returns the preconfigured value/error so the thin
+// TerminalControllerRPC wrappers can be exercised on both their success and
+// error branches without a live runtime.
+type fakeController struct {
+	pingResp   *api.PingMessage
+	pingErr    error
+	resizeArgs api.ResizeArgs
+	detachID   *api.ID
+	detachErr  error
+	attachErr  error
+	metadata   *api.TerminalDoc
+	metaErr    error
+	state      *api.TerminalStatusMode
+	stateErr   error
+	stopArgs   *api.StopArgs
+	stopErr    error
+	writeReq   *api.WriteRequest
+	writeErr   error
+	subErr     error
+	shotResult *api.ScreenshotResult
+	shotErr    error
+}
+
+func (f *fakeController) Run(*api.TerminalSpec) error { return nil }
+func (f *fakeController) WaitReady() error            { return nil }
+func (f *fakeController) WaitClose() error            { return nil }
+func (f *fakeController) Close(error) error           { return nil }
+
+func (f *fakeController) Ping(*api.PingMessage) (*api.PingMessage, error) {
+	return f.pingResp, f.pingErr
+}
+
+func (f *fakeController) Resize(args api.ResizeArgs) { f.resizeArgs = args }
+
+func (f *fakeController) Detach(id *api.ID) error {
+	f.detachID = id
+	return f.detachErr
+}
+
+func (f *fakeController) Attach(*api.AttachRequest, *api.ResponseWithFD) error {
+	return f.attachErr
+}
+
+func (f *fakeController) Metadata() (*api.TerminalDoc, error) {
+	return f.metadata, f.metaErr
+}
+
+func (f *fakeController) State() (*api.TerminalStatusMode, error) {
+	return f.state, f.stateErr
+}
+
+func (f *fakeController) Stop(args *api.StopArgs) error {
+	f.stopArgs = args
+	return f.stopErr
+}
+
+func (f *fakeController) Write(req *api.WriteRequest) error {
+	f.writeReq = req
+	return f.writeErr
+}
+
+func (f *fakeController) Subscribe(*api.SubscribeRequest, *api.ResponseWithFD) error {
+	return f.subErr
+}
+
+func (f *fakeController) Screenshot(*api.ScreenshotArgs) (*api.ScreenshotResult, error) {
+	return f.shotResult, f.shotErr
+}
+
+func TestPing_CopiesPongOnSuccess(t *testing.T) {
+	core := &fakeController{pingResp: &api.PingMessage{Message: "pong"}}
+	s := &TerminalControllerRPC{Core: core}
+	var out api.PingMessage
+	if err := s.Ping(&api.PingMessage{Message: "ping"}, &out); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	if out.Message != "pong" {
+		t.Fatalf("out.Message = %q; want pong", out.Message)
+	}
+}
+
+func TestPing_PropagatesError(t *testing.T) {
+	s := &TerminalControllerRPC{Core: &fakeController{pingErr: errCore}}
+	var out api.PingMessage
+	if err := s.Ping(&api.PingMessage{}, &out); !errors.Is(err, errCore) {
+		t.Fatalf("Ping err = %v; want errCore", err)
+	}
+}
+
+func TestResize_DelegatesArgs(t *testing.T) {
+	core := &fakeController{}
+	s := &TerminalControllerRPC{Core: core}
+	if err := s.Resize(api.ResizeArgs{Cols: 80, Rows: 24}, &api.Empty{}); err != nil {
+		t.Fatalf("Resize: %v", err)
+	}
+	if core.resizeArgs.Cols != 80 || core.resizeArgs.Rows != 24 {
+		t.Fatalf("resizeArgs = %+v; want {80 24}", core.resizeArgs)
+	}
+}
+
+func TestDetach_Delegates(t *testing.T) {
+	core := &fakeController{}
+	s := &TerminalControllerRPC{Core: core}
+	id := api.ID("term-1")
+	if err := s.Detach(&id, &api.Empty{}); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+	if core.detachID == nil || *core.detachID != id {
+		t.Fatalf("detachID = %v; want %v", core.detachID, id)
+	}
+
+	s2 := &TerminalControllerRPC{Core: &fakeController{detachErr: errCore}}
+	if err := s2.Detach(&id, &api.Empty{}); !errors.Is(err, errCore) {
+		t.Fatalf("Detach err = %v; want errCore", err)
+	}
+}
+
+func TestAttach_Delegates(t *testing.T) {
+	s := &TerminalControllerRPC{Core: &fakeController{}}
+	if err := s.Attach(&api.AttachRequest{}, &api.ResponseWithFD{}); err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	s2 := &TerminalControllerRPC{Core: &fakeController{attachErr: errCore}}
+	if err := s2.Attach(&api.AttachRequest{}, &api.ResponseWithFD{}); !errors.Is(err, errCore) {
+		t.Fatalf("Attach err = %v; want errCore", err)
+	}
+}
+
+func TestMetadata_CopiesDocOnSuccess(t *testing.T) {
+	core := &fakeController{metadata: &api.TerminalDoc{Kind: api.Kind("Terminal")}}
+	s := &TerminalControllerRPC{Core: core}
+	var out api.TerminalDoc
+	if err := s.Metadata(api.Empty{}, &out); err != nil {
+		t.Fatalf("Metadata: %v", err)
+	}
+	if out.Kind != api.Kind("Terminal") {
+		t.Fatalf("out.Kind = %q; want Terminal", out.Kind)
+	}
+
+	s2 := &TerminalControllerRPC{Core: &fakeController{metaErr: errCore}}
+	if err := s2.Metadata(api.Empty{}, &out); !errors.Is(err, errCore) {
+		t.Fatalf("Metadata err = %v; want errCore", err)
+	}
+}
+
+func TestState_CopiesStateOnSuccess(t *testing.T) {
+	want := api.Ready
+	core := &fakeController{state: &want}
+	s := &TerminalControllerRPC{Core: core}
+	var out api.TerminalStatusMode
+	if err := s.State(api.Empty{}, &out); err != nil {
+		t.Fatalf("State: %v", err)
+	}
+	if out != api.Ready {
+		t.Fatalf("out = %v; want Ready", out)
+	}
+
+	s2 := &TerminalControllerRPC{Core: &fakeController{stateErr: errCore}}
+	if err := s2.State(api.Empty{}, &out); !errors.Is(err, errCore) {
+		t.Fatalf("State err = %v; want errCore", err)
+	}
+}
+
+func TestStop_Delegates(t *testing.T) {
+	core := &fakeController{}
+	s := &TerminalControllerRPC{Core: core}
+	if err := s.Stop(&api.StopArgs{Reason: "bye"}, &api.Empty{}); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if core.stopArgs == nil || core.stopArgs.Reason != "bye" {
+		t.Fatalf("stopArgs = %+v; want reason bye", core.stopArgs)
+	}
+
+	s2 := &TerminalControllerRPC{Core: &fakeController{stopErr: errCore}}
+	if err := s2.Stop(&api.StopArgs{}, &api.Empty{}); !errors.Is(err, errCore) {
+		t.Fatalf("Stop err = %v; want errCore", err)
+	}
+}
+
+func TestWrite_Delegates(t *testing.T) {
+	core := &fakeController{}
+	s := &TerminalControllerRPC{Core: core}
+	if err := s.Write(&api.WriteRequest{Data: []byte("hi")}, &api.Empty{}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if core.writeReq == nil || string(core.writeReq.Data) != "hi" {
+		t.Fatalf("writeReq = %+v; want data hi", core.writeReq)
+	}
+
+	s2 := &TerminalControllerRPC{Core: &fakeController{writeErr: errCore}}
+	if err := s2.Write(&api.WriteRequest{}, &api.Empty{}); !errors.Is(err, errCore) {
+		t.Fatalf("Write err = %v; want errCore", err)
+	}
+}
+
+func TestSubscribe_Delegates(t *testing.T) {
+	s := &TerminalControllerRPC{Core: &fakeController{}}
+	if err := s.Subscribe(&api.SubscribeRequest{}, &api.ResponseWithFD{}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	s2 := &TerminalControllerRPC{Core: &fakeController{subErr: errCore}}
+	if err := s2.Subscribe(&api.SubscribeRequest{}, &api.ResponseWithFD{}); !errors.Is(err, errCore) {
+		t.Fatalf("Subscribe err = %v; want errCore", err)
+	}
+}
+
+func TestScreenshot_CopiesResultOnSuccess(t *testing.T) {
+	core := &fakeController{shotResult: &api.ScreenshotResult{Cols: 80, Rows: 24, Text: "grid"}}
+	s := &TerminalControllerRPC{Core: core}
+	var out api.ScreenshotResult
+	if err := s.Screenshot(&api.ScreenshotArgs{}, &out); err != nil {
+		t.Fatalf("Screenshot: %v", err)
+	}
+	if out.Cols != 80 || out.Text != "grid" {
+		t.Fatalf("out = %+v; want cols 80 text grid", out)
+	}
+
+	s2 := &TerminalControllerRPC{Core: &fakeController{shotErr: errCore}}
+	if err := s2.Screenshot(&api.ScreenshotArgs{}, &out); !errors.Is(err, errCore) {
+		t.Fatalf("Screenshot err = %v; want errCore", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Raises `internal/terminal/terminalrpc` statement coverage from 29.6% → 95.9% (well past the ≥80% phase-4a gate; umbrella #304, resize phase 4).
- Adds `rpc_server_test.go`: a configurable `api.TerminalController` fake exercising every `TerminalControllerRPC` delegation method (`Ping`, `Resize`, `Detach`, `Attach`, `Metadata`, `State`, `Stop`, `Write`, `Subscribe`, `Screenshot`) on both the success and core-error branches, plus the `*out = *result` copy-out for the value-returning methods. All ten methods were previously 0%.
- Extends `codec_test.go` to cover the codec's two large uncovered functions: `WriteResponse` (normal wire-id resolution, the `resp.Error` jsonrpc error shape, the `!hasID` server-seq fallback, the JSON-encode error branch, the SCM_RIGHTS FD-passing path including `r.FDs` clearing, and the FD-path encode error) and `Close`. Also adds the `ReadRequestHeader` decode-error branch.

Scope is `internal/terminal/terminalrpc` only — sibling phase-4 slices (#323–#327) are out of scope per the issue.

## Test plan
- [x] `go test -cover ./internal/terminal/terminalrpc/...` → `coverage: 95.9% of statements`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (full CI target, incl. e2e) — all packages pass
- [x] `make sbsh-sb` produces an ELF executable (verified via ELF magic `7f 45 4c 46`; `file` not installed on host)
- [ ] `make test-race` — not run: `-race` requires cgo and no C compiler is installed on the dev host. This PR is test-only and adds no production concurrency.

Closes #308