### PR TITLE
fix: close bind-then-chmod EACCES window in OpenSocketCtrl

### DIFF
--- a/internal/terminal/terminalrunner/sockets.go
+++ b/internal/terminal/terminalrunner/sockets.go
@@ -17,9 +17,12 @@
 package terminalrunner
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
+	"runtime"
+	"sync"
 	"time"
 
 	"github.com/eminwux/sbsh/pkg/api"
@@ -45,6 +48,50 @@ const defaultSocketMode os.FileMode = 0o600
 // flags, env vars, or profile blocks. Same contract shape as
 // defaultSocketMode for the control socket.
 const defaultArtifactMode os.FileMode = 0o600
+
+// listenerUmaskMu serializes the umask save/set/Listen/restore sequence
+// in listenUnixWithMode against in-package concurrent callers. umask(2)
+// is process-wide (it lives in the kernel's shared fs_struct on Linux),
+// so two concurrent OpenSocketCtrl callers without this mutex could
+// observe each other's temporary umask. The mutex does not isolate the
+// brief Listen window from file creations in *other* packages that
+// share this process — that's an inherent cost of using umask to plug
+// the bind-then-chmod EACCES window. The alternative (bind-on-side-path
+// then rename(2)) relies on a kernel quirk for AF_UNIX sockets and is
+// worse on portability and on the ENOENT-vs-EACCES dial-error story.
+//
+//nolint:gochecknoglobals // process-wide invariant guard, like the umask it serializes
+var listenerUmaskMu sync.Mutex
+
+// listenUnixWithMode binds an AF_UNIX listener with the process umask
+// temporarily set so the socket inode is born at the configured mode,
+// not at (0o666 & ~daemonUmask). This closes the bind-then-chmod
+// EACCES window in OpenSocketCtrl: pre-fix, the socket was briefly
+// reachable at the daemon's restrictive default (typically 0o600 under
+// a 0o077 umask), so a group-member client that dialed before
+// applySocketPerms landed hit EACCES even though the final post-chmod
+// state would have admitted it.
+//
+// runtime.LockOSThread pins the goroutine so the save/restore sequence
+// runs on a single OS thread; listenerUmaskMu serializes the temporary
+// umask against in-package concurrent callers. Callers should still
+// run applySocketPerms after this returns — the chmod becomes
+// idempotent at that point, but the chown still needs to apply when
+// SocketGID is set and the parent directory does not propagate gid.
+func listenUnixWithMode(ctx context.Context, socketFile string, mode os.FileMode) (net.Listener, error) {
+	if mode == 0 {
+		mode = defaultSocketMode
+	}
+	listenerUmaskMu.Lock()
+	defer listenerUmaskMu.Unlock()
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	//nolint:mnd // 0o777 is the standard permission-bit mask for umask(2)
+	prev := unix.Umask(int(^mode & 0o777))
+	defer unix.Umask(prev)
+	var lc net.ListenConfig
+	return lc.Listen(ctx, "unix", socketFile)
+}
 
 // applySocketPerms chmods (and optionally chowns the group of) the
 // control-socket inode after a listener has been bound to it. Called
@@ -169,9 +216,12 @@ func (sr *Exec) OpenSocketCtrl() error {
 		)
 	}
 
-	// Listen to CONTROL SOCKET
-	var lc net.ListenConfig
-	ctrlLn, errListen := lc.Listen(sr.ctx, "unix", socketFile)
+	// Listen to CONTROL SOCKET — bind with the umask set so the
+	// inode is born at socketMode and there is no window during
+	// which a group-member client dialing the socket hits EACCES
+	// because the daemon's umask masked off group access. See #361
+	// and listenUnixWithMode for the full rationale.
+	ctrlLn, errListen := listenUnixWithMode(sr.ctx, socketFile, socketMode)
 	if errListen != nil {
 		sr.logger.Error("OpenSocketCtrl: failed to listen", "socket", socketFile, "error", errListen)
 		return fmt.Errorf("listen ctrl: %w", errListen)

--- a/internal/terminal/terminalrunner/sockets_test.go
+++ b/internal/terminal/terminalrunner/sockets_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/eminwux/sbsh/pkg/api"
+	"golang.org/x/sys/unix"
 )
 
 // newOpenSocketCtrlExec builds a minimal Exec wired with the fields
@@ -167,4 +168,98 @@ func TestOpenSocketCtrl_CleansUpStaleSocket(t *testing.T) {
 		t.Fatalf("new listener does not accept dials after stale cleanup: %v", dialErr)
 	}
 	_ = conn.Close()
+}
+
+// TestListenUnixWithMode_SocketBornAtRequestedMode is the AC for #361.
+//
+// Pre-fix, OpenSocketCtrl called net.ListenConfig.Listen directly. The
+// socket inode was born at (0o666 & ~processUmask) — typically 0o600
+// under the common 0o077 daemon umask — and only later chmoded to the
+// configured 0o660. A group-member client that dialed in that window
+// hit EACCES even though the final post-chmod state would have admitted
+// it.
+//
+// Post-fix, listenUnixWithMode saves+sets umask around the bind so the
+// inode is born at the requested mode without any chmod having to run.
+// This test pre-sets a hostile umask (0o077, the common daemon default)
+// and asserts the inode mode immediately after listenUnixWithMode
+// returns — *before* any applySocketPerms chmod could mask the bug.
+func TestListenUnixWithMode_SocketBornAtRequestedMode(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "ctrl.sock")
+
+	prev := unix.Umask(0o077)
+	defer unix.Umask(prev)
+
+	ln, err := listenUnixWithMode(context.Background(), sockPath, 0o660)
+	if err != nil {
+		t.Fatalf("listenUnixWithMode: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	info, errStat := os.Stat(sockPath)
+	if errStat != nil {
+		t.Fatalf("stat socket: %v", errStat)
+	}
+	if got := info.Mode().Perm(); got != 0o660 {
+		t.Fatalf("socket inode mode = 0o%o; want 0o660 (born from umask, no chmod ran)", got)
+	}
+}
+
+// TestListenUnixWithMode_DefaultModeWhenZero confirms the mode==0
+// fallback path: listenUnixWithMode applies defaultSocketMode (0o600)
+// when the caller passes 0, matching applySocketPerms' contract so the
+// raw spec field can flow through without a guard at the call site.
+func TestListenUnixWithMode_DefaultModeWhenZero(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "ctrl.sock")
+
+	prev := unix.Umask(0o022)
+	defer unix.Umask(prev)
+
+	ln, err := listenUnixWithMode(context.Background(), sockPath, 0)
+	if err != nil {
+		t.Fatalf("listenUnixWithMode: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	info, errStat := os.Stat(sockPath)
+	if errStat != nil {
+		t.Fatalf("stat socket: %v", errStat)
+	}
+	if got := info.Mode().Perm(); got != defaultSocketMode {
+		t.Fatalf("socket inode mode = 0o%o; want 0o%o (default fallback)", got, defaultSocketMode)
+	}
+}
+
+// TestOpenSocketCtrl_SocketReachableAtConfiguredMode is the end-to-end
+// AC for #361. After OpenSocketCtrl returns, the control socket inode
+// must be at the configured SocketMode regardless of the daemon's
+// process umask. Pre-fix, the listener was born at 0o600 under a 0o077
+// umask and only later chmoded to 0o660; post-fix, the umask path
+// produces the right mode at bind time and applySocketPerms re-asserts
+// it idempotently.
+func TestOpenSocketCtrl_SocketReachableAtConfiguredMode(t *testing.T) {
+	sockPath := filepath.Join(t.TempDir(), "ctrl.sock")
+
+	prev := unix.Umask(0o077)
+	defer unix.Umask(prev)
+
+	sr := newOpenSocketCtrlExec(t, sockPath)
+	sr.metadata.Spec.SocketMode = 0o660
+	t.Cleanup(func() {
+		if sr.lnCtrl != nil {
+			_ = sr.lnCtrl.Close()
+		}
+	})
+
+	if errOpen := sr.OpenSocketCtrl(); errOpen != nil {
+		t.Fatalf("OpenSocketCtrl: %v", errOpen)
+	}
+
+	info, errStat := os.Stat(sockPath)
+	if errStat != nil {
+		t.Fatalf("stat socket: %v", errStat)
+	}
+	if got := info.Mode().Perm(); got != 0o660 {
+		t.Fatalf("socket mode = 0o%o; want 0o660", got)
+	}
 }


### PR DESCRIPTION
## Summary

- OpenSocketCtrl previously let `net.ListenConfig.Listen` bind the control socket with whatever umask the daemon process happened to carry (commonly `0o077`), leaving the inode briefly reachable at `0o666 & ~daemonUmask` (typically `0o600`) before `applySocketPerms` chmoded it to the configured mode. A group-member client that dialed inside that window hit EACCES even though the final post-chmod state would have admitted it — exactly the symptom reported in #361 against `kuke run`.
- This change introduces `listenUnixWithMode`, which temporarily sets the process umask so the socket inode is born at the configured `SocketMode`. The save/set/Listen/restore sequence runs under `runtime.LockOSThread` to keep the goroutine pinned to a single OS thread, and a package-level mutex serializes the umask manipulation against in-package concurrent callers. The follow-up `applySocketPerms` chmod becomes idempotent at that point but is left in place so the chown path still applies when `SocketGID` is set and the parent directory does not propagate gid.
- This is Option A from the issue, with the `runtime.LockOSThread` variant the issue author called out as cleanest. Option B (bind-on-side-path + `rename(2)`) was rejected per the issue's own portability caveat about `rename(2)` of a bound AF_UNIX socket. Option C (metadata gate) was rejected because it requires every embedder to opt in and does not help direct `sbsh attach` racing `sbsh terminal &`.

### Note on residual scope

`syscall.Umask` is process-wide on Linux. The mutex stops in-package concurrent OpenSocketCtrl callers from racing on the global umask, but the brief Listen window can still leak the temporary umask to file creations in *other* packages running in the same process. This is documented inline at `listenerUmaskMu` and called out in the issue itself; closing it would require `unshare(CLONE_FS)` or moving the listener to a dedicated process. UseListener (the externally-bound-listener path used by `pkg/terminal/server`) is unchanged — the bind happens in the caller, so the umask trick has to live there if the embedder needs the same guarantee.

## Test plan

- [x] `make sbsh-sb` (canonical build; `file ./sbsh` returns ELF executable)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/terminal/terminalrunner/...` — new tests pass
- [x] `make test` — full CI suite passes (note: `Test_RunStopTerminals_AllAggregation` is a pre-existing flake — reproduces at the same rate on baseline `origin/main`, unrelated to this change)
- [x] New `TestListenUnixWithMode_SocketBornAtRequestedMode` proves the inode mode immediately after the helper returns equals the configured mode under a hostile `0o077` umask — a regression replacing the helper with bare `lc.Listen` would observe `0o600` here.
- [x] New `TestListenUnixWithMode_DefaultModeWhenZero` locks in the `mode==0` fallback to `defaultSocketMode`.
- [x] New `TestOpenSocketCtrl_SocketReachableAtConfiguredMode` end-to-end check under hostile umask.

Closes #361