### PR TITLE
test: make terminal profile-fallback tests hermetic to SBSH_TERM_PROFILE

### DIFF
--- a/cmd/sbsh/terminal/terminal_test.go
+++ b/cmd/sbsh/terminal/terminal_test.go
@@ -672,9 +672,27 @@ func Test_setLoggingVarsFromFlags_Defaults(t *testing.T) {
 	}
 }
 
+// scrubProfileEnv neutralizes ambient SBSH_TERM_*/SBSH_ROOT_* environment
+// variables that viper.AutomaticEnv/BindEnv would otherwise leak into
+// profile-resolution tests. viper.Reset() clears prior viper.Set calls but
+// does not stop the rebound env bindings from re-reading the live process
+// environment, so a developer running the suite from inside an sbsh session
+// (which exports SBSH_TERM_PROFILE) would see the default-profile fallback
+// tests fail. Clearing the prefix surface keeps those tests hermetic. See #350.
+func scrubProfileEnv(t *testing.T) {
+	t.Helper()
+	for _, e := range os.Environ() {
+		k, _, _ := strings.Cut(e, "=")
+		if strings.HasPrefix(k, "SBSH_TERM_") || strings.HasPrefix(k, "SBSH_ROOT_") {
+			t.Setenv(k, "")
+		}
+	}
+}
+
 func Test_buildTerminalSpecFromFlags_DefaultProfile(t *testing.T) {
 	viper.Reset()
 	t.Cleanup(viper.Reset)
+	scrubProfileEnv(t)
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	viper.Set(config.SB_ROOT_RUN_PATH.ViperKey, t.TempDir())
@@ -700,6 +718,7 @@ func Test_buildTerminalSpecFromFlags_DefaultProfile(t *testing.T) {
 func Test_processSpec_BuildsFromFlags(t *testing.T) {
 	viper.Reset()
 	t.Cleanup(viper.Reset)
+	scrubProfileEnv(t)
 
 	runPath := t.TempDir()
 	viper.Set(config.SB_ROOT_RUN_PATH.ViperKey, runPath)
@@ -725,6 +744,7 @@ func Test_processSpec_BuildsFromFlags(t *testing.T) {
 func Test_TerminalCmd_PreRunE_BuildsSpecFromFlags(t *testing.T) {
 	viper.Reset()
 	t.Cleanup(viper.Reset)
+	scrubProfileEnv(t)
 
 	viper.Set(config.SB_ROOT_RUN_PATH.ViperKey, t.TempDir())
 	viper.Set(config.SBSH_ROOT_PROFILES_DIR.ViperKey, t.TempDir())


### PR DESCRIPTION
## Summary
- Three default-profile-fallback tests in `cmd/sbsh/terminal/terminal_test.go` (`Test_buildTerminalSpecFromFlags_DefaultProfile`, `Test_processSpec_BuildsFromFlags`, `Test_TerminalCmd_PreRunE_BuildsSpecFromFlags`) isolated the profiles *directory* but not the profile *name*. With `SBSH_TERM_PROFILE` exported — the case for any dev running the suite from inside an sbsh session, since sbsh dogfoods itself — viper's rebound env binding leaked the ambient profile name, so the loader looked for that profile in the empty temp dir and failed instead of exercising the default fallback. CI stayed green only because the container exports no such var.
- Added a `scrubProfileEnv(t)` helper that clears the `SBSH_TERM_*`/`SBSH_ROOT_*` env surface (via `t.Setenv` to empty, auto-restored at cleanup) and called it in each of the three tests after `viper.Reset()`. An empty profile name resolves to `"default"` and then to the hardcoded default profile (`internal/profile/profile.go:352`), which is exactly the path these tests intend to cover.

Implementation note: chose the issue's suggested shared-helper approach (over per-test `viper.Set` of the profile key) because it scrubs the whole prefix surface, guarding against any other `SBSH_TERM_*`/`SBSH_ROOT_*` key a test doesn't explicitly `viper.Set` leaking in the same way.

## Test plan
- [x] `SBSH_TERM_PROFILE=sbsh-dev-1 go test -count=1 ./cmd/sbsh/terminal/` — now passes (previously failed the three tests)
- [x] `env -u SBSH_TERM_PROFILE go test -count=1 ./cmd/sbsh/terminal/` — still passes
- [x] `make sbsh-sb` + `file ./sbsh` confirms ELF executable
- [x] `go build ./...`, `go vet ./cmd/sbsh/terminal/`
- [x] `make test` (full CI target, incl. e2e) — green
- [x] pre-commit hooks passed (gofmt, golangci-lint, addlicense, etc.)

Closes #350