### PR TITLE
fix: dedup close-time metadata permission-denied spam to one actionable warning

### DIFF
--- a/internal/terminal/terminalrunner/capture_metadata_cluster_test.go
+++ b/internal/terminal/terminalrunner/capture_metadata_cluster_test.go
@@ -17,12 +17,14 @@
 package terminalrunner
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -224,6 +226,51 @@ func TestUpdateTerminalState_WriteFailure(t *testing.T) {
 
 	if err := sr.updateTerminalState(api.Ready); err == nil {
 		t.Fatal("updateTerminalState: want write error on missing dir, got nil")
+	}
+}
+
+// When create and close run under different uids the terminal dir is not
+// writable by the closing uid, so every close/cleanup hook's metadata write is
+// denied. The close path must surface this once, actionably, instead of
+// re-spamming the same permission-denied WARN/ERROR on every hook. This drives
+// the close-state and attacher-update hooks repeatedly against an un-writable
+// dir and asserts the actionable warning fires exactly once. See #345.
+func TestUpdateMetadata_PermissionDeniedLoggedOnce(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory DAC, so a non-writable dir cannot deny the write")
+	}
+
+	runPath := t.TempDir()
+	id := api.ID("term-perm")
+	dir := filepath.Join(runPath, defaults.TerminalsRunPath, string(id))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir terminal dir: %v", err)
+	}
+	// Drop write (and exec) so the closing uid cannot create the temp file the
+	// atomic write needs — the embedded create-as-root/close-as-nonroot case.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod terminal dir: %v", err)
+	}
+	// Restore so t.TempDir's recursive cleanup can remove the tree.
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	var buf bytes.Buffer
+	sr := newMetadataExec(t, runPath, "", id)
+	sr.logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// Drive both close-path hooks several times, mirroring close + repeated
+	// client-cleanup. Each write must fail; the actionable WARN must fire once.
+	for range 3 {
+		if err := sr.updateTerminalState(api.Exited); err == nil {
+			t.Fatal("updateTerminalState: want permission error on un-writable dir, got nil")
+		}
+		if err := sr.updateTerminalAttachers(); err == nil {
+			t.Fatal("updateTerminalAttachers: want permission error on un-writable dir, got nil")
+		}
+	}
+
+	if got := strings.Count(buf.String(), metadataWriteDeniedMsg); got != 1 {
+		t.Fatalf("actionable permission-denied warning logged %d times, want exactly 1\nlog:\n%s", got, buf.String())
 	}
 }
 

--- a/internal/terminal/terminalrunner/lifecycle.go
+++ b/internal/terminal/terminalrunner/lifecycle.go
@@ -19,6 +19,7 @@ package terminalrunner
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"net"
 	"os"
 	"path/filepath"
@@ -205,7 +206,14 @@ func (sr *Exec) Close(reason error) error {
 	sr.logger.Info("closing terminal", "id", sr.id, "reason", reason)
 
 	if err := sr.updateTerminalState(api.Exited); err != nil {
-		sr.logger.Error("failed to update terminal state", "id", sr.id, "err", err)
+		// The permission-denied case is already surfaced once, actionably, by
+		// updateTerminalState -> noteMetadataWriteErr; demote here so close
+		// does not pair a redundant ERROR with that single WARN. See #345.
+		if errors.Is(err, fs.ErrPermission) {
+			sr.logger.Debug("terminal state not persisted on close (dir not writable)", "id", sr.id, "err", err)
+		} else {
+			sr.logger.Error("failed to update terminal state", "id", sr.id, "err", err)
+		}
 	}
 
 	// Graceful shutdown of the child before tearing anything else down:

--- a/internal/terminal/terminalrunner/metadata.go
+++ b/internal/terminal/terminalrunner/metadata.go
@@ -17,7 +17,9 @@
 package terminalrunner
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"time"
@@ -27,6 +29,27 @@ import (
 	"github.com/eminwux/sbsh/internal/shared"
 	"github.com/eminwux/sbsh/pkg/api"
 )
+
+// metadataWriteDeniedMsg is the single actionable warning logged (once per
+// runner) when a metadata write is denied because the terminal dir is not
+// writable by the closing uid. It names the ownership contract embedders must
+// satisfy so the message is self-diagnosing rather than a bare errno.
+//
+// Ownership/mode contract for RunPath/terminals/<id> (the dir that holds
+// metadata.json): sbsh writes metadata.json via an atomic
+// create-temp-then-rename, which needs write+exec on the directory at every
+// point in the terminal's lifecycle — not just at create. The legacy layout
+// creates the dir 0o700, owned by the creating uid. When an embedder runs
+// create and close under different uids (e.g. setup as root, the in-cell
+// process as a non-root container uid), the closing uid cannot create the
+// temp file and the write is denied. Embedders that span uids must either set
+// TerminalSpec.MetadataDir to a directory they pre-own and keep writable by
+// every uid in the terminal's lifecycle (e.g. group-writable under a shared
+// gid), or accept that close-time metadata updates will not persist — in which
+// case this single warning, not repeated spam, is the surfaced signal.
+const metadataWriteDeniedMsg = "metadata write denied: terminal dir is not writable by the closing uid; " +
+	"the embedder must keep RunPath/terminals/<id> (or TerminalSpec.MetadataDir) writable by every uid " +
+	"that runs the terminal lifecycle (create and close) — see TerminalSpec docs"
 
 func (sr *Exec) CreateMetadata() error {
 	sr.metadataMu.Lock()
@@ -114,13 +137,34 @@ func resolveMetadataDir(runPath, metadataDirOverride string, id api.ID) (string,
 	return filepath.Join(runPath, defaults.TerminalsRunPath, string(id)), false
 }
 
+// noteMetadataWriteErr logs a metadata-write failure with permission-denied
+// spam suppression. A permission error (the terminal dir is not writable by
+// the closing uid — typically an embedded runtime where create and close run
+// under different uids) is logged once at WARN with the actionable
+// ownership-contract message; subsequent permission failures drop to Debug so
+// the close and client-cleanup hooks do not re-spam the same condition.
+// Non-permission errors always log at WARN. See #345.
+func (sr *Exec) noteMetadataWriteErr(where string, err error) {
+	if errors.Is(err, fs.ErrPermission) {
+		first := false
+		sr.metadataWriteDeniedOnce.Do(func() { first = true })
+		if first {
+			sr.logger.Warn(metadataWriteDeniedMsg, "id", sr.id, "dir", sr.getTerminalDir(), "where", where, "err", err)
+		} else {
+			sr.logger.Debug("metadata write still denied", "id", sr.id, "where", where, "err", err)
+		}
+		return
+	}
+	sr.logger.Warn("failed to update metadata on close", "id", sr.id, "where", where, "err", err)
+}
+
 func (sr *Exec) updateTerminalState(status api.TerminalStatusMode) error {
 	sr.metadataMu.Lock()
 	sr.metadata.Status.State = status
 	sr.metadataMu.Unlock()
 
 	if err := sr.updateMetadata(); err != nil {
-		sr.logger.Warn("failed to update metadata on close", "id", sr.id, "err", err)
+		sr.noteMetadataWriteErr("updateTerminalState", err)
 		return err
 	}
 	return nil
@@ -143,7 +187,7 @@ func (sr *Exec) updateTerminalAttachers() error {
 	sr.metadataMu.Unlock()
 
 	if err := sr.updateMetadata(); err != nil {
-		sr.logger.Warn("failed to update metadata on close", "id", sr.id, "err", err)
+		sr.noteMetadataWriteErr("updateTerminalAttachers", err)
 		return err
 	}
 	return nil

--- a/internal/terminal/terminalrunner/terminal_runner_exec.go
+++ b/internal/terminal/terminalrunner/terminal_runner_exec.go
@@ -39,6 +39,15 @@ type Exec struct {
 	metadata   api.TerminalDoc
 	metadataMu sync.RWMutex // protects metadata field
 
+	// metadataWriteDeniedOnce dedups the actionable permission-denied warning
+	// emitted when the terminal dir is not writable by the uid running the
+	// close/cleanup path. In an embedded runtime (create-as-root,
+	// close-as-nonroot) every close and client-cleanup hook would otherwise
+	// re-fire the same permission-denied WARN/ERROR; this collapses it to one
+	// actionable message pointing at the RunPath/terminals/<id> ownership
+	// contract. See #345.
+	metadataWriteDeniedOnce sync.Once
+
 	// runtime (owned by Terminal)
 	cmd   *exec.Cmd
 	ptmx  *os.File // master

--- a/pkg/api/terminal.go
+++ b/pkg/api/terminal.go
@@ -69,6 +69,20 @@ type TerminalSpec struct {
 	Prompt      string   `json:"prompt"`
 	SetPrompt   bool     `json:"setPrompt,omitempty"`
 
+	// RunPath is the base directory under which the runner writes the
+	// per-terminal layout RunPath/terminals/<id>/ (holding metadata.json,
+	// the control socket, etc.) when MetadataDir is empty.
+	//
+	// Ownership/mode contract: the runner writes metadata.json via an atomic
+	// create-temp-then-rename, so RunPath/terminals/<id> must stay write+exec
+	// for every uid that runs the terminal lifecycle — create AND close — not
+	// just the creating uid. The legacy layout creates the dir 0o700 owned by
+	// the creating uid. Embedders that span uids (e.g. setup as root, the
+	// in-cell process as a non-root container uid) must instead set
+	// MetadataDir to a directory they pre-own and keep writable across those
+	// uids (e.g. group-writable under a shared gid). If the contract is not
+	// met, close-time metadata updates do not persist; the runner surfaces
+	// this as a single actionable warning rather than per-hook spam.
 	RunPath string `json:"runPath"`
 	// CaptureFile is the canonical capture path. It is the live, append-only
 	// segment: capture rotates into deterministic siblings to bound size, so


### PR DESCRIPTION
## Summary

When sbsh is embedded as an in-container terminal manager and create/close run under different uids (setup as root, in-cell process as a non-root container uid), the close-time metadata write is denied because the terminal dir was created `0o700` owned by the creating uid. The denial re-fired on every close and client-cleanup hook, spamming `WARN "failed to update metadata on close"` + a paired `ERROR "failed to update terminal state"`.

This change satisfies the AC's OR clause — *"fails once with a clear, actionable error rather than repeated permission-denied spam"* — plus the documentation and test requirements:

- **`metadata.go`**: new `noteMetadataWriteErr` helper classifies the write error. A permission error (`errors.Is(err, fs.ErrPermission)`) is logged **once per runner** (`sync.Once` guard on `Exec`) at WARN with a single actionable message naming the `RunPath/terminals/<id>` ownership contract; subsequent permission failures drop to Debug. Non-permission errors keep the existing WARN. Both close-path callers (`updateTerminalState`, `updateTerminalAttachers`) route through it.
- **`lifecycle.go`**: `Close()` demotes its paired `ERROR "failed to update terminal state"` to Debug for the permission case so it doesn't redundantly accompany the single actionable WARN already emitted.
- **`pkg/api/terminal.go`**: documents the ownership/mode contract for `RunPath/terminals/<id>` on the public `RunPath` field — the dir must stay write+exec for every uid that runs the lifecycle (create AND close); embedders spanning uids should use `MetadataDir` on a pre-owned, group-writable dir.
- **Test**: `TestUpdateMetadata_PermissionDeniedLoggedOnce` drives both close hooks repeatedly against a `0o500` (un-writable) terminal dir and asserts the actionable warning fires exactly once. Skips when running as root (root bypasses directory DAC).

## Design note for the reviewer

The issue's proposal listed three `and/or` options. I took the **lower-blast-radius** path (dedup + docs + test) rather than adding a `MetadataDirMode`/`MetadataGID` knob that makes close *succeed* across uids. Rationale: making close succeed requires choosing a gid policy ("group-writable under a *known* gid"), which is a project-level API decision; and AC's third checkbox — *"test covering the close path when the terminal dir is not writable by the closing uid"* — presumes the not-writable case remains a real, surfaced scenario, which is exactly the OR-clause path. The existing `SocketMode/GID`, `CaptureMode/GID`, `LogFileMode/GID` knobs are precedent if a follow-up wants the dir-mode knob; happy to add it if the reviewer prefers the succeed-across-uids path.

## Test plan

- [x] `make sbsh-sb` — canonical build; `file ./sbsh` and `./sb` both ELF executables
- [x] `go build ./...`
- [x] `go vet ./internal/terminal/terminalrunner/... ./pkg/api/...`
- [x] `go test ./internal/terminal/terminalrunner/...` (incl. new `TestUpdateMetadata_PermissionDeniedLoggedOnce`)
- [x] `go test ./internal/client...`, `go test -tags=integration ./cmd/sb/get/...`, e2e (`E2E_BIN_DIR=$(pwd) go test ./e2e`) — all green
- [ ] full `make test` — **3 pre-existing failures unrelated to this diff**: `Test_buildTerminalSpecFromFlags_DefaultProfile`, `Test_processSpec_BuildsFromFlags`, `Test_TerminalCmd_PreRunE_BuildsSpecFromFlags` in `cmd/sbsh/terminal` (`profile "sbsh-dev-0" not found`). Reproduced on a clean stash of `origin/main` (this PR touches only `terminalrunner`, `lifecycle`, and godoc in `pkg/api`); the target stops at first failure so the rest of the suite was run individually (above) and is green. Appears environment-specific to the dev host's default-profile-name resolution.

Closes #345