### PR TITLE
docs: document terminal output flow-control policy (backpressure vs drop-on-lag)

### DIFF
--- a/docs/site/concepts/multi-attach.md
+++ b/docs/site/concepts/multi-attach.md
@@ -68,6 +68,36 @@ Input from any attached client is forwarded to the terminal. If multiple clients
 
 Terminal output is broadcast to all attached clients. Each client receives a copy of all output.
 
+### Output Flow Control
+
+sbsh fans a terminal's PTY output to several consumers at once: every
+attached interactive client, the on-disk capture file, the live screen
+model (used for screenshots and attach repaint), and any passive
+`sb read` / `Subscribe` streams. These consumers drain at different
+speeds, so the fan-out applies two deliberately different policies when a
+consumer cannot keep up:
+
+- **Interactive attachers are flow-controlled (backpressure).** When an
+  attached terminal cannot render output as fast as the shell produces
+  it, sbsh slows the _producer_ — the shell's `write()` blocks until the
+  terminal catches up, exactly as a process is paced by a real PTY. A
+  high-throughput command such as `cat /dev/urandom | hexdump` therefore
+  scrolls at the terminal's speed and is **never** disconnected for being
+  slow.
+- **Passive observers are dropped on lag.** A `sb read` / `Subscribe`
+  consumer must never be able to stall the live session. If it falls more
+  than a bounded amount behind, it is disconnected with a
+  `[sbsh: subscriber lagged, disconnecting]` sentinel rather than being
+  allowed to apply backpressure.
+
+This split is intentional. The interactive terminal _is_ the session's
+output device and should pace the shell; a passive reader is an optional
+bystander whose slowness must not freeze the session for everyone else. A
+single paused or abandoned attacher likewise must not head-of-line-block
+the fan-out and freeze sibling attachers or the capture file. **Do not
+collapse interactive attachers onto the drop-on-lag path** — doing so
+disconnects a healthy interactive session the moment it runs a firehose.
+
 ### Detachment
 
 When a client detaches, other clients remain attached. The terminal continues running independently.


### PR DESCRIPTION
## Summary
- Adds an "Output Flow Control" subsection to `docs/site/concepts/multi-attach.md`, under the existing `### Output Broadcasting` subsection, capturing the two-policy slow-consumer split: interactive attachers get backpressure (shell paced to the terminal), passive `sb read`/`Subscribe` consumers get drop-on-lag.
- Includes the explicit **"do not collapse interactive attachers onto the drop-on-lag path"** warning, since this distinction was accidentally collapsed once before (#217 → #312).
- Pure docs/markdown change; verbatim paste-ready wording from the issue. Prettier normalized emphasis markers (`*x*` → `_x_`) on the new lines only.

## Notes
- **Merge precondition satisfied:** issue declares "Depends on #312 — document the policy once the backpressure behavior is restored." #312 is CLOSED/completed; its fix PR #315 ("restore backpressure for interactive attachers on high-throughput output") merged 2026-05-21, ahead of this checkout. The prose describes behavior now in `main`.
- **Anchor:** the issue alternates between `## Output Broadcasting` and `### Output Broadcasting`; the live file uses `###` (h3 under `## Multi-Attach Behavior`). The new section is `### Output Flow Control` to match its h3 siblings, inserted immediately after the Output Broadcasting subsection and before `### Detachment`.
- **Sentinel verified:** `[sbsh: subscriber lagged, disconnecting]` quoted in the prose matches `internal/terminal/terminalrunner/subscriber.go:59` exactly.

## Test plan
- [x] `pre-commit run --files docs/site/concepts/multi-attach.md` — passes (prettier, trailing-whitespace, EOF, line-ending hooks).
- [ ] Project CI test target (`go test`) — not run: docs/markdown-only change, no Go sources touched. Compile/test surface unaffected.

Closes #313