### PR TITLE
feat: add captureFormat field to profile YAML spec

### DIFF
--- a/docs/profiles/README.md
+++ b/docs/profiles/README.md
@@ -91,6 +91,7 @@ spec:
   logFile: # Per-terminal log-file permissions (optional)
     mode: "0640" # Octal string; defaults to 0600 if omitted
     gid: 986 # Numeric host GID; omit to leave the group unchanged
+  captureFormat: asciicast # On-disk capture format: "raw" (default) or "asciicast"
 ```
 
 ## Field Reference
@@ -334,6 +335,34 @@ their own flag:
 Widening the mode and setting a host group is opt-in for callers that share a
 log viewer across uids in the same group; the default (no `logFile` block, no
 flag) preserves owner-only access exactly as in earlier releases.
+
+#### `captureFormat` (optional)
+
+Selects the on-disk serialization of the terminal's capture transcript. It is
+orthogonal to the `capture` block above, which sets the file's chmod/gid — this
+picks how the bytes are written.
+
+```yaml
+spec:
+  # ...
+  captureFormat: asciicast # "raw" (default) or "asciicast"
+```
+
+- **`raw`** (default): the verbatim PTY output stream, replayed by
+  `sb log <terminal>`. Omitting the field keeps this behavior.
+- **`asciicast`**: the [asciinema](https://docs.asciinema.org/manual/asciicast/v2/)
+  v2 format, suitable for sharing or replaying with asciinema tooling.
+
+The same configuration can also be supplied at launch time and overrides the
+profile when set. The root command and the `terminal` subcommand each take
+their own flag:
+
+- `sbsh --terminal-capture-format asciicast`
+  (or `SBSH_ROOT_TERM_CAPTURE_FORMAT=asciicast`)
+- `sbsh terminal --capture-format asciicast`
+  (or `SBSH_TERM_CAPTURE_FORMAT=asciicast`)
+
+An unrecognized value is rejected at spec-build time.
 
 ## Example Profiles
 

--- a/internal/profile/build_test.go
+++ b/internal/profile/build_test.go
@@ -58,6 +58,26 @@ func writeProfileDir(t *testing.T) string {
 	return dir
 }
 
+const captureFormatProfileYAML = `apiVersion: sbsh/v1beta1
+kind: TerminalProfile
+metadata:
+  name: capprof
+spec:
+  runTarget: local
+  shell:
+    cmd: /bin/zsh
+  captureFormat: asciicast
+`
+
+func writeCaptureFormatProfileDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "p.yaml"), []byte(captureFormatProfileYAML), 0o644); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+	return dir
+}
+
 func TestBuildTerminalSpecFromProfile_LoadsNamedProfile(t *testing.T) {
 	ctx := context.Background()
 	logger := testLogger()
@@ -174,6 +194,48 @@ func TestBuildTerminalSpecFromProfile_InvalidCaptureFormatErrors(t *testing.T) {
 	})
 	if !errors.Is(err, errdefs.ErrInvalidFlag) {
 		t.Fatalf("expected ErrInvalidFlag, got %v", err)
+	}
+}
+
+// A profile YAML that pins captureFormat must reach the spec end-to-end when
+// no launch-time override is supplied — the profile-only surface that #321
+// closes the gap on.
+func TestBuildTerminalSpecFromProfile_CaptureFormatFromYAML(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	profilesDir := writeCaptureFormatProfileDir(t)
+
+	spec, err := BuildTerminalSpecFromProfile(ctx, logger, &BuildTerminalSpecParams{
+		RunPath:     t.TempDir(),
+		ProfilesDir: profilesDir,
+		ProfileName: "capprof",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.CaptureFormat != api.CaptureFormatAsciicast {
+		t.Fatalf("expected asciicast from profile YAML, got %q", spec.CaptureFormat)
+	}
+}
+
+// Explicit override > profile: a launch-time CaptureFormat must win over the
+// profile's captureFormat, matching the precedence used for CaptureMode.
+func TestBuildTerminalSpecFromProfile_CaptureFormatOverrideBeatsProfile(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+	profilesDir := writeCaptureFormatProfileDir(t)
+
+	spec, err := BuildTerminalSpecFromProfile(ctx, logger, &BuildTerminalSpecParams{
+		RunPath:       t.TempDir(),
+		ProfilesDir:   profilesDir,
+		ProfileName:   "capprof",
+		CaptureFormat: api.CaptureFormatRaw,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.CaptureFormat != api.CaptureFormatRaw {
+		t.Fatalf("expected explicit raw override to win, got %q", spec.CaptureFormat)
 	}
 }
 

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -118,6 +118,17 @@ func CreateTerminalFromProfile(profile *api.TerminalProfileDoc) (*api.TerminalSp
 		return nil, errPerm
 	}
 
+	if profile.Spec.CaptureFormat != "" {
+		cf, err := api.NormalizeCaptureFormat(profile.Spec.CaptureFormat)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"invalid spec.captureFormat in profile %q: %w",
+				profile.Metadata.Name, err,
+			)
+		}
+		spec.CaptureFormat = cf
+	}
+
 	return spec, nil
 }
 

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -261,6 +261,68 @@ func TestCreateTerminalFromProfile_OmittedArtifactBlocksLeaveDefaults(t *testing
 	}
 }
 
+// A profile that pins spec.captureFormat must thread the normalized value
+// into the produced TerminalSpec, giving profile-only users parity with the
+// --capture-format flag / SBSH_*_TERM_CAPTURE_FORMAT env / builder surfaces.
+func TestCreateTerminalFromProfile_AppliesCaptureFormat(t *testing.T) {
+	p := &api.TerminalProfileDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindTerminalProfile,
+		Metadata:   api.TerminalProfileMetadata{Name: "tprof"},
+		Spec: api.TerminalProfileSpec{
+			RunTarget:     api.RunTargetLocal,
+			Shell:         api.ShellSpec{Cmd: "/bin/bash"},
+			CaptureFormat: "asciicast",
+		},
+	}
+	spec, err := CreateTerminalFromProfile(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.CaptureFormat != api.CaptureFormatAsciicast {
+		t.Fatalf("CaptureFormat: want %q, got %q", api.CaptureFormatAsciicast, spec.CaptureFormat)
+	}
+}
+
+// An omitted spec.captureFormat leaves the spec field empty so the runner
+// falls back to the raw default — matching the omitted-perm-block behavior.
+func TestCreateTerminalFromProfile_OmittedCaptureFormatLeavesDefault(t *testing.T) {
+	p := &api.TerminalProfileDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindTerminalProfile,
+		Metadata:   api.TerminalProfileMetadata{Name: "tprof"},
+		Spec: api.TerminalProfileSpec{
+			RunTarget: api.RunTargetLocal,
+			Shell:     api.ShellSpec{Cmd: "/bin/bash"},
+		},
+	}
+	spec, err := CreateTerminalFromProfile(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.CaptureFormat != "" {
+		t.Fatalf("CaptureFormat: want \"\" (runner default raw), got %q", spec.CaptureFormat)
+	}
+}
+
+// An invalid spec.captureFormat is rejected at spec-build time, mirroring how
+// an out-of-range capture mode fails — the error names the YAML field path.
+func TestCreateTerminalFromProfile_InvalidCaptureFormatRejected(t *testing.T) {
+	p := &api.TerminalProfileDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindTerminalProfile,
+		Metadata:   api.TerminalProfileMetadata{Name: "tprof"},
+		Spec: api.TerminalProfileSpec{
+			RunTarget:     api.RunTargetLocal,
+			Shell:         api.ShellSpec{Cmd: "/bin/bash"},
+			CaptureFormat: "bogus",
+		},
+	}
+	if _, err := CreateTerminalFromProfile(p); err == nil {
+		t.Fatal("want error for invalid spec.captureFormat, got nil")
+	}
+}
+
 // applyOnePermOverride: an empty rawMode and nil gid leave prior values
 // untouched, so profile-resolved values survive when the caller passes
 // nothing.

--- a/pkg/api/profile.go
+++ b/pkg/api/profile.go
@@ -65,6 +65,13 @@ type TerminalProfileSpec struct {
 	Socket        *FilePermSpec `json:"socket,omitempty"  yaml:"socket,omitempty"`
 	Capture       *FilePermSpec `json:"capture,omitempty" yaml:"capture,omitempty"`
 	LogFile       *FilePermSpec `json:"logFile,omitempty" yaml:"logFile,omitempty"`
+	// CaptureFormat selects the on-disk capture format ("raw" default, or
+	// "asciicast"). It is orthogonal to the spec.capture block, which sets
+	// the capture file's chmod/gid — this picks the serialization. Empty
+	// leaves the runner default (raw); an invalid value is rejected at
+	// spec-build time. The launch-time --capture-format flag /
+	// SBSH_*_TERM_CAPTURE_FORMAT env var override it when set.
+	CaptureFormat string `json:"captureFormat,omitempty" yaml:"captureFormat,omitempty"`
 }
 
 // FilePermSpec configures the filesystem permissions of a per-terminal


### PR DESCRIPTION
## Summary

- Closes the profile-YAML gap surfaced in #321: `Spec.CaptureFormat` was reachable via the `--capture-format` flag, `SBSH_*_TERM_CAPTURE_FORMAT` env vars, and `builder.WithCaptureFormat`, but **not** via profile YAML — while its sibling `CaptureMode` *was* (`spec.capture.mode`). A profile-only user could pin the capture file's chmod but not its serialization format.
- Adds a top-level `spec.captureFormat` field to `api.TerminalProfileSpec` and maps + validates it in `CreateTerminalFromProfile` (mirroring `applyProfilePermBlock`'s build-time validation, with the error naming the YAML field path `spec.captureFormat`).
- Precedence (`explicit override > profile > default`) matches `CaptureMode` for free: `CreateTerminalFromProfile` sets the profile value, and the existing `applyCaptureFormat` overwrites it only when a launch-time override is non-empty.
- Documents the new field in `docs/profiles/README.md` (example + field reference, raw/asciicast, flag/env overrides).

## Design note for the reviewer

- **Placement: top-level `spec.captureFormat`, not nested under the `capture` block.** The `spec.capture` block is an `*api.FilePermSpec`, a type shared by `spec.socket` and `spec.logFile`. Adding a `format` field there would expose a meaningless `socket.format` / `logFile.format` on the other two artifacts. The issue's wording ("add a `captureFormat` field to the profile terminal spec type") also points at `TerminalProfileSpec`. This is the lowest-blast-radius reading; flag if you'd prefer a dedicated capture spec type instead.
- Validation lives at spec-build time (`CreateTerminalFromProfile`), matching how `CaptureMode`/`spec.capture.mode` is validated — `validateProfileDoc` does not validate perm blocks, so adding format validation there would exceed `CaptureMode` parity.

## Test plan

- [x] `make sbsh-sb` — canonical build; `file ./sbsh` confirms ELF executable
- [x] `go build ./...`
- [x] `go vet ./internal/profile/... ./pkg/api/...`
- [x] `make test` — full CI suite incl. e2e, all green
- [x] New unit tests: `CreateTerminalFromProfile` applies/omits/rejects `captureFormat`; `BuildTerminalSpecFromProfile` threads `captureFormat` from YAML end-to-end and explicit override beats profile

Closes #321