### PR TITLE
test: de-flake TestAttachDetach under parallel load

### DIFF
--- a/internal/terminal/terminalrunner/lifecycle_pty_cluster_test.go
+++ b/internal/terminal/terminalrunner/lifecycle_pty_cluster_test.go
@@ -455,7 +455,31 @@ func TestUseListener(t *testing.T) {
 }
 
 func TestAttachDetach(t *testing.T) {
-	spec := &api.TerminalSpec{ID: "ad", Name: "ad", RunPath: t.TempDir()}
+	// Client teardown is asynchronous: Detach spawns a 100ms grace goroutine
+	// that closes the server conn, whose reader-EOF path runs cleanupClient ->
+	// updateTerminalAttachers -> WriteMetadata after the test body has already
+	// returned. WriteMetadata recreates files under <runPath>/terminals/ad, so
+	// t.TempDir()'s single-shot RemoveAll can race that late write and fail
+	// with "directory not empty" under full-package parallel load (issue
+	// #351). This cleanup runs before t.TempDir's (LIFO) and drains the writers
+	// via a bounded retry, so t.TempDir's own RemoveAll then finds the tree
+	// already gone (a no-op on a missing path).
+	runPath := t.TempDir()
+	t.Cleanup(func() {
+		deadline := time.Now().Add(2 * time.Second)
+		for {
+			if rmErr := os.RemoveAll(runPath); rmErr == nil {
+				return
+			}
+			if time.Now().After(deadline) {
+				t.Errorf("draining run dir %s did not settle within deadline", runPath)
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	})
+
+	spec := &api.TerminalSpec{ID: "ad", Name: "ad", RunPath: runPath}
 	sr := NewTerminalRunnerExec(context.Background(), newDiscardLogger(), spec).(*Exec)
 	if err := sr.CreateMetadata(); err != nil {
 		t.Fatalf("CreateMetadata: %v", err)
@@ -477,7 +501,14 @@ func TestAttachDetach(t *testing.T) {
 	if len(resp.FDs) != 1 {
 		t.Fatalf("expected 1 returned fd, got %d", len(resp.FDs))
 	}
-	_ = syscall.Close(resp.FDs[0]) // release the client-side fd we won't use
+	// Release the client-side fd at the end of the test, not now. Closing it
+	// makes the server-side reader observe EOF, tripping the handleClient
+	// auto-detach path (cleanupClient -> removeClient); closing it before the
+	// assertion below lets that cleanup race the read and remove the client
+	// first under parallel load (issue #351). Attach already registered the
+	// client synchronously (CreateNewClient -> addClient), so the assertion is
+	// deterministic while this fd stays open.
+	defer func() { _ = syscall.Close(resp.FDs[0]) }()
 
 	if _, ok := sr.getClient(clientID); !ok {
 		t.Fatal("client should be registered after Attach")


### PR DESCRIPTION
## Summary

Closes #351. `TestAttachDetach` flaked under full-package parallel load. Investigation found the issue's premise had **rotted**, and two *distinct* timing races (only one of which the issue describes). Both are fixed test-side; the diff touches only `lifecycle_pty_cluster_test.go`.

### Premise divergence (issue claim vs. reality)

The issue hypothesised a *missing registration sync point* and suggested an `Eventually`-style poll for the client to appear in the registry. That premise is false: `Attach` → `CreateNewClient` calls `addClient` **synchronously** (`sockets.go:224`) before launching `go handleClient`, so the client is registered the instant `Attach` returns. An `Eventually` poll would have made things *worse* — it widens the window for the cleanup path below to fire. Proceeding with reinterpreted scope per CLAUDE.md's rotted-premise rule.

### Flake #1 — registration assertion races client-fd-close cleanup (the reported symptom)

The test closed `resp.FDs[0]` (the client-side socketpair fd) *before* asserting registration. Closing it makes the server-side reader observe EOF, tripping the `handleClient` auto-detach path (`detach()` → `cleanupClient` → `removeClient`, `connections.go:106`/`66`). Under parallel load that cleanup can win the race against the `getClient` read at the old line 482, removing the client first → `client should be registered after Attach`.
**Fix:** defer the fd close to the end of the test. With the fd open the reader can't EOF, and `addClient` already ran synchronously, so the assertion is deterministic.

### Flake #2 — late metadata write races `t.TempDir()` cleanup (reproduced here, 4/40 on `origin/main`)

`Detach` spawns a 100ms grace goroutine that closes the server conn; its reader-EOF path runs `cleanupClient` → `updateTerminalAttachers` → `WriteMetadata` **after the test body returns**. `WriteMetadata` (`atomicWriteFile`, `internal/shared/helpers.go`) creates a `.meta-*.tmp` then renames it under `<runPath>/terminals/ad`, so `t.TempDir()`'s single-shot `RemoveAll` races that late write and fails with `TempDir RemoveAll cleanup: unlinkat .../terminals/ad: directory not empty`.
**Fix:** keep `t.TempDir()` for allocation (the `usetesting` linter requires it) and add a cleanup that runs first (LIFO) and drains the async writer via a bounded retry-`RemoveAll`; `t.TempDir`'s own `RemoveAll` then no-ops on the already-gone tree.

## Pre-existing bugs surfaced (NOT fixed here — out of scope, separate review)

1. **Production data race on `ioClient.outWriter`.** `go test -race -run TestAttachDetach` reports a real race: `handleClient` writes `client.outWriter = aw` (`connections.go:145`) with no lock while `Detach` reads `ioClient.outWriter` (`lifecycle.go:405`) with no lock. Reproduced on unmodified `origin/main` (first run). CI does not run `-race` (`test.yaml:50` is plain `go test`), so this is latent. Filed as #355.
2. **`TestSubscribe_NoOrphanDrainOnConcurrentClose` flake** (`subscribe_close_race_test.go:159`, "race window never opened — every subscriber was early-rejected"), ~1/60 here. Distinct test, distinct cause. Filed as #356.

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `make sbsh-sb` → `file ./sbsh` confirms ELF executable
- [x] `TestAttachDetach` full-package, no `-race`: **120/120 pass** (two 60× sweeps); was ~10% failure on `origin/main`
- [x] CI unit-test command locally (`go test $(go list ./... | grep -v '/e2e$')`): only failures were the `SBSH_TERM_PROFILE` env-leak tests, since fixed on main by #353 and unrelated to this diff
- [x] `pre-commit run --files <test file>` (golangci-lint incl. `usetesting`) passes