### PR TITLE
test: cover cmd shared packages + argv[0] dispatch (phase 6e, ≥80%)

### DIFF
--- a/cmd/config/config_coverage_test.go
+++ b/cmd/config/config_coverage_test.go
@@ -1,0 +1,418 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/pkg/api"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// unsetEnv removes the given env vars for the duration of the test, restoring
+// their prior values on cleanup so production keys do not leak across tests.
+func unsetEnv(t *testing.T, keys ...string) {
+	t.Helper()
+	for _, k := range keys {
+		k := k
+		if old, ok := os.LookupEnv(k); ok {
+			t.Cleanup(func() { _ = os.Setenv(k, old) })
+		} else {
+			t.Cleanup(func() { _ = os.Unsetenv(k) })
+		}
+		_ = os.Unsetenv(k)
+	}
+}
+
+func TestApplyConfigurationDocEnv(t *testing.T) {
+	t.Run("nil doc is a no-op", func(t *testing.T) {
+		ApplyConfigurationDocEnv(nil)
+	})
+
+	t.Run("sets unset vars and skips empty values", func(t *testing.T) {
+		keys := []string{
+			SB_ROOT_RUN_PATH.EnvVar(), SBSH_ROOT_RUN_PATH.EnvVar(),
+			SB_GET_PROFILES_DIR.EnvVar(), SBSH_ROOT_PROFILES_DIR.EnvVar(),
+			SB_ROOT_LOG_LEVEL.EnvVar(), SBSH_ROOT_LOG_LEVEL.EnvVar(),
+		}
+		unsetEnv(t, keys...)
+
+		// LogLevel left empty exercises the value == "" early return.
+		doc := &api.ConfigurationDoc{
+			Spec: api.ConfigurationSpec{
+				RunPath:     "/var/run/sbsh",
+				ProfilesDir: "/etc/sbsh/profiles.d",
+			},
+		}
+		ApplyConfigurationDocEnv(doc)
+
+		if got := os.Getenv(SB_ROOT_RUN_PATH.EnvVar()); got != "/var/run/sbsh" {
+			t.Errorf("SB_RUN_PATH = %q, want /var/run/sbsh", got)
+		}
+		if got := os.Getenv(SBSH_ROOT_PROFILES_DIR.EnvVar()); got != "/etc/sbsh/profiles.d" {
+			t.Errorf("SBSH_PROFILES_DIR = %q, want /etc/sbsh/profiles.d", got)
+		}
+		if _, present := os.LookupEnv(SB_ROOT_LOG_LEVEL.EnvVar()); present {
+			t.Errorf("SB_LOG_LEVEL should remain unset for empty LogLevel")
+		}
+	})
+
+	t.Run("preserves already-set vars", func(t *testing.T) {
+		key := SB_ROOT_RUN_PATH.EnvVar()
+		unsetEnv(t, key)
+		t.Setenv(key, "user-supplied")
+
+		ApplyConfigurationDocEnv(&api.ConfigurationDoc{
+			Spec: api.ConfigurationSpec{RunPath: "/from/doc"},
+		})
+
+		if got := os.Getenv(key); got != "user-supplied" {
+			t.Errorf("SB_RUN_PATH = %q, want user-supplied (precedence env > doc)", got)
+		}
+	})
+}
+
+func TestDefaultPaths(t *testing.T) {
+	for _, fn := range []struct {
+		name string
+		got  string
+	}{
+		{"DefaultRunPath", DefaultRunPath()},
+		{"DefaultProfilesDir", DefaultProfilesDir()},
+		{"DefaultConfigFile", DefaultConfigFile()},
+	} {
+		if !strings.Contains(fn.got, ".sbsh") {
+			t.Errorf("%s() = %q, want it to contain .sbsh", fn.name, fn.got)
+		}
+	}
+}
+
+func TestGetRunPathFromEnvAndFlags(t *testing.T) {
+	const envVar = "SBSH_TEST_RUN_PATH"
+	unsetEnv(t, envVar)
+
+	t.Run("flag wins", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		cmd.Flags().String("run-path", "", "")
+		_ = cmd.Flags().Set("run-path", "/from/flag")
+		got, err := GetRunPathFromEnvAndFlags(cmd, envVar)
+		if err != nil || got != "/from/flag" {
+			t.Fatalf("got (%q, %v), want (/from/flag, nil)", got, err)
+		}
+	})
+
+	t.Run("env when flag empty", func(t *testing.T) {
+		t.Setenv(envVar, "/from/env")
+		cmd := &cobra.Command{}
+		cmd.Flags().String("run-path", "", "")
+		got, err := GetRunPathFromEnvAndFlags(cmd, envVar)
+		if err != nil || got != "/from/env" {
+			t.Fatalf("got (%q, %v), want (/from/env, nil)", got, err)
+		}
+	})
+
+	t.Run("default when flag and env empty", func(t *testing.T) {
+		unsetEnv(t, envVar)
+		cmd := &cobra.Command{}
+		cmd.Flags().String("run-path", "", "")
+		got, err := GetRunPathFromEnvAndFlags(cmd, envVar)
+		if err != nil || got != DefaultRunPath() {
+			t.Fatalf("got (%q, %v), want (%q, nil)", got, err, DefaultRunPath())
+		}
+	})
+}
+
+func TestGetProfilesDirFromEnvAndFlags(t *testing.T) {
+	const envVar = "SBSH_TEST_PROFILES_DIR"
+	unsetEnv(t, envVar)
+
+	t.Run("flag wins", func(t *testing.T) {
+		cmd := &cobra.Command{}
+		cmd.Flags().String("profiles-dir", "", "")
+		_ = cmd.Flags().Set("profiles-dir", "/from/flag")
+		got, err := GetProfilesDirFromEnvAndFlags(cmd, envVar)
+		if err != nil || got != "/from/flag" {
+			t.Fatalf("got (%q, %v), want (/from/flag, nil)", got, err)
+		}
+	})
+
+	t.Run("env when flag empty", func(t *testing.T) {
+		t.Setenv(envVar, "/from/env")
+		cmd := &cobra.Command{}
+		cmd.Flags().String("profiles-dir", "", "")
+		got, err := GetProfilesDirFromEnvAndFlags(cmd, envVar)
+		if err != nil || got != "/from/env" {
+			t.Fatalf("got (%q, %v), want (/from/env, nil)", got, err)
+		}
+	})
+
+	t.Run("default when flag and env empty", func(t *testing.T) {
+		unsetEnv(t, envVar)
+		cmd := &cobra.Command{}
+		cmd.Flags().String("profiles-dir", "", "")
+		got, err := GetProfilesDirFromEnvAndFlags(cmd, envVar)
+		if err != nil || got != DefaultProfilesDir() {
+			t.Fatalf("got (%q, %v), want (%q, nil)", got, err, DefaultProfilesDir())
+		}
+	})
+}
+
+func TestVarMethods(t *testing.T) {
+	const envKey = "SBSH_TEST_VAR"
+	const viperKey = "test/var"
+	unsetEnv(t, envKey)
+
+	v := DefineKV(envKey, viperKey, "fallback")
+	if v.EnvKey() != envKey || v.EnvVar() != envKey {
+		t.Fatalf("EnvKey/EnvVar = %q/%q, want %q", v.EnvKey(), v.EnvVar(), envKey)
+	}
+	if def, ok := v.DefaultValue(); !ok || def != "fallback" {
+		t.Fatalf("DefaultValue = (%q, %v), want (fallback, true)", def, ok)
+	}
+
+	// default branch: no viper, no env.
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	if got := v.ValueOrDefault(); got != "fallback" {
+		t.Fatalf("ValueOrDefault default = %q, want fallback", got)
+	}
+
+	// env branch.
+	t.Setenv(envKey, "from-env")
+	if got := v.ValueOrDefault(); got != "from-env" {
+		t.Fatalf("ValueOrDefault env = %q, want from-env", got)
+	}
+
+	// viper branch wins over env.
+	viper.Set(viperKey, "from-viper")
+	if got := v.ValueOrDefault(); got != "from-viper" {
+		t.Fatalf("ValueOrDefault viper = %q, want from-viper", got)
+	}
+
+	if err := v.BindEnv(); err != nil {
+		t.Fatalf("BindEnv() error = %v", err)
+	}
+
+	// Define without a viper key: ValueOrDefault skips viper, BindEnv is a no-op,
+	// and an absent env with no default yields "".
+	noViper := Define("SBSH_TEST_NOVIPER")
+	unsetEnv(t, "SBSH_TEST_NOVIPER")
+	if err := noViper.BindEnv(); err != nil {
+		t.Fatalf("BindEnv() on empty viper key = %v, want nil", err)
+	}
+	if got := noViper.ValueOrDefault(); got != "" {
+		t.Fatalf("ValueOrDefault no-default = %q, want empty", got)
+	}
+
+	// Set writes the OS env; SetDefault updates the default + viper default.
+	if err := v.Set("written"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	if got := os.Getenv(envKey); got != "written" {
+		t.Fatalf("after Set, env = %q, want written", got)
+	}
+	v.SetDefault("new-default")
+	if def, ok := v.DefaultValue(); !ok || def != "new-default" {
+		t.Fatalf("after SetDefault, DefaultValue = (%q, %v), want (new-default, true)", def, ok)
+	}
+
+	if got := KV(v, "x"); got != envKey+"=x" {
+		t.Fatalf("KV = %q, want %q", got, envKey+"=x")
+	}
+}
+
+const sampleProfile = `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: alpha
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/bash
+`
+
+func writeTerminalDoc(t *testing.T, runPath, id, name string, state api.TerminalStatusMode) {
+	t.Helper()
+	dir := filepath.Join(runPath, defaults.TerminalsRunPath, id)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	doc := api.TerminalDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindTerminal,
+		Metadata:   api.TerminalMetadata{Name: name},
+		Spec:       api.TerminalSpec{ID: api.ID(id), Name: name, RunPath: runPath},
+		Status:     api.TerminalStatus{State: state},
+	}
+	b, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), b, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func writeClientDoc(t *testing.T, runPath, id, name string, state api.ClientStatusMode) {
+	t.Helper()
+	dir := filepath.Join(runPath, defaults.ClientsRunPath, id)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	doc := api.ClientDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindClient,
+		Metadata:   api.ClientMetadata{Name: name},
+		Spec:       api.ClientSpec{ID: api.ID(id), RunPath: runPath},
+		Status:     api.ClientStatus{State: state},
+	}
+	b, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), b, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestAutoCompleteListProfileNames(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("no profiles", func(t *testing.T) {
+		if _, err := AutoCompleteListProfileNames(ctx, nil, t.TempDir()); err == nil {
+			t.Fatal("expected error for empty profiles dir, got nil")
+		}
+	})
+
+	t.Run("happy path", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "alpha.yaml"), []byte(sampleProfile), 0o644); err != nil {
+			t.Fatalf("write profile: %v", err)
+		}
+		names, err := AutoCompleteListProfileNames(ctx, nil, dir)
+		if err != nil {
+			t.Fatalf("AutoCompleteListProfileNames() error = %v", err)
+		}
+		if !slices.Contains(names, "alpha") {
+			t.Fatalf("names = %v, want it to contain alpha", names)
+		}
+	})
+}
+
+func TestAutoCompleteListTerminalNamesAndIDs(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty run path yields no names", func(t *testing.T) {
+		names, err := AutoCompleteListTerminalNames(ctx, nil, t.TempDir(), false)
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		if len(names) != 0 {
+			t.Fatalf("names = %v, want empty", names)
+		}
+	})
+
+	runPath := t.TempDir()
+	writeTerminalDoc(t, runPath, "id-active", "active", api.Ready)
+	writeTerminalDoc(t, runPath, "id-exited", "exited", api.Exited)
+
+	t.Run("names exclude exited by default", func(t *testing.T) {
+		names, err := AutoCompleteListTerminalNames(ctx, nil, runPath, false)
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		if !slices.Contains(names, "active") || slices.Contains(names, "exited") {
+			t.Fatalf("names = %v, want active only", names)
+		}
+	})
+
+	t.Run("names include exited when requested", func(t *testing.T) {
+		names, err := AutoCompleteListTerminalNames(ctx, nil, runPath, true)
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		if !slices.Contains(names, "active") || !slices.Contains(names, "exited") {
+			t.Fatalf("names = %v, want both", names)
+		}
+	})
+
+	t.Run("ids exclude exited by default", func(t *testing.T) {
+		ids, err := AutoCompleteListTerminalIDs(ctx, nil, runPath, false)
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		if !slices.Contains(ids, "id-active") || slices.Contains(ids, "id-exited") {
+			t.Fatalf("ids = %v, want id-active only", ids)
+		}
+	})
+
+	t.Run("ids include exited when requested", func(t *testing.T) {
+		ids, err := AutoCompleteListTerminalIDs(ctx, nil, runPath, true)
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		if len(ids) != 2 {
+			t.Fatalf("ids = %v, want both", ids)
+		}
+	})
+}
+
+func TestAutoCompleteListClientNames(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty run path yields no names", func(t *testing.T) {
+		names, err := AutoCompleteListClientNames(ctx, nil, t.TempDir(), false)
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		if len(names) != 0 {
+			t.Fatalf("names = %v, want empty", names)
+		}
+	})
+
+	runPath := t.TempDir()
+	writeClientDoc(t, runPath, "c-active", "active", api.ClientReady)
+	writeClientDoc(t, runPath, "c-exited", "exited", api.ClientExited)
+
+	t.Run("excludes exited by default", func(t *testing.T) {
+		names, err := AutoCompleteListClientNames(ctx, nil, runPath, false)
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		if !slices.Contains(names, "active") || slices.Contains(names, "exited") {
+			t.Fatalf("names = %v, want active only", names)
+		}
+	})
+
+	t.Run("includes exited when requested", func(t *testing.T) {
+		names, err := AutoCompleteListClientNames(ctx, nil, runPath, true)
+		if err != nil {
+			t.Fatalf("error = %v", err)
+		}
+		if !slices.Contains(names, "active") || !slices.Contains(names, "exited") {
+			t.Fatalf("names = %v, want both", names)
+		}
+	})
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -48,14 +49,15 @@ func runWithFactory(ctx context.Context, factory rootFactory) int {
 	return execRoot(root)
 }
 
-func main() {
-	logger := logging.NewNoopLogger()
-	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
-
-	// Select which subtree to run based on the executable name
-	exe := filepath.Base(os.Args[0])
-
-	// Decide which subtree to run by prepending the name as the first arg
+// dispatch selects the subtree to run based on the executable name (exe),
+// falling back to the SBSH_DEBUG_MODE value (debug) when exe is unrecognized.
+//
+// The debug fallback is useful for development and debugging purposes: it
+// allows running sbsh/sb even when the executable is not named sbsh or sb,
+// e.g. when launched from an IDE or a debugger. SBSH_DEBUG_MODE can be set to
+// "sbsh" or "sb" to run the corresponding subtree. The bool is false when
+// neither exe nor debug names a known subtree.
+func dispatch(exe, debug string) (rootFactory, bool) {
 	factories := map[string]rootFactory{
 		"sb":    sb.NewSbRootCmd,
 		"sbsh":  sbsh.NewSbshRootCmd,
@@ -63,22 +65,29 @@ func main() {
 	}
 
 	if factory, ok := factories[exe]; ok {
-		os.Exit(runWithFactory(ctx, factory))
+		return factory, true
 	}
-
-	// Fallback to sbsh if SBSH_DEBUG_MODE is set
-	// This is useful for development and debugging purposes
-	// as it allows to run sbsh even if the executable is not named sbsh
-	// or sb. For example, when running from an IDE or a debugger.
-	// In this case, SBSH_DEBUG_MODE can be set to "sbsh" or "sb"
-	// to run the corresponding subtree.
-	// If SBSH_DEBUG_MODE is not set, an error is printed and the program exits.
-	// This avoids confusion and ensures that the user is aware of the correct usage.
-	debug := os.Getenv("SBSH_DEBUG_MODE")
 	if factory, ok := factories[debug]; ok {
-		os.Exit(runWithFactory(ctx, factory))
+		return factory, true
 	}
+	return nil, false
+}
 
-	fmt.Fprintf(os.Stderr, "unknown entry command: %s\n", exe)
-	os.Exit(1)
+func run(args []string, getenv func(string) string, stderr io.Writer) int {
+	logger := logging.NewNoopLogger()
+	ctx := context.WithValue(context.Background(), types.CtxLogger, logger)
+
+	exe := filepath.Base(args[0])
+	debug := getenv("SBSH_DEBUG_MODE")
+
+	factory, ok := dispatch(exe, debug)
+	if !ok {
+		fmt.Fprintf(stderr, "unknown entry command: %s\n", exe)
+		return 1
+	}
+	return runWithFactory(ctx, factory)
+}
+
+func main() {
+	os.Exit(run(os.Args, os.Getenv, os.Stderr))
 }

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,129 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestDispatch(t *testing.T) {
+	tests := []struct {
+		name   string
+		exe    string
+		debug  string
+		wantOK bool
+	}{
+		{name: "exe sb", exe: "sb", debug: "", wantOK: true},
+		{name: "exe sbsh", exe: "sbsh", debug: "", wantOK: true},
+		{name: "exe -sbsh", exe: "-sbsh", debug: "", wantOK: true},
+		{name: "debug fallback sb", exe: "weird", debug: "sb", wantOK: true},
+		{name: "debug fallback sbsh", exe: "weird", debug: "sbsh", wantOK: true},
+		{name: "unknown exe empty debug", exe: "weird", debug: "", wantOK: false},
+		{name: "unknown exe unknown debug", exe: "weird", debug: "nope", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory, ok := dispatch(tt.exe, tt.debug)
+			if ok != tt.wantOK {
+				t.Fatalf("dispatch(%q, %q) ok = %v, want %v", tt.exe, tt.debug, ok, tt.wantOK)
+			}
+			if tt.wantOK && factory == nil {
+				t.Fatal("expected non-nil factory when ok is true")
+			}
+			if !tt.wantOK && factory != nil {
+				t.Fatal("expected nil factory when ok is false")
+			}
+		})
+	}
+}
+
+func TestRun_UnknownCommand(t *testing.T) {
+	var stderr bytes.Buffer
+	got := run([]string{"/usr/bin/bogus"}, func(string) string { return "" }, &stderr)
+	if got != 1 {
+		t.Fatalf("run() = %d, want 1", got)
+	}
+	if !strings.Contains(stderr.String(), "unknown entry command: bogus") {
+		t.Fatalf("stderr = %q, want it to mention the unknown command", stderr.String())
+	}
+}
+
+func TestExecRoot(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		cmd := &cobra.Command{
+			Use:           "x",
+			SilenceUsage:  true,
+			SilenceErrors: true,
+			RunE:          func(*cobra.Command, []string) error { return nil },
+		}
+		cmd.SetArgs([]string{})
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+		if got := execRoot(cmd); got != 0 {
+			t.Fatalf("execRoot() = %d, want 0", got)
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		cmd := &cobra.Command{
+			Use:           "x",
+			SilenceUsage:  true,
+			SilenceErrors: true,
+			RunE:          func(*cobra.Command, []string) error { return errors.New("boom") },
+		}
+		cmd.SetArgs([]string{})
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+		if got := execRoot(cmd); got != 1 {
+			t.Fatalf("execRoot() = %d, want 1", got)
+		}
+	})
+}
+
+func TestRunWithFactory(t *testing.T) {
+	t.Run("factory error", func(t *testing.T) {
+		factory := func() (*cobra.Command, error) { return nil, errors.New("build failed") }
+		if got := runWithFactory(context.Background(), factory); got != 1 {
+			t.Fatalf("runWithFactory() = %d, want 1", got)
+		}
+	})
+
+	t.Run("factory success", func(t *testing.T) {
+		factory := func() (*cobra.Command, error) {
+			cmd := &cobra.Command{
+				Use:           "x",
+				SilenceUsage:  true,
+				SilenceErrors: true,
+				RunE:          func(*cobra.Command, []string) error { return nil },
+			}
+			cmd.SetArgs([]string{})
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+			return cmd, nil
+		}
+		if got := runWithFactory(context.Background(), factory); got != 0 {
+			t.Fatalf("runWithFactory() = %d, want 0", got)
+		}
+	})
+}

--- a/cmd/parser/parser_test.go
+++ b/cmd/parser/parser_test.go
@@ -1,0 +1,66 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package parser
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+func TestJoinLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		in   map[string]string
+		want string
+	}{
+		{name: "nil map", in: nil, want: "none"},
+		{name: "empty map", in: map[string]string{}, want: "none"},
+		{name: "single", in: map[string]string{"env": "prod"}, want: "env=prod"},
+		{
+			name: "multiple sorted by key",
+			in:   map[string]string{"team": "infra", "env": "prod", "app": "api"},
+			want: "app=api,env=prod,team=infra",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := JoinLabels(tt.in); got != tt.want {
+				t.Fatalf("JoinLabels(%v) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetTerminalLabelsString(t *testing.T) {
+	t.Run("returns labels when present", func(t *testing.T) {
+		labels := map[string]string{"env": "prod"}
+		doc := api.TerminalDoc{Spec: api.TerminalSpec{Labels: labels}}
+		if got := GetTerminalLabelsString(doc); !reflect.DeepEqual(got, labels) {
+			t.Fatalf("GetTerminalLabelsString() = %v, want %v", got, labels)
+		}
+	})
+
+	t.Run("returns empty map when no labels", func(t *testing.T) {
+		doc := api.TerminalDoc{}
+		got := GetTerminalLabelsString(doc)
+		if len(got) != 0 {
+			t.Fatalf("GetTerminalLabelsString() = %v, want empty map", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Phase 6e of the CLI command-layer coverage work (#304 umbrella, sliced from #310). Raises the three cross-cutting/top-level CLI packages above the ≥80% statement-coverage bar with test-only additions plus one small testability seam.
- Coverage achieved: `cmd` 0.0% → **91.7%**, `cmd/config` 18.0% → **86.3%**, `cmd/parser` 0.0% → **100.0%**.
- **Non-obvious call (please push back if it oversteps):** `main()` could not be tested in-process because it calls `os.Exit`. To make the argv[0] dispatch routing testable per the AC, I extracted a behavior-preserving `dispatch(exe, debug) (rootFactory, bool)` plus a `run(args, getenv, stderr) int` seam from `main()`; `main()` is now the single one-line `os.Exit(run(...))` (the only statement that stays uncovered). No runtime behavior changed — the factory map, debug-mode fallback, and unknown-command error path are identical. This is the one piece of non-test code in the diff.
- `cmd/config` tests use temp-dir fixtures (terminal/client `metadata.json`, profile YAML) modeled on `internal/discovery`'s existing test helpers to drive the autocomplete happy paths and exited-filtering branches.

## Notes for reviewer
- The `terminals == nil` / `clients == nil` "no X found" branches in `cmd/config/autocomplete.go` are unreachable: `pkg/discovery.scanMetadataFiles` returns a non-nil empty slice (`make([]T, 0, …)`), never nil, on an empty/missing dir. They are left uncovered intentionally; coverage still clears 80%.
- `make test` does not currently include `./cmd`, `./cmd/config`, or `./cmd/parser` in its package set, so these new tests are run explicitly below in addition to the full suite.

## Test plan
- [x] `go test -cover ./cmd/ ./cmd/config/ ./cmd/parser/` — all three ≥80% (91.7% / 86.3% / 100.0%)
- [x] `make sbsh-sb` — canonical build, verified ELF magic `7f 45 4c 46`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — full CI suite incl. e2e, all green

Closes #340