### PR TITLE
test: stop terminalrunner SIGSEGV test from dropping a core dump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /node_modules/**
 /sb-*
 /sbsh-*
+core
+core.*

--- a/internal/terminal/terminalrunner/lifecycle_watch_child_exit_test.go
+++ b/internal/terminal/terminalrunner/lifecycle_watch_child_exit_test.go
@@ -90,7 +90,13 @@ func TestWatchChildExit_NonInitMode_PropagatesSignal(t *testing.T) {
 	// Using "kill -SEGV $$" from inside the shell is also possible but the
 	// shell can intercept the SIGSEGV in some implementations; signaling the
 	// process from outside is more deterministic.
-	cmd := exec.Command("/bin/sh", "-c", "sleep 30 & wait")
+	//
+	// `ulimit -c 0` makes the shell drop its own core-dump limit before the
+	// SIGSEGV lands, so a host running the suite under `ulimit -c unlimited`
+	// does not get a stray core.<pid> written into the package working tree.
+	// It does not change the death: WaitStatus still reports Signaled()==true
+	// with Signal()==SIGSEGV, which is all this test asserts.
+	cmd := exec.Command("/bin/sh", "-c", "ulimit -c 0; sleep 30 & wait")
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}


### PR DESCRIPTION
## Summary
- The `terminalrunner` package suite drops a `core.<pid>` (~440 KB ELF) into the working tree when the host runs tests under `ulimit -c unlimited`. The crash is in a spawned child, so `go test` reports PASS and the dump is invisible in CI output.
- **Root cause (localized):** `TestWatchChildExit_NonInitMode_PropagatesSignal` deliberately sends `SIGSEGV` to its `/bin/sh -c "sleep 30 & wait"` child to assert signal-death propagation. SIGSEGV is a core-dumping signal, so under `ulimit -c unlimited` the child dumps core into the package cwd. Confirmed via the core file's own metadata: `from '/bin/sh -c sleep 30 & wait'`, which matches this test verbatim (the shutdown test uses a `trap '' TERM` prefix, ruling it out). It is the sole core-dumping-signal sender in the package's tests.
- **Fix (both mitigations from the issue):**
  1. Root cause: prefix the test's shell command with `ulimit -c 0` so the shell drops its own core limit before the SIGSEGV lands. The signal still kills it — `WaitStatus.Signaled()==true`, `Signal()==SIGSEGV` — so every assertion in the test still holds; only the core file is suppressed. This keeps the test's SIGSEGV intent (per its original AC) intact rather than swapping the signal.
  2. Hygiene: add `core` / `core.*` to `.gitignore` so a stray dump from any future source can never be accidentally committed.

## Premise divergence (documented per CLAUDE.md)
- The issue states the core "Does **not** reproduce when running individual test families in isolation … Only the full-package run trips it — suggests a timing/ordering interaction between tests." **This premise has rotted / was incomplete.** The author's isolation list (`-run TestReaper`, `TestSignal`, `TestSignals`, `TestStartTerminalFullLifecycle`, `TestStartTerminalEmitsExitEvent`) did **not** include `-run TestWatchChildExit`. Running `go test -run TestWatchChildExit_NonInitMode_PropagatesSignal` under `ulimit -c unlimited` reproduces the core deterministically in isolation — there is no timing interaction; it is a single, deterministic test. The remediation goal (no stray core in the tree) is unchanged, so per CLAUDE.md I proceeded with the reinterpreted, narrower scope rather than stalling or bisecting families.

## Test plan
- [x] `bash -c 'ulimit -c unlimited; go test -count=1 .'` in `internal/terminal/terminalrunner` — PASS, **no `core.*` produced** (verified 3× full-package runs; previously dropped exactly one core each run).
- [x] `go test -run TestWatchChildExit ./internal/terminal/terminalrunner/` under `ulimit -c unlimited` — PASS, no core (the previously-reproducing isolated case).
- [x] `make sbsh-sb` — builds; `file ./sbsh` → ELF 64-bit LSB executable.
- [x] `go build ./...`, `go vet ./...` — clean.
- [x] pre-commit hooks (golangci-lint, go fmt, addlicense, …) — all pass.
- [x] Full CI test target `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` + `go test -tags=integration ./cmd/sb/get/...` — ran. Two **pre-existing, unrelated** failures reproduce identically on clean `origin/main` (verified in an isolated worktree) and are **not** introduced by this diff:
  - `cmd/sbsh/terminal` profile tests (`profile "sbsh-dev-1" not found`): a local-env leak — this dev host runs inside an sbsh session exporting `SBSH_TERM_PROFILE=sbsh-dev-1`, which viper picks up; the tests pass with `env -u SBSH_TERM_PROFILE`. CI (clean container, green on main) is unaffected.
  - `TestAttachDetach` (`lifecycle_pty_cluster_test.go`): a parallel-load flake — passes 3/3 in isolation and intermittently on `origin/main`. Untouched by this diff.

Closes #334