### PR TITLE
test: cover cmd/sb data commands (write, stop, get, prune) to ≥80%

### DIFF
--- a/cmd/sb/get/data_coverage_test.go
+++ b/cmd/sb/get/data_coverage_test.go
@@ -1,0 +1,276 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// These tests run under the default build (no integration tag) so the
+// command-layer logic in cmd/sb/get is exercised by the standard
+// `go test ./...` coverage run, not only the integration-tagged suite.
+
+package get
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/sbsh/cmd/config"
+	"github.com/eminwux/sbsh/cmd/types"
+	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/pkg/api"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func covLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// covCmd returns a cobra command carrying a logger context and a "run-path"
+// flag set to runPath, which the Complete*/get* paths resolve through
+// config.GetRunPathFromEnvAndFlags.
+func covCmd(t *testing.T, runPath string) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.WithValue(context.Background(), types.CtxLogger, covLogger()))
+	cmd.Flags().String("run-path", runPath, "")
+	return cmd
+}
+
+func covWriteTerminal(t *testing.T, runPath, id, name string, state api.TerminalStatusMode) {
+	t.Helper()
+	dir := filepath.Join(runPath, defaults.TerminalsRunPath, id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	doc := api.TerminalDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindTerminal,
+		Metadata:   api.TerminalMetadata{Name: name},
+		Spec:       api.TerminalSpec{ID: api.ID(id), Name: name, RunPath: runPath},
+		Status:     api.TerminalStatus{State: state, Pid: os.Getpid()},
+	}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if writeErr := os.WriteFile(filepath.Join(dir, "metadata.json"), data, 0o644); writeErr != nil {
+		t.Fatalf("write metadata: %v", writeErr)
+	}
+}
+
+func covWriteClient(t *testing.T, runPath, id, name string, state api.ClientStatusMode) {
+	t.Helper()
+	dir := filepath.Join(runPath, defaults.ClientsRunPath, id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	doc := api.ClientDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindClient,
+		Metadata:   api.ClientMetadata{Name: name},
+		Spec:       api.ClientSpec{ID: api.ID(id)},
+		Status:     api.ClientStatus{State: state, Pid: os.Getpid()},
+	}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if writeErr := os.WriteFile(filepath.Join(dir, "metadata.json"), data, 0o644); writeErr != nil {
+		t.Fatalf("write metadata: %v", writeErr)
+	}
+}
+
+func covWriteProfiles(t *testing.T, dir string) {
+	t.Helper()
+	y := `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: default
+spec:
+  shell:
+    cmd: /bin/bash
+`
+	if err := os.WriteFile(filepath.Join(dir, "profiles.yaml"), []byte(y), 0o644); err != nil {
+		t.Fatalf("write profiles: %v", err)
+	}
+}
+
+func Test_NewGetCmd_Cov(t *testing.T) {
+	cmd := NewGetCmd()
+	if cmd == nil {
+		t.Fatal("NewGetCmd returned nil")
+	}
+	if cmd.Use != "get" {
+		t.Errorf("Use = %q", cmd.Use)
+	}
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Errorf("get RunE (help): %v", err)
+	}
+	want := map[string]bool{"terminal": false, "clients": false, "profiles": false}
+	for _, sub := range cmd.Commands() {
+		if _, ok := want[sub.Name()]; ok {
+			want[sub.Name()] = true
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Errorf("get missing subcommand %q", name)
+		}
+	}
+}
+
+func Test_Terminals_Cov(t *testing.T) {
+	runPath := t.TempDir()
+	covWriteTerminal(t, runPath, "term1", "alpha", api.Ready)
+	covWriteTerminal(t, runPath, "term2", "beta", api.Ready)
+	cmd := covCmd(t, runPath)
+
+	viper.Reset()
+	viper.Set(config.SB_ROOT_RUN_PATH.ViperKey, runPath)
+	defer viper.Reset()
+
+	if err := listTerminals(cmd, nil); err != nil {
+		t.Errorf("listTerminals: %v", err)
+	}
+
+	viper.Set(outputFormat, "json")
+	if err := getTerminal(cmd, []string{"alpha"}); err != nil {
+		t.Errorf("getTerminal: %v", err)
+	}
+	viper.Set(outputFormat, "")
+
+	names, err := fetchTerminalNames(cmd.Context(), runPath, "al")
+	if err != nil {
+		t.Fatalf("fetchTerminalNames: %v", err)
+	}
+	if len(names) != 1 || names[0] != "alpha" {
+		t.Errorf("fetchTerminalNames = %v, want [alpha]", names)
+	}
+
+	got, _ := CompleteTerminals(cmd, nil, "")
+	if len(got) != 2 {
+		t.Errorf("CompleteTerminals = %v, want 2 names", got)
+	}
+	if nilGot, _ := CompleteTerminals(cmd, []string{"already"}, ""); nilGot != nil {
+		t.Errorf("CompleteTerminals with positional arg = %v, want nil", nilGot)
+	}
+
+	id, err := ResolveTerminalNameToID(cmd.Context(), covLogger(), runPath, "beta")
+	if err != nil {
+		t.Fatalf("ResolveTerminalNameToID: %v", err)
+	}
+	if id != "term2" {
+		t.Errorf("ResolveTerminalNameToID = %q, want term2", id)
+	}
+	if _, errResolve := ResolveTerminalNameToID(cmd.Context(), covLogger(), runPath, "ghost"); !errors.Is(
+		errResolve,
+		errdefs.ErrTerminalNotFound,
+	) {
+		t.Errorf("expected ErrTerminalNotFound, got: %v", errResolve)
+	}
+}
+
+func Test_Clients_Cov(t *testing.T) {
+	runPath := t.TempDir()
+	covWriteClient(t, runPath, "cl1", "client-a", api.ClientReady)
+	covWriteClient(t, runPath, "cl2", "client-b", api.ClientReady)
+	cmd := covCmd(t, runPath)
+
+	viper.Reset()
+	viper.Set(config.SB_ROOT_RUN_PATH.ViperKey, runPath)
+	defer viper.Reset()
+
+	if err := listClients(cmd, nil); err != nil {
+		t.Errorf("listClients: %v", err)
+	}
+
+	viper.Set(config.SB_GET_CLIENTS_OUTPUT.ViperKey, "json")
+	if err := getClient(cmd, []string{"client-a"}); err != nil {
+		t.Errorf("getClient: %v", err)
+	}
+	viper.Set(config.SB_GET_CLIENTS_OUTPUT.ViperKey, "")
+
+	names, err := fetchClientNames(cmd.Context(), runPath, "client-b")
+	if err != nil {
+		t.Fatalf("fetchClientNames: %v", err)
+	}
+	if len(names) != 1 || names[0] != "client-b" {
+		t.Errorf("fetchClientNames = %v, want [client-b]", names)
+	}
+
+	got, _ := CompleteClients(cmd, nil, "")
+	if len(got) != 2 {
+		t.Errorf("CompleteClients = %v, want 2 names", got)
+	}
+	if nilGot, _ := CompleteClients(cmd, []string{"already"}, ""); nilGot != nil {
+		t.Errorf("CompleteClients with positional arg = %v, want nil", nilGot)
+	}
+
+	id, err := ResolveClientNameToID(cmd.Context(), covLogger(), runPath, "client-b")
+	if err != nil {
+		t.Fatalf("ResolveClientNameToID: %v", err)
+	}
+	if id != "cl2" {
+		t.Errorf("ResolveClientNameToID = %q, want cl2", id)
+	}
+	if _, errResolve := ResolveClientNameToID(cmd.Context(), covLogger(), runPath, "ghost"); !errors.Is(
+		errResolve,
+		errdefs.ErrClientNotFound,
+	) {
+		t.Errorf("expected ErrClientNotFound, got: %v", errResolve)
+	}
+}
+
+func Test_Profiles_Cov(t *testing.T) {
+	dir := t.TempDir()
+	covWriteProfiles(t, dir)
+	cmd := covCmd(t, dir)
+
+	viper.Reset()
+	viper.Set(config.SB_GET_PROFILES_DIR.ViperKey, dir)
+	defer viper.Reset()
+
+	if err := listProfiles(cmd, nil); err != nil {
+		t.Errorf("listProfiles: %v", err)
+	}
+
+	viper.Set(config.SB_GET_PROFILES_OUTPUT.ViperKey, "json")
+	if err := getProfile(cmd, []string{"default"}); err != nil {
+		t.Errorf("getProfile: %v", err)
+	}
+	viper.Set(config.SB_GET_PROFILES_OUTPUT.ViperKey, "")
+
+	names, err := fetchProfileNames(cmd.Context(), dir, "def")
+	if err != nil {
+		t.Fatalf("fetchProfileNames: %v", err)
+	}
+	if len(names) != 1 || names[0] != "default" {
+		t.Errorf("fetchProfileNames = %v, want [default]", names)
+	}
+
+	got, _ := completeProfiles(cmd, nil, "")
+	if len(got) != 1 {
+		t.Errorf("completeProfiles = %v, want 1 name", got)
+	}
+	if nilGot, _ := completeProfiles(cmd, []string{"already"}, ""); nilGot != nil {
+		t.Errorf("completeProfiles with positional arg = %v, want nil", nilGot)
+	}
+}

--- a/cmd/sb/prune/prune_test.go
+++ b/cmd/sb/prune/prune_test.go
@@ -1,0 +1,83 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package prune
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/eminwux/sbsh/cmd/config"
+	"github.com/eminwux/sbsh/cmd/types"
+	"github.com/spf13/viper"
+)
+
+func pruneTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func pruneTestCtx() context.Context {
+	return context.WithValue(context.Background(), types.CtxLogger, pruneTestLogger())
+}
+
+func Test_NewPruneCmd_Metadata(t *testing.T) {
+	cmd := NewPruneCmd()
+	if cmd == nil {
+		t.Fatal("NewPruneCmd returned nil")
+	}
+	if cmd.Use != "prune" {
+		t.Errorf("Use = %q", cmd.Use)
+	}
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Errorf("prune RunE (help) returned error: %v", err)
+	}
+	var sawTerminals, sawClients bool
+	for _, sub := range cmd.Commands() {
+		switch sub.Name() {
+		case "terminals":
+			sawTerminals = true
+		case "clients":
+			sawClients = true
+		}
+	}
+	if !sawTerminals || !sawClients {
+		t.Errorf("prune missing subcommands: terminals=%v clients=%v", sawTerminals, sawClients)
+	}
+}
+
+func Test_PruneTerminals_RunE_EmptyRunPath(t *testing.T) {
+	viper.Reset()
+	viper.Set(config.SB_ROOT_RUN_PATH.ViperKey, t.TempDir())
+	cmd := NewPruneTerminalsCmd()
+	cmd.SetContext(pruneTestCtx())
+
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		t.Fatalf("prune terminals RunE: %v", err)
+	}
+}
+
+func Test_PruneClients_RunE_EmptyRunPath(t *testing.T) {
+	viper.Reset()
+	viper.Set(config.SB_ROOT_RUN_PATH.ViperKey, t.TempDir())
+	cmd := NewPruneClientsCmd()
+	cmd.SetContext(pruneTestCtx())
+
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		t.Fatalf("prune clients RunE: %v", err)
+	}
+}

--- a/cmd/sb/stop/stop_test.go
+++ b/cmd/sb/stop/stop_test.go
@@ -1,0 +1,233 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package stop
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/cmd/config"
+	"github.com/eminwux/sbsh/cmd/types"
+	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/pkg/api"
+	"github.com/spf13/viper"
+)
+
+func stopTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func Test_NewStopCmd_Metadata(t *testing.T) {
+	cmd := NewStopCmd()
+	if cmd == nil {
+		t.Fatal("NewStopCmd returned nil")
+	}
+	if cmd.Use != "stop" {
+		t.Errorf("Use = %q", cmd.Use)
+	}
+	// The default RunE prints help; exercise it for coverage.
+	if err := cmd.RunE(cmd, nil); err != nil {
+		t.Errorf("stop RunE (help) returned error: %v", err)
+	}
+	var found bool
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "terminal" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("stop command missing 'terminal' subcommand")
+	}
+}
+
+func Test_StopTerminals_RunE_PropagatesError(t *testing.T) {
+	viper.Reset()
+	cmd := NewStopTerminalsCmd() // binds flags into viper
+	viper.Set(config.SB_STOP_TIMEOUT.ViperKey, "5s")
+	viper.Set(config.SB_ROOT_RUN_PATH.ViperKey, t.TempDir())
+	ctx := context.WithValue(context.Background(), types.CtxLogger, stopTestLogger())
+	cmd.SetContext(ctx)
+
+	err := cmd.RunE(cmd, []string{"ghost"})
+	if !errors.Is(err, errdefs.ErrTerminalNotFound) {
+		t.Fatalf("expected ErrTerminalNotFound from RunE, got: %v", err)
+	}
+}
+
+func Test_RunStopTerminals_NoActiveTargets(t *testing.T) {
+	opts := stopOpts{runPath: t.TempDir(), all: true, timeout: defaultStopTimeout}
+	var out, errOut bytes.Buffer
+	if err := runStopTerminals(context.Background(), stopTestLogger(), &out, &errOut, opts); err != nil {
+		t.Fatalf("runStopTerminals: %v", err)
+	}
+	if !strings.Contains(out.String(), "no active terminals found") {
+		t.Errorf("stdout = %q, want 'no active terminals found'", out.String())
+	}
+}
+
+func Test_RunStopTerminals_NotFoundIgnored(t *testing.T) {
+	opts := stopOpts{runPath: t.TempDir(), name: "ghost", ignoreNotFound: true, timeout: defaultStopTimeout}
+	var out, errOut bytes.Buffer
+	if err := runStopTerminals(context.Background(), stopTestLogger(), &out, &errOut, opts); err != nil {
+		t.Fatalf("expected nil with --ignore-not-found, got: %v", err)
+	}
+	if !strings.Contains(out.String(), "not found (ignored)") {
+		t.Errorf("stdout = %q, want 'not found (ignored)'", out.String())
+	}
+}
+
+func Test_RunStopTerminals_NotFoundErrors(t *testing.T) {
+	opts := stopOpts{runPath: t.TempDir(), name: "ghost", timeout: defaultStopTimeout}
+	var out, errOut bytes.Buffer
+	err := runStopTerminals(context.Background(), stopTestLogger(), &out, &errOut, opts)
+	if !errors.Is(err, errdefs.ErrTerminalNotFound) {
+		t.Fatalf("expected ErrTerminalNotFound, got: %v", err)
+	}
+}
+
+func Test_RunStopTerminals_AlreadyExited(t *testing.T) {
+	const deadPid = 0x7fffffff
+	runPath := t.TempDir()
+	writeStopTestTerminal(t, runPath, "id-dead", "alpha", api.Ready, deadPid)
+
+	opts := stopOpts{runPath: runPath, name: "alpha", timeout: defaultStopTimeout}
+	var out, errOut bytes.Buffer
+	if err := runStopTerminals(context.Background(), stopTestLogger(), &out, &errOut, opts); err != nil {
+		t.Fatalf("runStopTerminals: %v", err)
+	}
+	if !strings.Contains(out.String(), "already exited") {
+		t.Errorf("stdout = %q, want 'already exited'", out.String())
+	}
+}
+
+func Test_RunStopTerminals_GracefulSIGTERM(t *testing.T) {
+	// A real child the SIGTERM fallback can reap. No socket is recorded, so
+	// stopViaRPC fails fast and runStopTerminals falls back to SIGTERM.
+	child := exec.Command("/bin/sh", "-c", "sleep 60")
+	_ = startBackgroundProc(t, child)
+
+	runPath := t.TempDir()
+	writeStopTestTerminal(t, runPath, "id-live", "beta", api.Ready, child.Process.Pid)
+
+	opts := stopOpts{runPath: runPath, name: "beta", timeout: 3 * time.Second}
+	var out, errOut bytes.Buffer
+	if err := runStopTerminals(context.Background(), stopTestLogger(), &out, &errOut, opts); err != nil {
+		t.Fatalf("runStopTerminals: %v\nstderr=%q", err, errOut.String())
+	}
+	if !strings.Contains(out.String(), `terminal "beta" stopped`) {
+		t.Errorf("stdout = %q, want 'terminal \"beta\" stopped'", out.String())
+	}
+}
+
+func Test_ResolveTargets_All_FiltersExited(t *testing.T) {
+	runPath := t.TempDir()
+	// Exited terminal is filtered out; a live one (self) stays active.
+	writeStopTestTerminal(t, runPath, "id-exited", "gone", api.Exited, 0x7fffffff)
+	writeStopTestTerminal(t, runPath, "id-alive", "here", api.Ready, os.Getpid())
+
+	opts := stopOpts{runPath: runPath, all: true, timeout: defaultStopTimeout}
+	docs, err := resolveTargets(context.Background(), stopTestLogger(), opts)
+	if err != nil {
+		t.Fatalf("resolveTargets: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 active target, got %d", len(docs))
+	}
+	if docs[0].Spec.Name != "here" {
+		t.Errorf("active target = %q, want 'here'", docs[0].Spec.Name)
+	}
+}
+
+// Test_StopOneTerminal_KillAfterEscalates covers the graceful→escalate path:
+// a child that traps SIGTERM survives the --timeout window, so --kill-after
+// escalates to a pgroup SIGKILL. Also exercises the attacher-warning branch.
+func Test_StopOneTerminal_KillAfterEscalates(t *testing.T) {
+	child := exec.Command("/bin/sh", "-c", `trap '' TERM; sleep 60 & wait`)
+	child.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	childDone := startBackgroundProc(t, child)
+	time.Sleep(100 * time.Millisecond) // let the trap install
+
+	doc := &api.TerminalDoc{
+		Spec: api.TerminalSpec{Name: "trap-term"},
+		Status: api.TerminalStatus{
+			State:     api.Ready,
+			Pid:       child.Process.Pid,
+			ChildPgid: child.Process.Pid, // Setsid → pgid == pid
+			Attachers: []string{"attacher-1"},
+		},
+	}
+	opts := stopOpts{killAfter: true, timeout: 200 * time.Millisecond}
+	var out, errOut bytes.Buffer
+	res := stopOneTerminal(context.Background(), stopTestLogger(), &out, &errOut, doc, opts)
+	if res != resultStopped {
+		t.Fatalf("expected resultStopped, got %v\nstdout=%q\nstderr=%q", res, out.String(), errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "attacher") {
+		t.Errorf("expected attacher warning on stderr, got %q", errOut.String())
+	}
+	if !strings.Contains(out.String(), "escalating to SIGKILL") {
+		t.Errorf("expected escalation notice, got %q", out.String())
+	}
+	select {
+	case <-childDone:
+	case <-time.After(sigkillGrace):
+		t.Fatal("child pgroup still alive after escalation")
+	}
+}
+
+func Test_SendSignal_InvalidPid(t *testing.T) {
+	err := sendSignal(0, 0, syscall.SIGTERM)
+	if !errors.Is(err, errdefs.ErrSignalProcess) {
+		t.Fatalf("expected ErrSignalProcess for pid 0, got: %v", err)
+	}
+}
+
+func Test_SendSignal_GoneProcessIsNoOp(t *testing.T) {
+	// A high pid that doesn't exist, with a non-zero token: pidutil.Match
+	// surfaces os.ErrNotExist, which sendSignal treats as "already gone".
+	if err := sendSignal(0x7fffffff, 12345, syscall.SIGTERM); err != nil {
+		t.Fatalf("expected nil for vanished process, got: %v", err)
+	}
+}
+
+func Test_WaitForExit_TimeoutAndCancel(t *testing.T) {
+	// Self never exits, so the deadline elapses and waitForExit reports false.
+	if waitForExit(context.Background(), os.Getpid(), 0, 50*time.Millisecond) {
+		t.Error("expected waitForExit to time out on a live process")
+	}
+
+	// Cancelled context takes the ctx.Done branch.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if waitForExit(ctx, os.Getpid(), 0, time.Hour) {
+		t.Error("expected waitForExit to report still-alive on cancel")
+	}
+
+	// Invalid pid is treated as already exited.
+	if !waitForExit(context.Background(), 0, 0, time.Second) {
+		t.Error("expected waitForExit(0) to report exited")
+	}
+}

--- a/cmd/sb/write/write_rpc_test.go
+++ b/cmd/sb/write/write_rpc_test.go
@@ -1,0 +1,92 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unix
+
+package write
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"net/rpc"
+	"sync"
+	"testing"
+
+	internalterminal "github.com/eminwux/sbsh/internal/terminal"
+	"github.com/eminwux/sbsh/internal/terminal/terminalrpc"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// startTermServer wires a real net/rpc server backed by the given fake
+// TerminalController on a tempdir Unix socket, mirroring the harness in
+// pkg/rpcclient/terminal. Returns the socket path the client should dial.
+func startTermServer(t *testing.T, core *internalterminal.ControllerTest) string {
+	t.Helper()
+	sockPath := t.TempDir() + "/term.sock"
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := rpc.NewServer()
+	if errReg := srv.RegisterName(api.TerminalService, &terminalrpc.TerminalControllerRPC{Core: core}); errReg != nil {
+		_ = ln.Close()
+		t.Fatalf("RegisterName: %v", errReg)
+	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			conn, errAccept := ln.Accept()
+			if errAccept != nil {
+				return
+			}
+			uconn, ok := conn.(*net.UnixConn)
+			if !ok {
+				_ = conn.Close()
+				continue
+			}
+			go srv.ServeCodec(terminalrpc.NewUnixJSONServerCodec(uconn, testLogger()))
+		}
+	}()
+	t.Cleanup(func() {
+		_ = ln.Close()
+		wg.Wait()
+	})
+	return sockPath
+}
+
+func Test_RunWrite_RPCSuccess(t *testing.T) {
+	var got []byte
+	sock := startTermServer(t, &internalterminal.ControllerTest{
+		WriteFunc: func(req *api.WriteRequest) error {
+			got = append(got, req.Data...)
+			return nil
+		},
+	})
+
+	runPath := t.TempDir()
+	writeTerminalMetadata(t, runPath, "term1", "alice", sock)
+	opts := writeOpts{runPath: runPath, name: "alice", payload: []byte("hello")}
+
+	if err := runWrite(context.Background(), testLogger(), opts); err != nil {
+		t.Fatalf("runWrite: %v", err)
+	}
+	if !bytes.Equal(got, []byte("hello")) {
+		t.Errorf("server received %q, want %q", got, "hello")
+	}
+}

--- a/cmd/sb/write/write_test.go
+++ b/cmd/sb/write/write_test.go
@@ -1,0 +1,155 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package write
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/sbsh/cmd/config"
+	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/pkg/api"
+	"github.com/spf13/viper"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// writeTerminalMetadata writes a terminal metadata.json under runPath so
+// discovery.FindTerminalByName resolves it. socket may be empty to exercise
+// the missing-socket error path.
+func writeTerminalMetadata(t *testing.T, runPath, id, name, socket string) {
+	t.Helper()
+	dir := filepath.Join(runPath, defaults.TerminalsRunPath, id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir terminal dir: %v", err)
+	}
+	doc := api.TerminalDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindTerminal,
+		Metadata:   api.TerminalMetadata{Name: name},
+		Spec:       api.TerminalSpec{ID: api.ID(id), Name: name, RunPath: runPath},
+		Status:     api.TerminalStatus{State: api.Ready, SocketFile: socket},
+	}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+	if writeErr := os.WriteFile(filepath.Join(dir, "metadata.json"), data, 0o644); writeErr != nil {
+		t.Fatalf("write metadata: %v", writeErr)
+	}
+}
+
+func Test_NewWriteCmd_Metadata(t *testing.T) {
+	cmd := NewWriteCmd()
+	if cmd == nil {
+		t.Fatal("NewWriteCmd returned nil")
+	}
+	if cmd.Use != "write <name> [text|-]" {
+		t.Errorf("Use = %q", cmd.Use)
+	}
+	if cmd.Flags().Lookup("raw") == nil {
+		t.Error("--raw flag not registered")
+	}
+}
+
+func Test_RunE_ErrLoggerNotFound(t *testing.T) {
+	cmd := NewWriteCmd()
+	cmd.SetContext(context.Background())
+
+	err := cmd.RunE(cmd, []string{"box", "hi"})
+	if !errors.Is(err, errdefs.ErrLoggerNotFound) {
+		t.Fatalf("expected ErrLoggerNotFound, got: %v", err)
+	}
+}
+
+func Test_ResolveWriteOpts(t *testing.T) {
+	cases := []struct {
+		name        string
+		args        []string
+		raw         bool
+		wantErr     error
+		wantPayload []byte
+	}{
+		{name: "no args", args: nil, wantErr: errdefs.ErrNoTerminalIdentifier},
+		{name: "empty name", args: []string{""}, wantErr: errdefs.ErrNoTerminalIdentifier},
+		{name: "name only yields empty payload", args: []string{"box"}, wantPayload: nil},
+		{name: "caret parsed", args: []string{"box", "hi^M"}, wantPayload: append([]byte("hi"), 0x0D)},
+		{name: "invalid caret", args: []string{"box", "^!"}, wantErr: errdefs.ErrInvalidArgument},
+		{name: "raw verbatim", args: []string{"box", `^C\n`}, raw: true, wantPayload: []byte(`^C\n`)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			viper.Reset()
+			_ = NewWriteCmd() // bind flags into viper
+			if tc.raw {
+				viper.Set(config.SB_WRITE_RAW.ViperKey, true)
+			}
+			opts, err := resolveWriteOpts(tc.args)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("expected %v, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !bytes.Equal(opts.payload, tc.wantPayload) {
+				t.Fatalf("payload = %v, want %v", opts.payload, tc.wantPayload)
+			}
+		})
+	}
+}
+
+func Test_RunWrite_EmptyPayloadNoOp(t *testing.T) {
+	err := runWrite(context.Background(), testLogger(), writeOpts{name: "box"})
+	if err != nil {
+		t.Fatalf("expected nil for empty payload, got: %v", err)
+	}
+}
+
+func Test_RunWrite_TerminalNotFound(t *testing.T) {
+	opts := writeOpts{runPath: t.TempDir(), name: "ghost", payload: []byte("x")}
+	err := runWrite(context.Background(), testLogger(), opts)
+	if !errors.Is(err, errdefs.ErrTerminalNotFound) {
+		t.Fatalf("expected ErrTerminalNotFound, got: %v", err)
+	}
+}
+
+func Test_RunWrite_NoSocketRecorded(t *testing.T) {
+	runPath := t.TempDir()
+	writeTerminalMetadata(t, runPath, "term1", "alice", "")
+	opts := writeOpts{runPath: runPath, name: "alice", payload: []byte("x")}
+
+	err := runWrite(context.Background(), testLogger(), opts)
+	if err == nil {
+		t.Fatal("expected error for missing socket, got nil")
+	}
+	if errors.Is(err, errdefs.ErrTerminalNotFound) {
+		t.Fatalf("terminal should resolve; got not-found: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 6b of the CLI command-layer coverage work (#304 umbrella). The four `cmd/sb` data/state-mutation subcommands sat below the ≥80% bar; this raises each with focused, test-only changes.

- **`write`** — exercises `NewWriteCmd`/`setupWriteFlags`, `resolveWriteOpts` (name validation, caret-parse, `--raw` verbatim, invalid-caret error), and `runWrite` (empty-payload no-op, terminal-not-found, missing-socket, plus a live-socket RPC success via the project's `net/rpc` + `ControllerTest` harness in `write_rpc_test.go`, `//go:build unix`, mirroring `pkg/rpcclient/terminal` and phase 6a's `read`/`screenshot` tests).
- **`stop`** — covers `NewStopCmd`/`setupStopCmd`, the `NewStopTerminalsCmd` RunE closure, `runStopTerminals` (no-targets, `--ignore-not-found`, already-exited, graceful SIGTERM-fallback against a real child), `resolveTargets` `--all` filtering, and the `--kill-after` escalation + attacher-warning path, plus unit coverage for `sendSignal` and `waitForExit` edge branches.
- **`get`** — the package's substantive tests are `//go:build integration`-tagged, so they don't count toward the default `go test -cover` run (which the issue's 37.1% baseline reflects). Added `data_coverage_test.go` (default build) covering `NewGetCmd`/`setupListCmd`, the `list*`/`get*`/`Complete*`/`fetch*`/`Resolve*` functions for terminals, clients, and profiles. Helper and test names are disjoint from the integration file so both compile together under `-tags=integration`.
- **`prune`** — covers `NewPruneCmd`/`setupPruneCmd` and the `NewPruneTerminalsCmd`/`NewPruneClientsCmd` RunE success paths.

## Coverage (plain `go test -cover`, matching the issue's baseline measurement)

| package | before | after |
|---|---|---|
| `cmd/sb/write` | 43.7% | 89.7% |
| `cmd/sb/stop` | 46.7% | 81.7% |
| `cmd/sb/get` | 37.1% | 82.7% |
| `cmd/sb/prune` | 35.3% | 82.4% |

## Notes

- Test-only change; no production code touched.
- **Measurement basis:** coverage is reported under plain `go test -cover ./cmd/sb/<pkg>/` (no integration tag), consistent with the issue's baseline table and phase 6a (#341). For `get`, this is why a default-tagged file was added rather than relying on the existing integration-tagged suite (which alone reaches only 69.5%).
- **Dependency on #310 (phase 6a, PR #341):** the issue notes 6a "establishes the test approach". 6a is not yet merged, but 6b targets different packages and the RPC harness here is copied from the same pre-existing reference (`pkg/rpcclient/terminal`), so there is no code-level coupling. The `write` RPC test independently re-derives the harness rather than importing from 6a.
- Subsumes #107 (`test: deeper coverage for sb stop terminal paths`): the `cmd/sb/stop` work here covers it.
- Removed a stray `internal/terminal/terminalrunner/core.NNNN` core-dump artifact found untracked in the tree (unrelated prior-crash leftover; not part of this commit).

## Test plan
- [x] `go test -cover ./cmd/sb/write/ ./cmd/sb/stop/ ./cmd/sb/get/ ./cmd/sb/prune/` — all ≥80%
- [x] `go test -tags=integration ./cmd/sb/get/...` — still passes (both test files compile together)
- [x] `make test` (full CI suite incl. integration + e2e) — pass
- [x] `go build ./...` — pass
- [x] `go vet ./cmd/sb/{write,stop,get,prune}/` — pass
- [x] `pre-commit run --files <changed>` (incl. golangci-lint) — pass

Closes #337