### PR TITLE
fix: synchronize ioClient.outWriter access under clientsMu

### DIFF
--- a/internal/terminal/terminalrunner/connections.go
+++ b/internal/terminal/terminalrunner/connections.go
@@ -39,8 +39,16 @@ func (sr *Exec) cleanupClient(client *ioClient) {
 	sr.ptyPipesMu.RLock()
 	multiOutW := sr.ptyPipes.multiOutW
 	sr.ptyPipesMu.RUnlock()
-	if multiOutW != nil && client.outWriter != nil {
-		multiOutW.Remove(client.outWriter)
+
+	// Snapshot outWriter under clientsMu — handleClient publishes it under
+	// the same lock, so reading it unsynchronized here races the writer
+	// (issue #355).
+	sr.clientsMu.RLock()
+	outWriter := client.outWriter
+	sr.clientsMu.RUnlock()
+
+	if multiOutW != nil && outWriter != nil {
+		multiOutW.Remove(outWriter)
 	}
 
 	// Closing outWriter signals its drain goroutine to flush any pending
@@ -49,8 +57,8 @@ func (sr *Exec) cleanupClient(client *ioClient) {
 	// remains the sole owner of the lifecycle — double-close on a
 	// *net.UnixConn just logs and is harmless, but a single owner keeps
 	// the path easy to reason about.
-	if client.outWriter != nil {
-		_ = client.outWriter.Close()
+	if outWriter != nil {
+		_ = outWriter.Close()
 	} else if client.conn != nil {
 		// Early-failure fallback: handleClient never wired the writer,
 		// so there is no drain goroutine to take the conn with it.
@@ -142,7 +150,14 @@ func (sr *Exec) handleClient(client *ioClient) {
 	aw := newSubscriberWriter(client.conn, defaultSubscriberBufferBytes, detach, sr.logger)
 	aw.enableBackpressure()
 	aw.seedReplay(initial)
+	// outWriter is read by the Detach RPC, cleanupClient, and Close on
+	// other goroutines, so publish it under clientsMu — the same lock those
+	// readers take — rather than racing the unsynchronized field write a
+	// just-launched handleClient would otherwise expose to a concurrent
+	// Detach (issue #355).
+	sr.clientsMu.Lock()
 	client.outWriter = aw
+	sr.clientsMu.Unlock()
 	multiOutW.Add(aw)
 	go aw.Run()
 

--- a/internal/terminal/terminalrunner/lifecycle.go
+++ b/internal/terminal/terminalrunner/lifecycle.go
@@ -410,13 +410,22 @@ func (sr *Exec) Detach(id *api.ID) error {
 	sr.ptyPipesMu.RLock()
 	multiOutW := sr.ptyPipes.multiOutW
 	sr.ptyPipesMu.RUnlock()
-	if ioClient.outWriter != nil {
-		multiOutW.Remove(ioClient.outWriter)
+
+	// Snapshot outWriter under clientsMu — handleClient publishes it under
+	// the same lock, so a Detach arriving immediately after Attach (before
+	// handleClient finished wiring the writer) would otherwise race the
+	// field write (issue #355).
+	sr.clientsMu.RLock()
+	outWriter := ioClient.outWriter
+	sr.clientsMu.RUnlock()
+
+	if outWriter != nil {
+		multiOutW.Remove(outWriter)
 		// Close signals the drain goroutine to flush any pending bytes
 		// and exit. The drain's deferred conn.Close releases the
 		// socketpair fd. The async block below force-closes the conn
 		// after a short grace so a stuck drain can't pin the fd.
-		_ = ioClient.outWriter.Close()
+		_ = outWriter.Close()
 	}
 
 	// 3) Drop from the registry so it’s no longer discoverable


### PR DESCRIPTION
## Summary

- `ioClient.outWriter` was written by the per-client `handleClient` goroutine (`connections.go`) and read by the `Detach` RPC (`lifecycle.go`) and `cleanupClient` (`connections.go`) with no synchronization. A `Detach` arriving immediately after `Attach` — before `handleClient` finished wiring the writer — raced the field write (issue #355). `Close` already read the field under `clientsMu.Lock()`, so the field had one synchronized reader and several unsynchronized ones.
- Fix: publish the write in `handleClient` under `clientsMu` (the same lock `Close` already takes), and snapshot the field under `clientsMu.RLock()` in `Detach` and `cleanupClient` before use. No new mutex — the field is part of the client registry `clientsMu` already guards, which is also the issue's suggested approach.

## Design notes

- **Reused `clientsMu` rather than a new per-client mutex.** `Close` already reads `outWriter` under `clientsMu.Lock()`, so the field is conceptually registry-scoped; adding the missing lock at the remaining sites is lower blast radius than introducing a dedicated field mutex.
- **No lock-ordering change.** All three touched sites take `ptyPipesMu` and `clientsMu` only as acquire-release (never nested), preserving the existing `ptyPipesMu`-then-`clientsMu` ordering invariant noted in `Close` (`lifecycle.go`) and `cleanupClient`.
- The early-`Detach`-before-writer-wired case is now a clean `nil` read (Detach skips Remove/Close); the writer is later torn down via the dualcopier reader-error path into `cleanupClient`'s `detachOnce`, unchanged.

## Test plan

- [x] `make sbsh-sb` — canonical build; ELF magic `7f 45 4c 46` confirmed (`file` not installed on this host)
- [x] `go build ./...`
- [x] `go vet ./internal/terminal/terminalrunner/...`
- [x] `make test` — full CI suite incl. e2e, all green
- [ ] `go test -race -count=2 -run TestAttachDetach .` (the issue's repro) — **not run: no C compiler on the dev host, and `-race` requires cgo (`CGO_ENABLED=1` fails with `gcc: not found`).** Note CI does not run `-race` either (`.github/workflows/test.yaml:50` is plain `go test`), so this is not a CI gate; the fix is verified by reasoning + the plain suite passing. Reviewer with a cgo-capable host can run the repro to confirm the DATA RACE warning is gone.

Closes #355