### PR TITLE
test: de-flake Test_RunStopTerminals_AllAggregation (stubborn-trap install race)

### DIFF
--- a/cmd/sb/stop/terminals_paths_test.go
+++ b/cmd/sb/stop/terminals_paths_test.go
@@ -20,10 +20,14 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"net/rpc"
 	"net/rpc/jsonrpc"
+	"os"
 	"os/exec"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -86,6 +90,53 @@ func spawnSessionProc(t *testing.T, script string) (pid int, pidStart uint64, do
 		t.Fatalf("StartTime(%d): %v", pid, err)
 	}
 	return pid, pidStart, d
+}
+
+// waitForSignalIgnored blocks until the process at pid has installed SIG_IGN
+// for sig, as reported by the SigIgn bitmask in /proc/<pid>/status.
+//
+// A shell running `trap "" <SIG>` does not install that disposition
+// synchronously with fork: there is a startup window (fork → exec /bin/sh →
+// run the trap builtin) during which the process still carries the default
+// disposition. spawnSessionProc returns as soon as the PID exists, so a test
+// that hands the PID straight to stopOneTerminal races that window — if the
+// SIGTERM fallback lands before `trap "" TERM` is in place, the "stubborn"
+// process is killed and miscounted as stopped instead of failed. Gating on
+// the installed disposition closes the race deterministically without
+// perturbing the production stop contract.
+func waitForSignalIgnored(t *testing.T, pid int, sig syscall.Signal) {
+	t.Helper()
+	mask := uint64(1) << (uint(sig) - 1)
+	deadline := time.Now().Add(2 * time.Second)
+	var last uint64
+	for {
+		ign, err := readSigIgnMask(pid)
+		if err == nil {
+			last = ign
+			if ign&mask != 0 {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for pid %d to ignore signal %d (SigIgn=%#016x)", pid, sig, last)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// readSigIgnMask parses the SigIgn bitmask (ignored-signal set, hex) from
+// /proc/<pid>/status.
+func readSigIgnMask(pid int) (uint64, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
+	if err != nil {
+		return 0, err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if v, ok := strings.CutPrefix(line, "SigIgn:"); ok {
+			return strconv.ParseUint(strings.TrimSpace(v), 16, 64)
+		}
+	}
+	return 0, fmt.Errorf("SigIgn not found in /proc/%d/status", pid)
 }
 
 // Test_StopOneTerminal_RPCGraceful covers the graceful path: the controller
@@ -176,8 +227,14 @@ func Test_RunStopTerminals_AllAggregation(t *testing.T) {
 	writeStopTestTerminal(t, runPath, "id-dead", "dead", api.Ready, 0x7fffffff)
 
 	// Failing: traps SIGTERM and --kill-after is off, so it never exits within
-	// the short timeout → resultFailed.
+	// the short timeout → resultFailed. Wait until the shell has actually
+	// installed `trap "" TERM` before proceeding: spawnSessionProc returns as
+	// soon as the PID exists, but the SIGTERM-ignore disposition lands a beat
+	// later. Without this gate the SIGTERM fallback races the trap and
+	// occasionally kills the process, miscounting it as stopped (the flake in
+	// #363 — fast ~0.21s return, nil aggregated error).
 	failPid, _, _ := spawnSessionProc(t, `trap "" TERM; sleep 60`)
+	waitForSignalIgnored(t, failPid, syscall.SIGTERM)
 	writeStopTestTerminal(t, runPath, "id-fail", "stubborn", api.Ready, failPid)
 
 	opts := stopOpts{


### PR DESCRIPTION
## Summary

`Test_RunStopTerminals_AllAggregation` was flaky (~20–40% locally), failing fast (~0.21s, well under the 300ms timeout) with a nil aggregated error. This PR closes the race deterministically.

### Root cause (differs from the issue's shortlist)

The issue's candidate causes were the reconcile filter dropping the failing terminal, a `spawnSessionProc` `/proc` readiness gap, or timeout tuning. I instrumented the real test across 60 runs and **ruled all three out**:

- `failInActive` was **true in every iteration** — reconcile never drops the failing terminal, and it's always alive at signal time. So candidates (a) reconcile-filter-drop and (b) misclassified-already-exited do not fire (the metadata records `PidStart: 0`, so liveness-only always passes for a freshly-spawned PID).
- The sole discriminator was the stubborn shell's `SigIgn` bitmask in `/proc/<pid>/status`: when `trap "" TERM` was already installed (`SigIgn` has the SIGTERM bit), the test passed; when it wasn't yet installed, the SIGTERM **fallback** killed the stubborn process during its startup window, so it counted as `resultStopped` instead of `resultFailed` → `stopped 2 ... 0 error(s)`, aggregated error nil, ~0.21s return.

So the real race is `trap "" TERM` **installation vs. the SIGTERM fallback**, not reconcile. `spawnSessionProc` returns as soon as the PID exists, but the SIGTERM-ignore disposition lands a beat later (fork → exec `/bin/sh` → run the `trap` builtin). Widening the timeout (issue suggestion b) would **not** fix this — the kill happens at signal-delivery time, regardless of how long we then wait.

### Fix

Test-side only, no production-code change, aggregation contract untouched. Added `waitForSignalIgnored(t, pid, sig)` which polls `/proc/<pid>/status`'s `SigIgn` mask until the process has installed `SIG_IGN` for the signal, and gate the stubborn terminal on `SIGTERM` before invoking `runStopTerminals`. This guarantees the trap is in place before the fallback can race it.

This matches the spirit of the issue's "readiness gate" suggestion (a), but gates on the **disposition** the test actually depends on rather than mere `/proc` presence (the process is already in `/proc` — `pidutil.StartTime` succeeds — so a presence gate would not help).

> Note on the issue body: the *symptom* description (flaky, fast nil-error return) was accurate; only the candidate root-cause shortlist was off. Documenting here per the rotted-premise guidance so the reviewer can push back on the reinterpretation.

## Test plan
- [x] Reproduced the original flake (`-count` loop → FAIL at 0.21s) on `origin/main`
- [x] `go test ./cmd/sb/stop/ -run Test_RunStopTerminals_AllAggregation -count=50` → 50/50 pass with the fix
- [x] `go test -race ./cmd/sb/stop/ -run Test_RunStopTerminals_AllAggregation -count=15` → clean, no data races
- [x] `make sbsh-sb` (canonical build; `file ./sbsh` → ELF executable)
- [x] `go build ./...`, `go vet ./...`
- [x] `make test` (full CI target incl. e2e) → all green
- [x] `pre-commit run --files cmd/sb/stop/terminals_paths_test.go` → all hooks pass

Closes #363