### PR TITLE
test: cover cmd/sb zero-coverage leaf subcommands (phase 6a)

### DIFF
--- a/cmd/sb/autocomplete/autocomplete_test.go
+++ b/cmd/sb/autocomplete/autocomplete_test.go
@@ -1,0 +1,92 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package autocomplete
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newRoot() *cobra.Command {
+	return &cobra.Command{Use: "sb"}
+}
+
+func Test_NewAutoCompleteCmd_Metadata(t *testing.T) {
+	cmd := NewAutoCompleteCmd(newRoot())
+	if cmd == nil {
+		t.Fatal("NewAutoCompleteCmd returned nil")
+	}
+	if cmd.Use != Command {
+		t.Errorf("Use = %q, want %q", cmd.Use, Command)
+	}
+	if got, want := cmd.ValidArgs, []string{"bash", "zsh", "fish"}; len(got) != len(want) {
+		t.Fatalf("ValidArgs = %v, want %v", got, want)
+	}
+}
+
+func Test_AutoComplete_GeneratesScripts(t *testing.T) {
+	tests := []struct {
+		shell  string
+		needle string
+	}{
+		{"bash", "bash completion"},
+		{"zsh", "compdef"},
+		{"fish", "complete"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.shell, func(t *testing.T) {
+			cmd := NewAutoCompleteCmd(newRoot())
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+
+			if err := cmd.RunE(cmd, []string{tc.shell}); err != nil {
+				t.Fatalf("RunE(%q) returned error: %v", tc.shell, err)
+			}
+			if buf.Len() == 0 {
+				t.Fatalf("RunE(%q) produced no output", tc.shell)
+			}
+			if !bytes.Contains(bytes.ToLower(buf.Bytes()), []byte(tc.needle)) {
+				t.Errorf("RunE(%q) output missing %q marker", tc.shell, tc.needle)
+			}
+		})
+	}
+}
+
+func Test_AutoComplete_UnknownShell_NoOutputNoError(t *testing.T) {
+	cmd := NewAutoCompleteCmd(newRoot())
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := cmd.RunE(cmd, []string{"powershell"}); err != nil {
+		t.Fatalf("RunE(unknown) returned error: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("RunE(unknown) should produce no output, got %q", buf.String())
+	}
+}
+
+func Test_AutoComplete_RejectsWrongArgCount(t *testing.T) {
+	cmd := NewAutoCompleteCmd(newRoot())
+	cmd.SetArgs([]string{})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error for missing shell argument, got nil")
+	}
+}

--- a/cmd/sb/read/read_rpc_test.go
+++ b/cmd/sb/read/read_rpc_test.go
@@ -1,0 +1,141 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unix
+
+package read
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"net/rpc"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	internalterminal "github.com/eminwux/sbsh/internal/terminal"
+	"github.com/eminwux/sbsh/internal/terminal/terminalrpc"
+	"github.com/eminwux/sbsh/pkg/api"
+	"golang.org/x/sys/unix"
+)
+
+// startTermServer wires a real net/rpc server backed by the given fake
+// TerminalController on a tempdir Unix socket, mirroring the harness in
+// pkg/rpcclient/terminal. Returns the socket path the client should dial.
+func startTermServer(t *testing.T, core *internalterminal.ControllerTest) string {
+	t.Helper()
+	sockPath := filepath.Join(t.TempDir(), "term.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := rpc.NewServer()
+	if errReg := srv.RegisterName(api.TerminalService, &terminalrpc.TerminalControllerRPC{Core: core}); errReg != nil {
+		_ = ln.Close()
+		t.Fatalf("RegisterName: %v", errReg)
+	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			conn, errAccept := ln.Accept()
+			if errAccept != nil {
+				return
+			}
+			uconn, ok := conn.(*net.UnixConn)
+			if !ok {
+				_ = conn.Close()
+				continue
+			}
+			go srv.ServeCodec(terminalrpc.NewUnixJSONServerCodec(uconn, testLogger()))
+		}
+	}()
+	t.Cleanup(func() {
+		_ = ln.Close()
+		wg.Wait()
+	})
+	return sockPath
+}
+
+// fdPair returns a connected socketpair. ours is retained by the test (its
+// write side feeds the live stream); theirs is handed to the server to pass
+// back over SCM_RIGHTS as the subscriber's read end. The server codec closes
+// the fd it sends, so theirs must not be closed by the test.
+func fdPair(t *testing.T) (ours, theirs int) {
+	t.Helper()
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatalf("socketpair: %v", err)
+	}
+	return fds[0], fds[1]
+}
+
+func Test_runRead_Follow_ReplaysThenStreams(t *testing.T) {
+	ours, theirs := fdPair(t)
+
+	sock := startTermServer(t, &internalterminal.ControllerTest{
+		SubscribeFunc: func(_ *api.SubscribeRequest, resp *api.ResponseWithFD) error {
+			resp.JSON = map[string]any{"subscribed": true}
+			resp.FDs = []int{theirs}
+			return nil
+		},
+	})
+
+	runPath := t.TempDir()
+	capturePath := filepath.Join(runPath, "capture.log")
+	if err := os.WriteFile(capturePath, []byte("REPLAY:"), 0o644); err != nil {
+		t.Fatalf("write capture: %v", err)
+	}
+	writeTerminalMetadata(t, runPath, "term1", "alice", capturePath, sock)
+
+	// Queue live bytes in the socketpair buffer and close our end so the
+	// follower reads the replay, then the live tail, then EOF and returns.
+	if _, err := unix.Write(ours, []byte("LIVE\n")); err != nil {
+		t.Fatalf("seed live bytes: %v", err)
+	}
+	_ = unix.Close(ours)
+
+	var out, errOut bytes.Buffer
+	opts := readOpts{runPath: runPath, name: "alice", follow: true}
+	if err := runRead(context.Background(), testLogger(), &out, &errOut, opts); err != nil {
+		t.Fatalf("runRead(follow): %v", err)
+	}
+	if !strings.HasPrefix(out.String(), "REPLAY:") {
+		t.Errorf("output missing replay prefix: %q", out.String())
+	}
+	if !strings.Contains(out.String(), "LIVE\n") {
+		t.Errorf("output missing live tail: %q", out.String())
+	}
+}
+
+func Test_runRead_Follow_NoSocketRecorded(t *testing.T) {
+	runPath := t.TempDir()
+	capturePath := filepath.Join(runPath, "capture.log")
+	if err := os.WriteFile(capturePath, []byte("data"), 0o644); err != nil {
+		t.Fatalf("write capture: %v", err)
+	}
+	writeTerminalMetadata(t, runPath, "term1", "alice", capturePath, "")
+
+	opts := readOpts{runPath: runPath, name: "alice", follow: true}
+	err := runRead(context.Background(), testLogger(), &bytes.Buffer{}, &bytes.Buffer{}, opts)
+	if err == nil {
+		t.Fatal("expected error for missing socket in follow mode, got nil")
+	}
+}

--- a/cmd/sb/read/read_test.go
+++ b/cmd/sb/read/read_test.go
@@ -1,0 +1,256 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package read
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/sbsh/cmd/types"
+	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// writeTerminalMetadata writes a terminal metadata.json under runPath so
+// discovery.FindTerminalByName resolves it. capturePath/socket may be empty to
+// exercise the missing-field error paths.
+func writeTerminalMetadata(t *testing.T, runPath, id, name, capturePath, socket string) {
+	t.Helper()
+	dir := filepath.Join(runPath, defaults.TerminalsRunPath, id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir terminal dir: %v", err)
+	}
+	doc := api.TerminalDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindTerminal,
+		Metadata:   api.TerminalMetadata{Name: name},
+		Spec:       api.TerminalSpec{ID: api.ID(id), Name: name, RunPath: runPath},
+		Status: api.TerminalStatus{
+			State:       api.Ready,
+			CaptureFile: capturePath,
+			SocketFile:  socket,
+		},
+	}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), data, 0o644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+}
+
+func Test_NewReadCmd_Metadata(t *testing.T) {
+	cmd := NewReadCmd()
+	if cmd == nil {
+		t.Fatal("NewReadCmd returned nil")
+	}
+	if cmd.Use != "read <name>" {
+		t.Errorf("Use = %q", cmd.Use)
+	}
+	if cmd.Flags().Lookup("follow") == nil {
+		t.Error("--follow flag not registered")
+	}
+}
+
+func Test_RunE_ErrLoggerNotFound(t *testing.T) {
+	cmd := NewReadCmd()
+	cmd.SetContext(context.Background())
+
+	err := cmd.RunE(cmd, []string{"some-terminal"})
+	if !errors.Is(err, errdefs.ErrLoggerNotFound) {
+		t.Fatalf("expected ErrLoggerNotFound, got: %v", err)
+	}
+}
+
+func Test_RunE_ErrNoTerminalIdentifier(t *testing.T) {
+	cmd := NewReadCmd()
+	ctx := context.WithValue(context.Background(), types.CtxLogger, testLogger())
+	cmd.SetContext(ctx)
+
+	err := cmd.RunE(cmd, []string{""})
+	if !errors.Is(err, errdefs.ErrNoTerminalIdentifier) {
+		t.Fatalf("expected ErrNoTerminalIdentifier, got: %v", err)
+	}
+}
+
+func Test_runRead_TerminalNotFound(t *testing.T) {
+	runPath := t.TempDir()
+	opts := readOpts{runPath: runPath, name: "ghost"}
+
+	err := runRead(context.Background(), testLogger(), io.Discard, io.Discard, opts)
+	if !errors.Is(err, errdefs.ErrTerminalNotFound) {
+		t.Fatalf("expected ErrTerminalNotFound, got: %v", err)
+	}
+}
+
+func Test_runRead_NoCaptureFileRecorded(t *testing.T) {
+	runPath := t.TempDir()
+	writeTerminalMetadata(t, runPath, "term1", "alice", "", "")
+	opts := readOpts{runPath: runPath, name: "alice"}
+
+	err := runRead(context.Background(), testLogger(), io.Discard, io.Discard, opts)
+	if err == nil {
+		t.Fatal("expected error for missing capture file, got nil")
+	}
+	if errors.Is(err, errdefs.ErrTerminalNotFound) {
+		t.Fatalf("terminal should resolve; got not-found: %v", err)
+	}
+}
+
+func Test_runRead_NoFollow_DumpsCapture(t *testing.T) {
+	runPath := t.TempDir()
+	capturePath := filepath.Join(runPath, "capture.log")
+	want := []byte("hello from the capture log\n")
+	if err := os.WriteFile(capturePath, want, 0o644); err != nil {
+		t.Fatalf("write capture: %v", err)
+	}
+	writeTerminalMetadata(t, runPath, "term1", "alice", capturePath, "")
+	opts := readOpts{runPath: runPath, name: "alice", follow: false}
+
+	var out bytes.Buffer
+	if err := runRead(context.Background(), testLogger(), &out, io.Discard, opts); err != nil {
+		t.Fatalf("runRead returned error: %v", err)
+	}
+	if !bytes.Equal(out.Bytes(), want) {
+		t.Errorf("dumped capture = %q, want %q", out.Bytes(), want)
+	}
+}
+
+func Test_dumpCapture_RawPassthrough(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "capture.log")
+	want := []byte("raw bytes\x1b[0m\n")
+	if err := os.WriteFile(path, want, 0o644); err != nil {
+		t.Fatalf("write capture: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := dumpCapture(path, &out); err != nil {
+		t.Fatalf("dumpCapture returned error: %v", err)
+	}
+	if !bytes.Equal(out.Bytes(), want) {
+		t.Errorf("dumpCapture wrote %q, want %q", out.Bytes(), want)
+	}
+}
+
+func Test_dumpCapture_AbsentFileNoOutput(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "never-written.log")
+
+	var out bytes.Buffer
+	if err := dumpCapture(path, &out); err != nil {
+		t.Fatalf("dumpCapture on absent file should not error, got: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("expected no output for absent capture, got %q", out.Bytes())
+	}
+}
+
+// errWriter fails on every Write to exercise the write-error path.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) { return 0, errors.New("boom") }
+
+func Test_dumpCapture_WriteError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "capture.log")
+	if err := os.WriteFile(path, []byte("data"), 0o644); err != nil {
+		t.Fatalf("write capture: %v", err)
+	}
+
+	if err := dumpCapture(path, errWriter{}); err == nil {
+		t.Fatal("expected write error, got nil")
+	}
+}
+
+func Test_streamLive_NormalEOF(t *testing.T) {
+	client, server := net.Pipe()
+	go func() {
+		_, _ = server.Write([]byte("live output\n"))
+		_ = server.Close()
+	}()
+
+	var out bytes.Buffer
+	if err := streamLive(client, &out, io.Discard); err != nil {
+		t.Fatalf("streamLive returned error: %v", err)
+	}
+	if out.String() != "live output\n" {
+		t.Errorf("streamLive wrote %q", out.String())
+	}
+}
+
+func Test_streamLive_LaggedSentinel(t *testing.T) {
+	client, server := net.Pipe()
+	go func() {
+		_, _ = server.Write(append([]byte("some output "), laggedNotice...))
+		_ = server.Close()
+	}()
+
+	var out, errOut bytes.Buffer
+	err := streamLive(client, &out, &errOut)
+	if !errors.Is(err, errdefs.ErrSubscriberLagged) {
+		t.Fatalf("expected ErrSubscriberLagged, got: %v", err)
+	}
+	if errOut.Len() == 0 {
+		t.Error("expected a lagged notice on stderr")
+	}
+}
+
+func Test_streamLive_LaggedSentinelSplitAcrossReads(t *testing.T) {
+	half := len(laggedNotice) / 2
+	client, server := net.Pipe()
+	go func() {
+		// net.Pipe is unbuffered: each Write pairs with a Read, so the
+		// sentinel arrives split across two streamLive read iterations.
+		_, _ = server.Write(laggedNotice[:half])
+		_, _ = server.Write(laggedNotice[half:])
+		_ = server.Close()
+	}()
+
+	var out, errOut bytes.Buffer
+	err := streamLive(client, &out, &errOut)
+	if !errors.Is(err, errdefs.ErrSubscriberLagged) {
+		t.Fatalf("expected ErrSubscriberLagged on split sentinel, got: %v", err)
+	}
+}
+
+func Test_streamLive_WriteError(t *testing.T) {
+	client, server := net.Pipe()
+	go func() {
+		_, _ = server.Write([]byte("x"))
+		_ = server.Close()
+	}()
+
+	err := streamLive(client, errWriter{}, io.Discard)
+	if err == nil {
+		t.Fatal("expected write error, got nil")
+	}
+}

--- a/cmd/sb/screenshot/screenshot_rpc_test.go
+++ b/cmd/sb/screenshot/screenshot_rpc_test.go
@@ -1,0 +1,126 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unix
+
+package screenshot
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"net/rpc"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	internalterminal "github.com/eminwux/sbsh/internal/terminal"
+	"github.com/eminwux/sbsh/internal/terminal/terminalrpc"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// startTermServer wires a real net/rpc server backed by the given fake
+// TerminalController on a tempdir Unix socket, mirroring the harness in
+// pkg/rpcclient/terminal. Returns the socket path the client should dial.
+func startTermServer(t *testing.T, core *internalterminal.ControllerTest) string {
+	t.Helper()
+	sockPath := filepath.Join(t.TempDir(), "term.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := rpc.NewServer()
+	if errReg := srv.RegisterName(api.TerminalService, &terminalrpc.TerminalControllerRPC{Core: core}); errReg != nil {
+		_ = ln.Close()
+		t.Fatalf("RegisterName: %v", errReg)
+	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			conn, errAccept := ln.Accept()
+			if errAccept != nil {
+				return
+			}
+			uconn, ok := conn.(*net.UnixConn)
+			if !ok {
+				_ = conn.Close()
+				continue
+			}
+			go srv.ServeCodec(terminalrpc.NewUnixJSONServerCodec(uconn, testLogger()))
+		}
+	}()
+	t.Cleanup(func() {
+		_ = ln.Close()
+		wg.Wait()
+	})
+	return sockPath
+}
+
+func Test_runScreenshot_ANSIRoundtrip(t *testing.T) {
+	sock := startTermServer(t, &internalterminal.ControllerTest{
+		ScreenshotFunc: func(_ *api.ScreenshotArgs) (*api.ScreenshotResult, error) {
+			return &api.ScreenshotResult{Cols: 80, Rows: 24, Text: "plain-grid", ANSI: "ansi-grid"}, nil
+		},
+	})
+	runPath := t.TempDir()
+	writeTerminalMetadata(t, runPath, "term1", "alice", sock)
+
+	var out bytes.Buffer
+	opts := screenshotOpts{runPath: runPath, name: "alice", plain: false}
+	if err := runScreenshot(context.Background(), testLogger(), &out, opts); err != nil {
+		t.Fatalf("runScreenshot: %v", err)
+	}
+	if out.String() != "ansi-grid" {
+		t.Errorf("ANSI screenshot = %q, want %q", out.String(), "ansi-grid")
+	}
+}
+
+func Test_runScreenshot_PlainGrid(t *testing.T) {
+	sock := startTermServer(t, &internalterminal.ControllerTest{
+		ScreenshotFunc: func(_ *api.ScreenshotArgs) (*api.ScreenshotResult, error) {
+			return &api.ScreenshotResult{Text: "plain-grid", ANSI: "ansi-grid"}, nil
+		},
+	})
+	runPath := t.TempDir()
+	writeTerminalMetadata(t, runPath, "term1", "alice", sock)
+
+	var out bytes.Buffer
+	opts := screenshotOpts{runPath: runPath, name: "alice", plain: true}
+	if err := runScreenshot(context.Background(), testLogger(), &out, opts); err != nil {
+		t.Fatalf("runScreenshot: %v", err)
+	}
+	if out.String() != "plain-grid" {
+		t.Errorf("plain screenshot = %q, want %q", out.String(), "plain-grid")
+	}
+}
+
+func Test_runScreenshot_RPCError(t *testing.T) {
+	sock := startTermServer(t, &internalterminal.ControllerTest{
+		ScreenshotFunc: func(_ *api.ScreenshotArgs) (*api.ScreenshotResult, error) {
+			return nil, errors.New("boom")
+		},
+	})
+	runPath := t.TempDir()
+	writeTerminalMetadata(t, runPath, "term1", "alice", sock)
+
+	opts := screenshotOpts{runPath: runPath, name: "alice"}
+	if err := runScreenshot(context.Background(), testLogger(), &bytes.Buffer{}, opts); err == nil {
+		t.Fatal("expected screenshot RPC error, got nil")
+	}
+}

--- a/cmd/sb/screenshot/screenshot_test.go
+++ b/cmd/sb/screenshot/screenshot_test.go
@@ -1,0 +1,120 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package screenshot
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/sbsh/cmd/types"
+	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// writeTerminalMetadata writes a terminal metadata.json under runPath so
+// discovery.FindTerminalByName resolves it. socket may be empty to exercise the
+// "no control socket recorded" path.
+func writeTerminalMetadata(t *testing.T, runPath, id, name, socket string) {
+	t.Helper()
+	dir := filepath.Join(runPath, defaults.TerminalsRunPath, id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir terminal dir: %v", err)
+	}
+	doc := api.TerminalDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindTerminal,
+		Metadata:   api.TerminalMetadata{Name: name},
+		Spec:       api.TerminalSpec{ID: api.ID(id), Name: name, RunPath: runPath},
+		Status:     api.TerminalStatus{State: api.Ready, SocketFile: socket},
+	}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), data, 0o644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+}
+
+func Test_NewScreenshotCmd_Metadata(t *testing.T) {
+	cmd := NewScreenshotCmd()
+	if cmd == nil {
+		t.Fatal("NewScreenshotCmd returned nil")
+	}
+	if cmd.Use != "screenshot <name>" {
+		t.Errorf("Use = %q", cmd.Use)
+	}
+	if cmd.Flags().Lookup("plain") == nil {
+		t.Error("--plain flag not registered")
+	}
+}
+
+func Test_RunE_ErrLoggerNotFound(t *testing.T) {
+	cmd := NewScreenshotCmd()
+	cmd.SetContext(context.Background())
+
+	err := cmd.RunE(cmd, []string{"some-terminal"})
+	if !errors.Is(err, errdefs.ErrLoggerNotFound) {
+		t.Fatalf("expected ErrLoggerNotFound, got: %v", err)
+	}
+}
+
+func Test_RunE_ErrNoTerminalIdentifier(t *testing.T) {
+	cmd := NewScreenshotCmd()
+	ctx := context.WithValue(context.Background(), types.CtxLogger, testLogger())
+	cmd.SetContext(ctx)
+
+	err := cmd.RunE(cmd, []string{""})
+	if !errors.Is(err, errdefs.ErrNoTerminalIdentifier) {
+		t.Fatalf("expected ErrNoTerminalIdentifier, got: %v", err)
+	}
+}
+
+func Test_runScreenshot_TerminalNotFound(t *testing.T) {
+	runPath := t.TempDir()
+	opts := screenshotOpts{runPath: runPath, name: "ghost"}
+
+	err := runScreenshot(context.Background(), testLogger(), io.Discard, opts)
+	if !errors.Is(err, errdefs.ErrTerminalNotFound) {
+		t.Fatalf("expected ErrTerminalNotFound, got: %v", err)
+	}
+}
+
+func Test_runScreenshot_NoSocketRecorded(t *testing.T) {
+	runPath := t.TempDir()
+	writeTerminalMetadata(t, runPath, "term1", "alice", "")
+	opts := screenshotOpts{runPath: runPath, name: "alice"}
+
+	err := runScreenshot(context.Background(), testLogger(), io.Discard, opts)
+	if err == nil {
+		t.Fatal("expected error for missing socket, got nil")
+	}
+	if errors.Is(err, errdefs.ErrTerminalNotFound) {
+		t.Fatalf("terminal should resolve; got not-found: %v", err)
+	}
+}

--- a/cmd/sb/version/version_test.go
+++ b/cmd/sb/version/version_test.go
@@ -1,0 +1,78 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package version
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/eminwux/sbsh/cmd/config"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+
+	var buf bytes.Buffer
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		wg.Done()
+	}()
+
+	fn()
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+	wg.Wait()
+	_ = r.Close()
+	return buf.String()
+}
+
+func Test_NewVersionCmd_Metadata(t *testing.T) {
+	cmd := NewVersionCmd()
+	if cmd == nil {
+		t.Fatal("NewVersionCmd returned nil")
+	}
+	if cmd.Use != "version" {
+		t.Errorf("Use = %q, want %q", cmd.Use, "version")
+	}
+	if cmd.Short == "" {
+		t.Error("Short description should not be empty")
+	}
+}
+
+func Test_VersionCmd_PrintsVersion(t *testing.T) {
+	cmd := NewVersionCmd()
+	out := captureStdout(t, func() {
+		cmd.Run(cmd, []string{})
+	})
+	got := strings.TrimSpace(out)
+	if got != config.Version {
+		t.Errorf("printed version = %q, want %q", got, config.Version)
+	}
+}


### PR DESCRIPTION
## Summary
- Phase 6a of the CLI command-layer coverage work (#304 umbrella): the four `cmd/sb` leaf subcommands had **0%** statement coverage. This adds focused unit tests raising each above the ≥80% bar.
- `version` and `autocomplete` are pure command builders, covered to 100% by exercising the print path and each shell-script branch (bash/zsh/fish + unknown-shell + arg-count rejection).
- `read` and `screenshot` reach the live-socket RPC paths via the project's existing `net/rpc` + `ControllerTest` server harness (mirrors `pkg/rpcclient/terminal/rpc_client_test.go`), so the success branches — not just the error/validation paths — are exercised. The RPC-backed tests live in `*_rpc_test.go` under `//go:build unix` to match that harness's tag.

## Coverage (was 0% across the board)
- `cmd/sb/version` — 100.0%
- `cmd/sb/autocomplete` — 100.0%
- `cmd/sb/screenshot` — 93.3%
- `cmd/sb/read` — 90.5%

## Notes
- Test-only change; no production code touched.
- The `read`/`screenshot` tests stand up terminal `metadata.json` on a tempdir `run-path` (same shape as `cmd/sb/get`'s integration helper) to drive `discovery.FindTerminalByName`, plus a socketpair for the `read --follow` subscribe path's SCM_RIGHTS FD handoff.
- Removed a stray `internal/terminal/terminalrunner/core.11143` core-dump artifact found untracked in the tree (unrelated leftover from a prior test crash).

## Test plan
- [x] `go test -cover ./cmd/sb/read/ ./cmd/sb/screenshot/ ./cmd/sb/version/ ./cmd/sb/autocomplete/` — all ≥80%
- [x] `make test` (full CI suite incl. integration + e2e) — pass
- [x] `go build ./...` — pass
- [x] `go vet` on the four packages — pass
- [x] `make sbsh-sb` — ELF binary produced

Closes #310