### PR TITLE
test: phase 6d — cmd/sbsh subcommand tree coverage

### DIFF
--- a/cmd/sbsh/autocomplete/autocomplete_test.go
+++ b/cmd/sbsh/autocomplete/autocomplete_test.go
@@ -1,0 +1,98 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package autocomplete
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newRoot() *cobra.Command {
+	return &cobra.Command{Use: "sbsh"}
+}
+
+func TestNewAutoCompleteCmd_Metadata(t *testing.T) {
+	cmd := NewAutoCompleteCmd(newRoot())
+	if cmd.Use != Command {
+		t.Fatalf("Use = %q, want %q", cmd.Use, Command)
+	}
+	if cmd.Short == "" {
+		t.Fatal("Short should not be empty")
+	}
+	wantValid := []string{"bash", "zsh", "fish"}
+	if len(cmd.ValidArgs) != len(wantValid) {
+		t.Fatalf("ValidArgs = %v, want %v", cmd.ValidArgs, wantValid)
+	}
+	for i, v := range wantValid {
+		if cmd.ValidArgs[i] != v {
+			t.Fatalf("ValidArgs[%d] = %q, want %q", i, cmd.ValidArgs[i], v)
+		}
+	}
+}
+
+func TestNewAutoCompleteCmd_RejectsWrongArgCount(t *testing.T) {
+	root := newRoot()
+	cmd := NewAutoCompleteCmd(root)
+	root.AddCommand(cmd)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	root.SetArgs([]string{"autocomplete"})
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	if err := root.Execute(); err == nil {
+		t.Fatal("expected error for missing shell argument (ExactArgs(1))")
+	}
+}
+
+func TestNewAutoCompleteCmd_GeneratesCompletions(t *testing.T) {
+	for _, shell := range []string{"bash", "zsh", "fish"} {
+		t.Run(shell, func(t *testing.T) {
+			root := newRoot()
+			cmd := NewAutoCompleteCmd(root)
+			root.AddCommand(cmd)
+
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+
+			if err := cmd.RunE(cmd, []string{shell}); err != nil {
+				t.Fatalf("RunE(%q) error = %v", shell, err)
+			}
+			if buf.Len() == 0 {
+				t.Fatalf("RunE(%q) produced no output", shell)
+			}
+		})
+	}
+}
+
+func TestNewAutoCompleteCmd_UnknownShellNoOp(t *testing.T) {
+	root := newRoot()
+	cmd := NewAutoCompleteCmd(root)
+	root.AddCommand(cmd)
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := cmd.RunE(cmd, []string{"powershell"}); err != nil {
+		t.Fatalf("RunE(unknown) error = %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("RunE(unknown) should produce no output; got %q", buf.String())
+	}
+}

--- a/cmd/sbsh/sbsh_test.go
+++ b/cmd/sbsh/sbsh_test.go
@@ -19,12 +19,15 @@ package sbsh
 import (
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/eminwux/sbsh/cmd/config"
+	"github.com/eminwux/sbsh/cmd/types"
 	"github.com/eminwux/sbsh/internal/client"
 	"github.com/eminwux/sbsh/internal/errdefs"
 	"github.com/eminwux/sbsh/internal/naming"
@@ -584,6 +587,460 @@ func Test_setTerminalFlags_HappyPath(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewSbshRootCmd_WiresSubcommandsAndFlags(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	rootCmd, err := NewSbshRootCmd()
+	if err != nil {
+		t.Fatalf("NewSbshRootCmd() error = %v", err)
+	}
+	if rootCmd.Use != "sbsh" {
+		t.Fatalf("Use = %q, want %q", rootCmd.Use, "sbsh")
+	}
+
+	wantSubcommands := []string{"version", "terminal", "autocomplete"}
+	for _, name := range wantSubcommands {
+		found := false
+		for _, c := range rootCmd.Commands() {
+			if c.Name() == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected subcommand %q to be registered", name)
+		}
+	}
+
+	for _, flag := range []string{"run-path", "config", "profiles-dir"} {
+		if rootCmd.PersistentFlags().Lookup(flag) == nil {
+			t.Fatalf("expected persistent flag %q", flag)
+		}
+	}
+	for _, flag := range []string{"id", "socket", "detach", "terminal-id", "terminal-profile"} {
+		if rootCmd.Flags().Lookup(flag) == nil {
+			t.Fatalf("expected flag %q", flag)
+		}
+	}
+}
+
+func Test_setClientFlags_HappyPath(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	flagCases := []struct {
+		flagName string
+		value    string
+		viperKey string
+		isBool   bool
+	}{
+		{"id", "client-123", config.SBSH_CLIENT_ID.ViperKey, false},
+		{"socket", "/tmp/client.sock", config.SBSH_CLIENT_SOCKET.ViperKey, false},
+		{"log-file", "/tmp/client.log", config.SBSH_CLIENT_LOG_FILE.ViperKey, false},
+		{"log-level", "debug", config.SBSH_CLIENT_LOG_LEVEL.ViperKey, false},
+		{"detach", "true", config.SBSH_CLIENT_DETACH.ViperKey, true},
+		{"disable-detach", "true", config.SBSH_CLIENT_DISABLE_DETACH_KEYSTROKE.ViperKey, true},
+	}
+
+	for _, tc := range flagCases {
+		t.Run(tc.flagName, func(t *testing.T) {
+			viper.Reset()
+			rootCmd := &cobra.Command{Use: "sbsh"}
+			if err := setClientFlags(rootCmd); err != nil {
+				t.Fatalf("setClientFlags() error = %v", err)
+			}
+			if err := rootCmd.Flags().Set(tc.flagName, tc.value); err != nil {
+				t.Fatalf("set flag %s: %v", tc.flagName, err)
+			}
+			if tc.isBool {
+				if !viper.GetBool(tc.viperKey) {
+					t.Fatalf("viper key %s expected true", tc.viperKey)
+				}
+				return
+			}
+			if got := viper.GetString(tc.viperKey); got != tc.value {
+				t.Fatalf("viper key %s: expected %s, got %s", tc.viperKey, tc.value, got)
+			}
+		})
+	}
+}
+
+func Test_setPersistentLoggingFlags_HappyPath(t *testing.T) {
+	t.Cleanup(viper.Reset)
+
+	flagCases := []struct {
+		flagName string
+		value    string
+		viperKey string
+	}{
+		{"run-path", "/tmp/run", config.SBSH_ROOT_RUN_PATH.ViperKey},
+		{"config", "/tmp/config.yaml", config.SBSH_ROOT_CONFIG_FILE.ViperKey},
+		{"profiles-dir", "/tmp/profiles.d", config.SBSH_ROOT_PROFILES_DIR.ViperKey},
+	}
+
+	for _, tc := range flagCases {
+		t.Run(tc.flagName, func(t *testing.T) {
+			viper.Reset()
+			rootCmd := &cobra.Command{Use: "sbsh"}
+			if err := setPersistentLoggingFlags(rootCmd); err != nil {
+				t.Fatalf("setPersistentLoggingFlags() error = %v", err)
+			}
+			if err := rootCmd.PersistentFlags().Set(tc.flagName, tc.value); err != nil {
+				t.Fatalf("set flag %s: %v", tc.flagName, err)
+			}
+			if got := viper.GetString(tc.viperKey); got != tc.value {
+				t.Fatalf("viper key %s: expected %s, got %s", tc.viperKey, tc.value, got)
+			}
+		})
+	}
+}
+
+func Test_readRootGIDFlag(t *testing.T) {
+	const flagName = "terminal-socket-gid"
+	const envName = "SBSH_TEST_ROOT_GID"
+
+	t.Run("flag wins", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		cmd.Flags().Int(flagName, -1, "")
+		if err := cmd.Flags().Set(flagName, "55"); err != nil {
+			t.Fatalf("set: %v", err)
+		}
+		if got := readRootGIDFlag(cmd, flagName, envName); got == nil || *got != 55 {
+			t.Fatalf("expected 55; got %v", got)
+		}
+	})
+
+	t.Run("env fallback", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		cmd.Flags().Int(flagName, -1, "")
+		t.Setenv(envName, "9")
+		if got := readRootGIDFlag(cmd, flagName, envName); got == nil || *got != 9 {
+			t.Fatalf("expected 9; got %v", got)
+		}
+	})
+
+	t.Run("nil when unset", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		cmd.Flags().Int(flagName, -1, "")
+		t.Setenv(envName, "")
+		if got := readRootGIDFlag(cmd, flagName, envName); got != nil {
+			t.Fatalf("expected nil; got %v", got)
+		}
+	})
+}
+
+func Test_readRootGIDWrappers(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	rootCmd, err := NewSbshRootCmd()
+	if err != nil {
+		t.Fatalf("NewSbshRootCmd() error = %v", err)
+	}
+	if err := rootCmd.Flags().Set("terminal-socket-gid", "21"); err != nil {
+		t.Fatalf("set socket-gid: %v", err)
+	}
+	if err := rootCmd.Flags().Set("terminal-capture-gid", "22"); err != nil {
+		t.Fatalf("set capture-gid: %v", err)
+	}
+	if err := rootCmd.Flags().Set("terminal-log-file-gid", "23"); err != nil {
+		t.Fatalf("set log-file-gid: %v", err)
+	}
+
+	if got := readRootSocketGID(rootCmd); got == nil || *got != 21 {
+		t.Fatalf("readRootSocketGID: expected 21; got %v", got)
+	}
+	if got := readRootCaptureGID(rootCmd); got == nil || *got != 22 {
+		t.Fatalf("readRootCaptureGID: expected 22; got %v", got)
+	}
+	if got := readRootLogFileGID(rootCmd); got == nil || *got != 23 {
+		t.Fatalf("readRootLogFileGID: expected 23; got %v", got)
+	}
+}
+
+func Test_LoadConfig_Defaults(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	missingCfg := filepath.Join(t.TempDir(), "config.yaml")
+	t.Setenv(config.SBSH_ROOT_CONFIG_FILE.EnvVar(), missingCfg)
+	_ = config.SBSH_ROOT_CONFIG_FILE.BindEnv()
+	t.Setenv(config.SBSH_ROOT_RUN_PATH.EnvVar(), "")
+	t.Setenv(config.SBSH_ROOT_PROFILES_DIR.EnvVar(), "")
+	t.Setenv(config.SBSH_ROOT_LOG_LEVEL.EnvVar(), "")
+
+	if err := LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+
+	if got, want := viper.GetString(config.SBSH_ROOT_RUN_PATH.ViperKey), config.DefaultRunPath(); got != want {
+		t.Fatalf("run path = %q, want %q", got, want)
+	}
+	if got := viper.GetString(config.SBSH_ROOT_LOG_LEVEL.ViperKey); got != "info" {
+		t.Fatalf("log level = %q, want info", got)
+	}
+}
+
+func Test_LoadConfig_ConfigurationDoc(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	content := `apiVersion: sbsh/v1beta1
+kind: Configuration
+metadata:
+  name: default
+spec:
+  runPath: /tmp/sbsh-root-test-run
+  profilesDir: /tmp/sbsh-root-test-profiles.d
+  logLevel: debug
+`
+	if err := os.WriteFile(cfgPath, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	t.Setenv(config.SBSH_ROOT_CONFIG_FILE.EnvVar(), cfgPath)
+	t.Setenv(config.SBSH_ROOT_RUN_PATH.EnvVar(), "")
+	t.Setenv(config.SBSH_ROOT_PROFILES_DIR.EnvVar(), "")
+	t.Setenv(config.SBSH_ROOT_LOG_LEVEL.EnvVar(), "")
+	_ = config.SBSH_ROOT_CONFIG_FILE.BindEnv()
+
+	if err := LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if got, want := viper.GetString(config.SBSH_ROOT_RUN_PATH.ViperKey), "/tmp/sbsh-root-test-run"; got != want {
+		t.Fatalf("run path = %q, want %q", got, want)
+	}
+	if got, want := viper.GetString(config.SBSH_ROOT_PROFILES_DIR.ViperKey), "/tmp/sbsh-root-test-profiles.d"; got != want {
+		t.Fatalf("profiles dir = %q, want %q", got, want)
+	}
+	if got, want := viper.GetString(config.SBSH_ROOT_LOG_LEVEL.ViperKey), "debug"; got != want {
+		t.Fatalf("log level = %q, want %q", got, want)
+	}
+}
+
+func Test_LoadConfig_EmptyConfigUsesDefault(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	// No config file set anywhere -> LoadConfig falls back to
+	// config.DefaultConfigFile(), which (absent on this host) loads as a
+	// nil doc and the built-in defaults apply.
+	t.Setenv(config.SBSH_ROOT_CONFIG_FILE.EnvVar(), "")
+	t.Setenv(config.SBSH_ROOT_RUN_PATH.EnvVar(), "")
+	t.Setenv(config.SBSH_ROOT_PROFILES_DIR.EnvVar(), "")
+	t.Setenv(config.SBSH_ROOT_LOG_LEVEL.EnvVar(), "")
+
+	if err := LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if got, want := viper.GetString(config.SBSH_ROOT_RUN_PATH.ViperKey), config.DefaultRunPath(); got != want {
+		t.Fatalf("run path = %q, want %q", got, want)
+	}
+}
+
+func Test_LoadConfig_MalformedConfigErrors(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("\tnot: [valid"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv(config.SBSH_ROOT_CONFIG_FILE.EnvVar(), cfgPath)
+	_ = config.SBSH_ROOT_CONFIG_FILE.BindEnv()
+
+	if err := LoadConfig(); err == nil {
+		t.Fatal("expected error for malformed config file")
+	}
+}
+
+func Test_RootCmd_PreRunE_SetupLoggerError(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	// Point the client log file at a path whose parent is a regular file so
+	// the logger's MkdirAll/Open fails, exercising PreRunE's error return.
+	parent := filepath.Join(t.TempDir(), "afile")
+	if err := os.WriteFile(parent, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	viper.Set(config.SBSH_CLIENT_LOG_FILE.ViperKey, filepath.Join(parent, "sub", "log"))
+
+	rootCmd, err := NewSbshRootCmd()
+	if err != nil {
+		t.Fatalf("NewSbshRootCmd() error = %v", err)
+	}
+	rootCmd.SetContext(context.Background())
+
+	if err := rootCmd.PreRunE(rootCmd, []string{}); err == nil {
+		t.Fatal("expected error when log file path is unwritable")
+	}
+}
+
+func Test_detachSelf_AlreadyDetached(t *testing.T) {
+	// SB_DETACHED=1 short-circuits before any re-exec, so the call is a
+	// safe no-op (no os.Exit, no child process).
+	t.Setenv("SB_DETACHED", "1")
+	detachSelf()
+}
+
+func Test_RootCmd_RunE_DetachPath(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	// SB_DETACHED=1 makes detachSelf a no-op, so RunE's detach branch
+	// returns nil without re-exec or os.Exit.
+	t.Setenv("SB_DETACHED", "1")
+	viper.Set(config.SBSH_CLIENT_DETACH.ViperKey, true)
+
+	rootCmd, err := NewSbshRootCmd()
+	if err != nil {
+		t.Fatalf("NewSbshRootCmd() error = %v", err)
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+	rootCmd.SetContext(ctx)
+
+	if err := rootCmd.RunE(rootCmd, []string{}); err != nil {
+		t.Fatalf("RunE() detach path error = %v", err)
+	}
+}
+
+func Test_RootCmd_RunE_MissingLogger(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	rootCmd, err := NewSbshRootCmd()
+	if err != nil {
+		t.Fatalf("NewSbshRootCmd() error = %v", err)
+	}
+	rootCmd.SetContext(context.Background())
+
+	if err := rootCmd.RunE(rootCmd, []string{}); err == nil {
+		t.Fatal("expected error when logger is missing from context")
+	}
+}
+
+func Test_RootCmd_PersistentPreRunE(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	missingCfg := filepath.Join(t.TempDir(), "config.yaml")
+	t.Setenv(config.SBSH_ROOT_CONFIG_FILE.EnvVar(), missingCfg)
+	_ = config.SBSH_ROOT_CONFIG_FILE.BindEnv()
+	t.Setenv(config.SBSH_ROOT_RUN_PATH.EnvVar(), "")
+	t.Setenv(config.SBSH_ROOT_PROFILES_DIR.EnvVar(), "")
+	t.Setenv(config.SBSH_ROOT_LOG_LEVEL.EnvVar(), "")
+
+	rootCmd, err := NewSbshRootCmd()
+	if err != nil {
+		t.Fatalf("NewSbshRootCmd() error = %v", err)
+	}
+	rootCmd.SetContext(context.Background())
+
+	if err := rootCmd.PersistentPreRunE(rootCmd, []string{}); err != nil {
+		t.Fatalf("PersistentPreRunE() error = %v", err)
+	}
+}
+
+func Test_RootCmd_PreRunE_DerivesDefaults(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	viper.Set(config.SBSH_ROOT_RUN_PATH.ViperKey, t.TempDir())
+
+	rootCmd, err := NewSbshRootCmd()
+	if err != nil {
+		t.Fatalf("NewSbshRootCmd() error = %v", err)
+	}
+	rootCmd.SetContext(context.Background())
+
+	if err := rootCmd.PreRunE(rootCmd, []string{}); err != nil {
+		t.Fatalf("PreRunE() error = %v", err)
+	}
+
+	if got := viper.GetString(config.SBSH_CLIENT_ID.ViperKey); got == "" {
+		t.Fatal("expected a generated client ID")
+	}
+}
+
+func Test_RootCmd_RunE_SpecBuildError(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	// No run path -> BuildTerminalSpecFromProfile rejects, exercising RunE's
+	// logging + spec-param assembly and the build-error return.
+	viper.Set(config.SBSH_CLIENT_DETACH.ViperKey, false)
+
+	rootCmd, err := NewSbshRootCmd()
+	if err != nil {
+		t.Fatalf("NewSbshRootCmd() error = %v", err)
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	rootCmd.SetContext(context.WithValue(context.Background(), types.CtxLogger, logger))
+
+	if err := rootCmd.RunE(rootCmd, []string{}); err == nil {
+		t.Fatal("expected spec-build error when run path is empty")
+	}
+}
+
+func Test_setAutoCompleteProfile_CompletionFunc(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	t.Setenv(config.SBSH_ROOT_PROFILES_DIR.EnvVar(), t.TempDir())
+
+	rootCmd, err := NewSbshRootCmd()
+	if err != nil {
+		t.Fatalf("NewSbshRootCmd() error = %v", err)
+	}
+
+	fn, ok := rootCmd.GetFlagCompletionFunc("terminal-profile")
+	if !ok || fn == nil {
+		t.Fatal("expected a registered completion func for terminal-profile")
+	}
+
+	_, directive := fn(rootCmd, []string{}, "")
+	if directive != cobra.ShellCompDirectiveNoFileComp {
+		t.Fatalf("expected ShellCompDirectiveNoFileComp; got %v", directive)
+	}
+}
+
+func Test_RootCmd_PostRunE(t *testing.T) {
+	rootCmd, err := NewSbshRootCmd()
+	if err != nil {
+		t.Fatalf("NewSbshRootCmd() error = %v", err)
+	}
+
+	t.Run("nil closer", func(t *testing.T) {
+		rootCmd.SetContext(context.Background())
+		if err := rootCmd.PostRunE(rootCmd, []string{}); err != nil {
+			t.Fatalf("PostRunE() error = %v", err)
+		}
+	})
+
+	t.Run("closer closed", func(t *testing.T) {
+		c := &rootRecordingCloser{}
+		ctx := context.WithValue(context.Background(), types.CtxCloser, io.Closer(c))
+		rootCmd.SetContext(ctx)
+		if err := rootCmd.PostRunE(rootCmd, []string{}); err != nil {
+			t.Fatalf("PostRunE() error = %v", err)
+		}
+		if !c.closed {
+			t.Fatal("expected closer to be closed")
+		}
+	})
+}
+
+type rootRecordingCloser struct{ closed bool }
+
+func (r *rootRecordingCloser) Close() error {
+	r.closed = true
+	return nil
 }
 
 func Test_setTerminalFlags_ProfileEnvBinding(t *testing.T) {

--- a/cmd/sbsh/terminal/terminal_test.go
+++ b/cmd/sbsh/terminal/terminal_test.go
@@ -511,3 +511,349 @@ func Test_processSpec_RejectsWorkloadWithSpec(t *testing.T) {
 		t.Fatalf("expected '%v'; got: '%v'", errdefs.ErrInvalidArgument, err)
 	}
 }
+
+func TestRunTerminal_ChildExitError(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	ctrl := &terminal.ControllerTest{
+		RunFunc:       func(_ *api.TerminalSpec) error { return errdefs.ErrChildExit },
+		WaitReadyFunc: func() error { return nil },
+		WaitCloseFunc: func() error { return errors.New("close failed") },
+	}
+
+	spec := api.TerminalSpec{
+		ID:      api.ID(naming.RandomID()),
+		Kind:    api.TerminalLocal,
+		Name:    naming.RandomName(),
+		Command: "/bin/bash",
+	}
+
+	done := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { done <- runTerminal(ctx, cancel, logger, ctrl, &spec) }()
+
+	select {
+	case err := <-done:
+		// runTerminal swallows child-exit errors to avoid polluting the
+		// terminal; it returns nil after exercising the WaitClose branch.
+		if err != nil {
+			t.Fatalf("expected nil (child-exit is swallowed); got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for runTerminal to return")
+	}
+}
+
+func Test_buildTerminalSpecFromFlags_RunPathRequired(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	// No run path set -> BuildTerminalSpecFromProfile rejects with ErrRunPathRequired.
+	cmd := NewTerminalCmd()
+	cmd.SetContext(context.Background())
+
+	spec, err := buildTerminalSpecFromFlags(cmd, logger, nil)
+	if err == nil {
+		t.Fatal("expected error when run path is empty")
+	}
+	if spec != nil {
+		t.Fatal("expected nil spec on error")
+	}
+}
+
+func Test_checkStdInUsage_RejectsConflictingFlags(t *testing.T) {
+	cmd := NewTerminalCmd()
+	if err := cmd.Flags().Set("name", "foo"); err != nil {
+		t.Fatalf("set name flag: %v", err)
+	}
+
+	err := checkStdInUsage(cmd, []string{"-"})
+	if err == nil {
+		t.Fatal("expected error when --name is used alongside stdin '-'")
+	}
+	if !errors.Is(err, errdefs.ErrInvalidFlag) {
+		t.Fatalf("expected '%v'; got: '%v'", errdefs.ErrInvalidFlag, err)
+	}
+}
+
+func Test_checkStdInUsage_NoFlagsOK(t *testing.T) {
+	cmd := NewTerminalCmd()
+	if err := checkStdInUsage(cmd, []string{"-"}); err != nil {
+		t.Fatalf("expected nil when no conflicting flags set; got %v", err)
+	}
+}
+
+func Test_readGIDFlag(t *testing.T) {
+	const flagName = "socket-gid"
+	const envName = "SBSH_TEST_GID"
+
+	t.Run("flag changed wins", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		cmd.Flags().Int(flagName, -1, "")
+		if err := cmd.Flags().Set(flagName, "42"); err != nil {
+			t.Fatalf("set flag: %v", err)
+		}
+		got := readGIDFlag(cmd, flagName, envName)
+		if got == nil || *got != 42 {
+			t.Fatalf("expected 42; got %v", got)
+		}
+	})
+
+	t.Run("env used when flag unchanged", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		cmd.Flags().Int(flagName, -1, "")
+		t.Setenv(envName, "7")
+		got := readGIDFlag(cmd, flagName, envName)
+		if got == nil || *got != 7 {
+			t.Fatalf("expected 7; got %v", got)
+		}
+	})
+
+	t.Run("nil when neither set", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		cmd.Flags().Int(flagName, -1, "")
+		t.Setenv(envName, "")
+		if got := readGIDFlag(cmd, flagName, envName); got != nil {
+			t.Fatalf("expected nil; got %v", got)
+		}
+	})
+
+	t.Run("nil when env not parseable", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		cmd.Flags().Int(flagName, -1, "")
+		t.Setenv(envName, "not-a-number")
+		if got := readGIDFlag(cmd, flagName, envName); got != nil {
+			t.Fatalf("expected nil; got %v", got)
+		}
+	})
+}
+
+func Test_readGIDWrappers(t *testing.T) {
+	cmd := NewTerminalCmd()
+	if err := cmd.Flags().Set("socket-gid", "11"); err != nil {
+		t.Fatalf("set socket-gid: %v", err)
+	}
+	if err := cmd.Flags().Set("capture-gid", "12"); err != nil {
+		t.Fatalf("set capture-gid: %v", err)
+	}
+	if err := cmd.Flags().Set("log-file-gid", "13"); err != nil {
+		t.Fatalf("set log-file-gid: %v", err)
+	}
+
+	if got := readSocketGID(cmd); got == nil || *got != 11 {
+		t.Fatalf("readSocketGID: expected 11; got %v", got)
+	}
+	if got := readCaptureGID(cmd); got == nil || *got != 12 {
+		t.Fatalf("readCaptureGID: expected 12; got %v", got)
+	}
+	if got := readLogFileGID(cmd); got == nil || *got != 13 {
+		t.Fatalf("readLogFileGID: expected 13; got %v", got)
+	}
+}
+
+func Test_setLoggingVarsFromFlags_Defaults(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	runPath := t.TempDir()
+	viper.Set(config.SB_ROOT_RUN_PATH.ViperKey, runPath)
+
+	setLoggingVarsFromFlags()
+
+	if got := viper.GetString(config.SBSH_TERM_ID.ViperKey); got == "" {
+		t.Fatal("expected a generated terminal ID")
+	}
+	if got := viper.GetString(config.SBSH_TERM_LOG_LEVEL.ViperKey); got != "info" {
+		t.Fatalf("expected log level info; got %q", got)
+	}
+	if got := viper.GetString(config.SBSH_TERM_LOG_FILE.ViperKey); got == "" {
+		t.Fatal("expected a derived log file path")
+	}
+}
+
+func Test_buildTerminalSpecFromFlags_DefaultProfile(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	viper.Set(config.SB_ROOT_RUN_PATH.ViperKey, t.TempDir())
+	// Point profiles dir at an empty dir so the loader falls back to the
+	// hardcoded default profile rather than reading the caller's $HOME.
+	viper.Set(config.SBSH_ROOT_PROFILES_DIR.ViperKey, t.TempDir())
+
+	cmd := NewTerminalCmd()
+	cmd.SetContext(context.Background())
+
+	spec, err := buildTerminalSpecFromFlags(cmd, logger, []string{"/bin/echo", "hi"})
+	if err != nil {
+		t.Fatalf("buildTerminalSpecFromFlags() error = %v", err)
+	}
+	if spec == nil {
+		t.Fatal("expected non-nil spec")
+	}
+	if spec.Command != "/bin/echo" {
+		t.Fatalf("expected command /bin/echo from workload; got %q", spec.Command)
+	}
+}
+
+func Test_processSpec_BuildsFromFlags(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	runPath := t.TempDir()
+	viper.Set(config.SB_ROOT_RUN_PATH.ViperKey, runPath)
+	viper.Set(config.SBSH_ROOT_PROFILES_DIR.ViperKey, t.TempDir())
+	viper.Set(config.SBSH_TERM_LOG_FILE.ViperKey, filepath.Join(t.TempDir(), "term.log"))
+	viper.Set(config.SBSH_TERM_LOG_LEVEL.ViperKey, "info")
+
+	cmd := NewTerminalCmd()
+	cmd.SetContext(context.Background())
+
+	var spec *api.TerminalSpec
+	if err := processSpec(cmd, &spec, []string{"/bin/echo"}); err != nil {
+		t.Fatalf("processSpec() error = %v", err)
+	}
+	if spec == nil {
+		t.Fatal("expected spec to be built from flags")
+	}
+	if spec.Command != "/bin/echo" {
+		t.Fatalf("expected command /bin/echo; got %q", spec.Command)
+	}
+}
+
+func Test_TerminalCmd_PreRunE_BuildsSpecFromFlags(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	viper.Set(config.SB_ROOT_RUN_PATH.ViperKey, t.TempDir())
+	viper.Set(config.SBSH_ROOT_PROFILES_DIR.ViperKey, t.TempDir())
+	viper.Set(config.SBSH_TERM_LOG_FILE.ViperKey, filepath.Join(t.TempDir(), "term.log"))
+
+	cmd := NewTerminalCmd()
+	cmd.SetContext(context.Background())
+
+	if err := cmd.PreRunE(cmd, []string{}); err != nil {
+		t.Fatalf("PreRunE() error = %v", err)
+	}
+
+	spec, ok := cmd.Context().Value(types.CtxTerminalSpec).(*api.TerminalSpec)
+	if !ok || spec == nil {
+		t.Fatal("expected terminal spec to be stored in context after PreRunE")
+	}
+}
+
+func Test_TerminalCmd_PreRunE_FromFileSpec(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	logFile := filepath.Join(t.TempDir(), "term.log")
+	fileSpec := api.TerminalSpec{
+		ID:       api.ID("file-id"),
+		Kind:     api.TerminalLocal,
+		Name:     "file-name",
+		Command:  "/bin/bash",
+		LogFile:  logFile,
+		LogLevel: "info",
+	}
+	jsonData, err := json.Marshal(fileSpec)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	specFile := filepath.Join(t.TempDir(), "spec.json")
+	if err := os.WriteFile(specFile, jsonData, 0o600); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+	viper.Set(config.SBSH_TERM_SPEC.ViperKey, specFile)
+
+	cmd := NewTerminalCmd()
+	cmd.SetContext(context.Background())
+
+	if err := cmd.PreRunE(cmd, []string{}); err != nil {
+		t.Fatalf("PreRunE() error = %v", err)
+	}
+
+	spec, ok := cmd.Context().Value(types.CtxTerminalSpec).(*api.TerminalSpec)
+	if !ok || spec == nil {
+		t.Fatal("expected terminal spec from file in context")
+	}
+	if spec.ID != fileSpec.ID {
+		t.Fatalf("expected ID %q; got %q", fileSpec.ID, spec.ID)
+	}
+}
+
+func Test_TerminalCmd_PreRunE_InvalidArgErrors(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	cmd := NewTerminalCmd()
+	cmd.SetContext(context.Background())
+
+	err := cmd.PreRunE(cmd, []string{"bogus"})
+	if err == nil {
+		t.Fatal("expected error for invalid positional argument")
+	}
+	if !errors.Is(err, errdefs.ErrInvalidArgument) {
+		t.Fatalf("expected '%v'; got: '%v'", errdefs.ErrInvalidArgument, err)
+	}
+}
+
+func Test_TerminalCmd_PostRunE(t *testing.T) {
+	t.Run("nil closer is a no-op", func(t *testing.T) {
+		cmd := NewTerminalCmd()
+		cmd.SetContext(context.Background())
+		if err := cmd.PostRunE(cmd, []string{}); err != nil {
+			t.Fatalf("PostRunE() error = %v", err)
+		}
+	})
+
+	t.Run("closer is closed", func(t *testing.T) {
+		cmd := NewTerminalCmd()
+		c := &recordingCloser{}
+		ctx := context.WithValue(context.Background(), types.CtxCloser, io.Closer(c))
+		cmd.SetContext(ctx)
+		if err := cmd.PostRunE(cmd, []string{}); err != nil {
+			t.Fatalf("PostRunE() error = %v", err)
+		}
+		if !c.closed {
+			t.Fatal("expected closer to be closed")
+		}
+	})
+}
+
+type recordingCloser struct{ closed bool }
+
+func (r *recordingCloser) Close() error {
+	r.closed = true
+	return nil
+}
+
+func Test_setupTerminalCmdFlags_BindsFlags(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	cmd := &cobra.Command{Use: "terminal"}
+	setupTerminalCmdFlags(cmd)
+
+	cases := []struct {
+		flagName string
+		value    string
+		viperKey string
+	}{
+		{"id", "tid", config.SBSH_TERM_ID.ViperKey},
+		{"name", "tname", config.SBSH_TERM_NAME.ViperKey},
+		{"log-file", "/tmp/t.log", config.SBSH_TERM_LOG_FILE.ViperKey},
+		{"capture-file", "/tmp/c.log", config.SBSH_TERM_CAPTURE_FILE.ViperKey},
+		{"socket", "/tmp/t.sock", config.SBSH_TERM_SOCKET.ViperKey},
+	}
+	for _, tc := range cases {
+		t.Run(tc.flagName, func(t *testing.T) {
+			if err := cmd.Flags().Set(tc.flagName, tc.value); err != nil {
+				t.Fatalf("set %s: %v", tc.flagName, err)
+			}
+			if got := viper.GetString(tc.viperKey); got != tc.value {
+				t.Fatalf("viper key %s: expected %s, got %s", tc.viperKey, tc.value, got)
+			}
+		})
+	}
+}

--- a/cmd/sbsh/version/version_test.go
+++ b/cmd/sbsh/version/version_test.go
@@ -1,0 +1,63 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package version
+
+import (
+	"bufio"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/sbsh/cmd/config"
+)
+
+func TestNewVersionCmd_Metadata(t *testing.T) {
+	cmd := NewVersionCmd()
+	if cmd.Use != "version" {
+		t.Fatalf("Use = %q, want %q", cmd.Use, "version")
+	}
+	if cmd.Short == "" {
+		t.Fatal("Short should not be empty")
+	}
+	if cmd.Run == nil {
+		t.Fatal("Run should be set")
+	}
+}
+
+func TestNewVersionCmd_PrintsVersion(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = old })
+
+	cmd := NewVersionCmd()
+	cmd.Run(cmd, []string{})
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe: %v", err)
+	}
+	got, err := bufio.NewReader(r).ReadString('\n')
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if strings.TrimSpace(got) != config.Version {
+		t.Fatalf("output = %q, want %q", strings.TrimSpace(got), config.Version)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 6d of the CLI command-layer coverage work (umbrella #304, sliced from #310). Adds table-driven, fake-backed tests for the `sbsh`-side command cluster — exercising flag parsing/binding, argument validation, and error/exit paths without launching real terminals or clients.

Coverage moves:

| package | before | after | ≥80%? |
|---|---|---|---|
| `cmd/sbsh/version` | 0.0% | **100.0%** | ✅ |
| `cmd/sbsh/autocomplete` | 0.0% | **100.0%** | ✅ |
| `cmd/sbsh/terminal` | 46.8% | **81.5%** | ✅ |
| `cmd/sbsh` (`sbsh.go`) | 27.5% | **72.1%** | ⚠️ see ceiling note |

New tests cover, among others: `NewVersionCmd` output, `NewAutoCompleteCmd` bash/zsh/fish + unknown-shell + arg-count paths, the terminal command's GID readers / `checkStdInUsage` / `setLoggingVarsFromFlags` / `buildTerminalSpecFromFlags` / `processSpec` build-from-flags / `PreRunE`/`PostRunE` / `runTerminal` child-exit branch, and the root command's `setClientFlags`/`setPersistentLoggingFlags`/`LoadConfig` (defaults, ConfigurationDoc, malformed, empty) / GID readers / `PersistentPreRunE`/`PreRunE`/`PostRunE` / the `RunE` detach + spec-build-error branches / the `terminal-profile` completion func / the `detachSelf` already-detached guard.

## Coverage ceiling on `cmd/sbsh` (the one AC checkbox left unchecked)

`cmd/sbsh` reaches **72.1%**, below the ≥80% AC. This is a structural ceiling, not missing test effort. Statement-level accounting of `sbsh.go` (258 statements total, measured from the cover profile):

- **37 statements** are `if err := viper.BindPFlag(...); err != nil { return err }` (and `BindEnv`) returns across `setClientFlags`, `setTerminalFlags`, `setPersistentLoggingFlags`, and `setupRootCmd`. `Flags().Lookup("<just-defined-flag>")` never returns nil, so `BindPFlag` never errors here — these returns are **unreachable** from any test.
- **16 statements** are `detachSelf`'s re-exec body (`exec.Command(os.Args[0], …)`, `cmd.Start()`, `os.Exit(0)`). Calling it without the `SB_DETACHED=1` guard would fork the test binary and `os.Exit(0)` the test process — untestable in-process. The guard's early-return path *is* covered.

That floor of **53 unreachable statements** caps `sbsh.go` at **≤79.5%** even if every other statement (including `RunE`'s real client-launch tail, which would need a controller-injection seam) were covered. Reaching ≥80% would require deleting/restructuring legitimate defensive error handling — a code-quality regression I judged out of scope for a test-only PR. Flagging for reviewer/PM: either accept <80% for this package with the above rationale, or relax the per-package bar. I did **not** add a production controller-injection seam (it tops out at ~79.5% anyway, so it adds production risk without meeting the bar).

The other three packages meet ≥80% cleanly.

## Test plan
- [x] `make sbsh-sb` (canonical build; verified ELF via magic bytes `7f 45 4c 46` — `file` not installed on host)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (full CI suite incl. `cmd/sb`, `cmd/sbsh`, `internal/terminal`, `internal/client`, integration `get`, and e2e — all green)
- [x] Per-package coverage confirmed: version 100%, autocomplete 100%, terminal 81.5%, cmd/sbsh 72.1%

Closes #339