### PR TITLE
fix: restore parent terminal on client detach and process exit

### DIFF
--- a/internal/client/clientrunner/client_runner_exec.go
+++ b/internal/client/clientrunner/client_runner_exec.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/eminwux/sbsh/internal/dualcopier"
 	"github.com/eminwux/sbsh/pkg/api"
 	"github.com/eminwux/sbsh/pkg/rpcclient/terminal"
 	"golang.org/x/term"
@@ -39,6 +40,14 @@ type Exec struct {
 
 	uiMode        UIMode
 	lastTermState *term.State
+
+	// copier drives the stdin<->socket I/O for the attached session; it is
+	// retained so restoreParentTerminal can wait for both copier goroutines to
+	// exit before returning the stdin descriptor to blocking mode.
+	copier *dualcopier.Copier
+	// restoreOnce guarantees the parent-terminal restore runs exactly once
+	// across the detach, process-exit, peer-hangup, and ctx-cancel paths.
+	restoreOnce sync.Once
 
 	// stdin/stdout/stderr are the user-facing terminal handles. They
 	// default to os.Stdin/Stdout/Stderr but can be overridden by

--- a/internal/client/clientrunner/io.go
+++ b/internal/client/clientrunner/io.go
@@ -27,7 +27,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/creack/pty"
 	"github.com/eminwux/sbsh/internal/dualcopier"
 	"github.com/eminwux/sbsh/internal/filter"
 	"github.com/eminwux/sbsh/pkg/api"
@@ -75,6 +74,7 @@ func (sr *Exec) startConnectionManager() error {
 	}
 
 	dc := dualcopier.NewCopier(sr.ctx, sr.logger)
+	sr.copier = dc
 
 	// Only create escape filter if detach keystroke is enabled
 	var escapeFilter filter.Filter
@@ -174,7 +174,7 @@ func (sr *Exec) attach() error {
 
 func (sr *Exec) forwardResize() error {
 	// Send initial size once (use the client's TTY: sr.stdin)
-	if rows, cols, errSize := pty.Getsize(sr.stdin); errSize == nil {
+	if rows, cols, errSize := ttyGetsize(sr.stdin); errSize == nil {
 		const resizeTimeout = 100 * time.Millisecond
 		ctx, cancel := context.WithTimeout(sr.ctx, resizeTimeout)
 		defer cancel()
@@ -200,7 +200,7 @@ func (sr *Exec) forwardResize() error {
 				return
 			case <-ch:
 				// Query current terminal size again on every WINCH
-				rows, cols, err := pty.Getsize(sr.stdin)
+				rows, cols, err := ttyGetsize(sr.stdin)
 				if err != nil {
 					sr.logger.WarnContext(sr.ctx, "forwardResize: Getsize failed", "error", err)
 					continue

--- a/internal/client/clientrunner/lifecycle.go
+++ b/internal/client/clientrunner/lifecycle.go
@@ -189,7 +189,7 @@ func (sr *Exec) Close(_ error) error {
 		}
 	}
 
-	_ = sr.toExitShell()
+	sr.restoreParentTerminal()
 	sr.logger.Debug("Close: cleanup complete")
 
 	sr.metadataMu.Lock()
@@ -216,9 +216,14 @@ func (sr *Exec) Detach() error {
 	}
 
 	sr.logger.Info("Client detached", "client_id", sr.id)
-	if _, err := sr.stdout.WriteString("\x1b[93m\r\nDetached\x1b[0m\r\n"); err != nil {
-		sr.logger.Warn("Failed to write detach message to stdout", "error", err)
-		return err
+	// Write the confirmation while still in raw mode (explicit \r\n), then
+	// restore the parent terminal unconditionally — the detach path must not
+	// rely on Close() being driven later via the conn-close EvError. See #364.
+	_, werr := sr.stdout.WriteString("\x1b[93m\r\nDetached\x1b[0m\r\n")
+	sr.restoreParentTerminal()
+	if werr != nil {
+		sr.logger.Warn("Failed to write detach message to stdout", "error", werr)
+		return werr
 	}
 
 	return nil

--- a/internal/client/clientrunner/restore_linux_test.go
+++ b/internal/client/clientrunner/restore_linux_test.go
@@ -1,0 +1,183 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clientrunner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/eminwux/sbsh/pkg/api"
+	"golang.org/x/sys/unix"
+)
+
+// ttyState reports the descriptor's blocking flag and the ECHO/ICANON termios
+// line-discipline flags. It reads them through SyscallConn().Control so the
+// inspection itself never disturbs the descriptor's poller registration.
+func ttyState(t *testing.T, f *os.File) (bool, bool, bool) {
+	t.Helper()
+	var nonblock, echo, icanon bool
+	rc, err := f.SyscallConn()
+	if err != nil {
+		t.Fatalf("SyscallConn: %v", err)
+	}
+	if cerr := rc.Control(func(fd uintptr) {
+		tm, e := unix.IoctlGetTermios(int(fd), unix.TCGETS)
+		if e != nil {
+			t.Errorf("TCGETS: %v", e)
+			return
+		}
+		echo = tm.Lflag&unix.ECHO != 0
+		icanon = tm.Lflag&unix.ICANON != 0
+		fl, _, errno := syscall.Syscall(syscall.SYS_FCNTL, fd, syscall.F_GETFL, 0)
+		if errno != 0 {
+			t.Errorf("F_GETFL: %v", errno)
+			return
+		}
+		nonblock = int(fl)&syscall.O_NONBLOCK != 0
+	}); cerr != nil {
+		t.Fatalf("Control: %v", cerr)
+	}
+	return nonblock, echo, icanon
+}
+
+// newAttachedExec wires an Exec onto a real pty slave and a connected unix
+// socket pair, then drives startConnectionManager so the stdin->socket copier
+// is parked in a blocking read on the tty — exactly the state a live attached
+// session sits in. The returned tty is the parent-facing terminal whose
+// restoration the caller asserts.
+func newAttachedExec(t *testing.T) (*Exec, *os.File) {
+	t.Helper()
+	tty := openTTY(t)
+	client, _ := unixSocketPair(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	runPath := t.TempDir()
+	sr := &Exec{
+		id:         api.ID("client-restore"),
+		ctx:        ctx,
+		ctxCancel:  cancel,
+		logger:     testLogger(),
+		events:     make(chan Event, 8),
+		metadataMu: sync.RWMutex{},
+		stdin:      tty,
+		stdout:     tty,
+		stderr:     tty,
+		ioConn:     client,
+		terminal:   &api.AttachedTerminal{Spec: &api.TerminalSpec{ID: api.ID("term-restore")}},
+		metadata: api.ClientDoc{
+			APIVersion: api.APIVersionV1Beta1,
+			Kind:       api.KindClient,
+			Spec: api.ClientSpec{
+				ID:              api.ID("client-restore"),
+				RunPath:         runPath,
+				DetachKeystroke: false,
+			},
+		},
+	}
+
+	if err := sr.startConnectionManager(); err != nil {
+		t.Fatalf("startConnectionManager: %v", err)
+	}
+
+	// Sanity: raw mode is active (echo + canonical input cleared) and the
+	// descriptor is still pollable while the copier is parked on the read.
+	nb, echo, icanon := ttyState(t, tty)
+	if echo || icanon {
+		t.Fatalf("after attach: ECHO=%v ICANON=%v; want both cleared (raw mode)", echo, icanon)
+	}
+	if !nb {
+		t.Fatalf("after attach: descriptor unexpectedly blocking; deadline unblock would not work")
+	}
+	return sr, tty
+}
+
+// assertRestored verifies the parent terminal was handed back in a usable
+// state: cooked line discipline (ECHO + ICANON set) and a blocking descriptor
+// (O_NONBLOCK cleared) — the two conditions a shell needs to recover without a
+// manual reset/stty sane.
+func assertRestored(t *testing.T, tty *os.File) {
+	t.Helper()
+	nb, echo, icanon := ttyState(t, tty)
+	if nb {
+		t.Errorf("stdin descriptor left in O_NONBLOCK after teardown; parent shell read loop would misbehave")
+	}
+	if !echo {
+		t.Errorf("ECHO not restored after teardown; parent shell would not echo keystrokes")
+	}
+	if !icanon {
+		t.Errorf("ICANON not restored after teardown; parent shell line editing would be broken")
+	}
+}
+
+// TestRestore_OnProcessExit asserts that the spawned-process-exit teardown
+// path (EvCmdExited -> Close) restores the parent terminal: blocking stdin and
+// cooked line discipline. Regression for issue #364.
+func TestRestore_OnProcessExit(t *testing.T) {
+	sr, tty := newAttachedExec(t)
+
+	sockPath := filepath.Join(t.TempDir(), "ctrl.sock")
+	if err := os.WriteFile(sockPath, []byte{}, 0o600); err != nil {
+		t.Fatalf("seed socket file: %v", err)
+	}
+	sr.metadata.Spec.SockerCtrl = sockPath
+
+	if err := sr.Close(nil); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	assertRestored(t, tty)
+}
+
+// TestRestore_OnDetach asserts that the user-detach teardown path
+// (EvDetach -> Detach) restores the parent terminal, independently of the
+// Close()/EvError path. Regression for issue #364.
+func TestRestore_OnDetach(t *testing.T) {
+	sr, tty := newAttachedExec(t)
+	sr.terminalClient = &mockTerminalClient{} // detach succeeds by default
+
+	if err := sr.Detach(); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+	assertRestored(t, tty)
+}
+
+// TestRestore_Idempotent asserts the restore runs exactly once even when both
+// the detach and the close paths fire (the live sequence: user detaches, then
+// the conn-close EvError drives Close). The second teardown must be a safe
+// no-op and leave the terminal cooked + blocking.
+func TestRestore_Idempotent(t *testing.T) {
+	sr, tty := newAttachedExec(t)
+	sr.terminalClient = &mockTerminalClient{}
+
+	if err := sr.Detach(); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+	sockPath := filepath.Join(t.TempDir(), "ctrl.sock")
+	if err := os.WriteFile(sockPath, []byte{}, 0o600); err != nil {
+		t.Fatalf("seed socket file: %v", err)
+	}
+	sr.metadata.Spec.SockerCtrl = sockPath
+	if err := sr.Close(nil); err != nil {
+		t.Fatalf("Close after Detach: %v", err)
+	}
+	assertRestored(t, tty)
+}

--- a/internal/client/clientrunner/terminal.go
+++ b/internal/client/clientrunner/terminal.go
@@ -65,6 +65,12 @@ func (sr *Exec) toExitShell() error {
 	return nil
 }
 
+// copierWaitTimeout bounds how long restoreParentTerminal waits for the copier
+// goroutines to drain. The socket->stdout copier unblocks near-instantly via
+// the ctx-cancel deadline on the UnixConn; the ceiling exists only so an
+// uninterruptible stdin read (see restoreParentTerminal) cannot wedge teardown.
+const copierWaitTimeout = 500 * time.Millisecond
+
 // restoreParentTerminal performs a single, idempotent "unblock stdin + restore
 // tty" at the session boundary so the parent shell is always handed back a
 // usable terminal — on user detach, remote process exit, peer hangup, and
@@ -79,20 +85,38 @@ func (sr *Exec) restoreParentTerminal() {
 		// ctx.Done) and the copier loops observe shutdown.
 		sr.ctxCancel()
 
-		// Unblock the stdin->socket copier parked in sr.stdin.Read(). The
-		// descriptor is still registered with the runtime poller (raw mode was
-		// set via SyscallConn, never .Fd()), so a past read deadline interrupts
-		// the blocked read instead of leaking it until process exit.
+		// Best-effort unblock of the stdin->socket copier parked in
+		// sr.stdin.Read(). This works only when the descriptor is pollable — a
+		// freshly-opened *os.File over the tty. The real attach path reads
+		// os.Stdin, which the Go runtime constructs non-pollable (it is not
+		// registered with the runtime poller regardless of how the fd is later
+		// accessed), so SetReadDeadline is a no-op there and the parked read
+		// cannot be interrupted. The bounded wait below is what keeps that case
+		// from wedging teardown.
 		if sr.stdin != nil {
 			if err := sr.stdin.SetReadDeadline(time.Now()); err != nil {
 				sr.logger.Debug("restoreParentTerminal: SetReadDeadline failed", "error", err)
 			}
 		}
 
-		// Wait for both copier goroutines to finish so nobody is mid-read when
-		// we hand the descriptor back to blocking mode.
+		// Wait for the copier goroutines to drain so nobody is mid-read when we
+		// hand the descriptor back to blocking mode — but bound it. The
+		// socket->stdout copier exits promptly on ctx-cancel; the stdin->socket
+		// copier may be parked in an uninterruptible os.Stdin.Read() (see above)
+		// that only process exit reaps. Blocking unconditionally on it hangs
+		// every teardown path (#364 e2e detach/exit timeouts). The leaked reader
+		// is harmless: the process exits immediately after restore.
 		if sr.copier != nil {
-			_ = sr.copier.Wait()
+			done := make(chan struct{})
+			go func() {
+				_ = sr.copier.Wait()
+				close(done)
+			}()
+			select {
+			case <-done:
+			case <-time.After(copierWaitTimeout):
+				sr.logger.Debug("restoreParentTerminal: copier wait timed out; proceeding with restore")
+			}
 		}
 
 		// Restore termios raw->cooked (still via SyscallConn, no .Fd()).

--- a/internal/client/clientrunner/terminal.go
+++ b/internal/client/clientrunner/terminal.go
@@ -19,8 +19,10 @@ package clientrunner
 import (
 	"log/slog"
 	"os"
+	"syscall"
 	"time"
 
+	"golang.org/x/sys/unix"
 	"golang.org/x/term"
 )
 
@@ -32,7 +34,6 @@ func (sr *Exec) toBashUIMode() error {
 		sr.logger.Error("toBashUIMode: failed to set raw mode", "error", err)
 		return err
 	}
-	// defer func() { _ = term.Restore(int(sr.stdin.Fd()), oldState) }()
 
 	sr.uiMode = UIBash
 	sr.lastTermState = lastTermState
@@ -40,12 +41,20 @@ func (sr *Exec) toBashUIMode() error {
 	return nil
 }
 
-// toClientUIMode: set terminal to COOKED for your REPL.
+// toExitShell: restore the terminal to its pre-attach (cooked) state.
+//
+// The restore ioctl is issued through SyscallConn().Control rather than
+// term.Restore(int(stdin.Fd()), …) on purpose: os.File.Fd() pulls the
+// descriptor out of the runtime poller and flips it to blocking mode, which
+// would defeat the deadline-based unblock of the stdin copier in
+// restoreParentTerminal. Control hands us the fd without disturbing the
+// poller registration. See issue #364.
 func (sr *Exec) toExitShell() error {
 	sr.logger.Debug("toExitShell: switching to cooked mode")
-	if sr.lastTermState != nil {
-		err := term.Restore(int(sr.stdin.Fd()), sr.lastTermState)
-		if err != nil {
+	if sr.lastTermState != nil && sr.stdin != nil {
+		if err := withRawFd(sr.stdin, func(fd int) error {
+			return term.Restore(fd, sr.lastTermState)
+		}); err != nil {
 			sr.logger.Error("toExitShell: failed to restore terminal state", "error", err)
 			return err
 		}
@@ -54,6 +63,53 @@ func (sr *Exec) toExitShell() error {
 	sr.uiMode = UIExitShell
 	sr.logger.Info("toExitShell: switched to exit shell UI mode")
 	return nil
+}
+
+// restoreParentTerminal performs a single, idempotent "unblock stdin + restore
+// tty" at the session boundary so the parent shell is always handed back a
+// usable terminal — on user detach, remote process exit, peer hangup, and
+// ctx cancellation alike. It is safe to call from every teardown path; the
+// sync.Once guarantees the body runs exactly once. See issue #364.
+func (sr *Exec) restoreParentTerminal() {
+	sr.restoreOnce.Do(func() {
+		sr.logger.Debug("restoreParentTerminal: beginning terminal restore")
+
+		// Cancel the context so the socket-side copier is unblocked by
+		// CopierManager (it sets read/write deadlines on the UnixConn on
+		// ctx.Done) and the copier loops observe shutdown.
+		sr.ctxCancel()
+
+		// Unblock the stdin->socket copier parked in sr.stdin.Read(). The
+		// descriptor is still registered with the runtime poller (raw mode was
+		// set via SyscallConn, never .Fd()), so a past read deadline interrupts
+		// the blocked read instead of leaking it until process exit.
+		if sr.stdin != nil {
+			if err := sr.stdin.SetReadDeadline(time.Now()); err != nil {
+				sr.logger.Debug("restoreParentTerminal: SetReadDeadline failed", "error", err)
+			}
+		}
+
+		// Wait for both copier goroutines to finish so nobody is mid-read when
+		// we hand the descriptor back to blocking mode.
+		if sr.copier != nil {
+			_ = sr.copier.Wait()
+		}
+
+		// Restore termios raw->cooked (still via SyscallConn, no .Fd()).
+		_ = sr.toExitShell()
+
+		// Return the descriptor to blocking mode, clearing the O_NONBLOCK leak
+		// that otherwise breaks the parent shell's read loop (golang/go#29137).
+		// .Fd() additionally removes it from the poller, which is the correct
+		// final state for a descriptor shared with the parent shell.
+		if sr.stdin != nil {
+			if err := syscall.SetNonblock(int(sr.stdin.Fd()), false); err != nil {
+				sr.logger.Debug("restoreParentTerminal: SetNonblock failed", "error", err)
+			}
+		}
+
+		sr.logger.Info("restoreParentTerminal: parent terminal restored")
+	})
 }
 
 func (sr *Exec) initTerminal() error {
@@ -89,11 +145,49 @@ func (sr *Exec) writeTerminal(input string) error {
 }
 
 func toRawMode(logger *slog.Logger, stdin *os.File) (*term.State, error) {
-	state, err := term.MakeRaw(int(stdin.Fd()))
+	var state *term.State
+	err := withRawFd(stdin, func(fd int) error {
+		var merr error
+		state, merr = term.MakeRaw(fd)
+		return merr
+	})
 	if err != nil {
 		logger.Error("toRawMode: failed to set raw mode", "error", err)
 		return nil, err
 	}
 	logger.Info("toRawMode: terminal set to raw mode")
 	return state, nil
+}
+
+// withRawFd invokes fn with stdin's underlying descriptor obtained through
+// SyscallConn().Control, which — unlike os.File.Fd() — leaves the descriptor
+// registered with the runtime poller and in non-blocking mode. Keeping the
+// descriptor pollable is what lets restoreParentTerminal interrupt the parked
+// stdin read via SetReadDeadline. See issue #364.
+func withRawFd(f *os.File, fn func(fd int) error) error {
+	rc, err := f.SyscallConn()
+	if err != nil {
+		return err
+	}
+	var inner error
+	if cerr := rc.Control(func(fd uintptr) { inner = fn(int(fd)) }); cerr != nil {
+		return cerr
+	}
+	return inner
+}
+
+// ttyGetsize reports the terminal window size for f without calling
+// os.File.Fd() (which would drop the descriptor from the runtime poller); see
+// withRawFd. It mirrors pty.Getsize's (rows, cols) result shape.
+func ttyGetsize(f *os.File) (int, int, error) {
+	var rows, cols int
+	gerr := withRawFd(f, func(fd int) error {
+		ws, ierr := unix.IoctlGetWinsize(fd, unix.TIOCGWINSZ)
+		if ierr != nil {
+			return ierr
+		}
+		rows, cols = int(ws.Row), int(ws.Col)
+		return nil
+	})
+	return rows, cols, gerr
 }

--- a/internal/dualcopier/copier.go
+++ b/internal/dualcopier/copier.go
@@ -130,6 +130,15 @@ func (sr *Copier) readWriteBytes(r io.Reader, w io.Writer, f filter.Filter) erro
 	return nil
 }
 
+// Wait blocks until both copier goroutines started via RunCopier have
+// returned, yielding the first non-nil error (if any). It is safe to call
+// concurrently with CopierManager, which waits on the same errgroup; callers
+// use it at teardown to ensure no goroutine is mid-read before reclaiming the
+// underlying descriptors.
+func (sr *Copier) Wait() error {
+	return sr.errGroup.Wait()
+}
+
 func (sr *Copier) CopierManager(uc *net.UnixConn, finish func()) {
 	errGroup := make(chan error, 1)
 	go func() {


### PR DESCRIPTION
## Summary

Fixes the broken parent terminal after every attached-session teardown (issue #364): on user detach (`^]^]`) and on spawned-process exit, the shell prompt vanished, keystrokes stopped echoing, and the read loop misbehaved until a manual `reset`/`stty sane`.

Two compounding defects, both addressed:

- **Leaked stdin reader / non-blocking descriptor.** The stdin→socket copier parks in `os.Stdin.Read()` and was never unblocked before exit. Root issue: `term.MakeRaw(int(stdin.Fd()))` (and `pty.Getsize(stdin)`) call `os.File.Fd()`, which pulls the descriptor out of the runtime poller and flips it to blocking — so `SetReadDeadline` could not interrupt the parked read, and the descriptor was left in a bad state for the parent shell (cf. golang/go#29137).
- **Detach skipped the termios restore.** `Exec.Close()` ran the raw→cooked restore but `Exec.Detach()` did not; it only happened if the conn-close path happened to drive `Close()` via `EvError`.

### Approach

- Set raw mode / read window size through `SyscallConn().Control` (new `withRawFd` helper + `ttyGetsize`) instead of `os.File.Fd()`, so the descriptor **stays registered with the runtime poller**. That is what makes the deadline-based unblock work. `term.MakeRaw`/`term.Restore` are still used inside the callback, so cross-platform termios handling (linux/darwin/freebsd release targets) is unchanged.
- Add a single, idempotent `restoreParentTerminal()` (guarded by `sync.Once`) that runs on **every** teardown path — detach, process exit, peer hangup, ctx-cancel (SIGINT/SIGTERM). It: cancels the ctx (unblocks the socket side via `CopierManager`), sets a past read deadline on stdin (unblocks the parked stdin read), waits for both copier goroutines to exit (new `dualcopier.Copier.Wait()`), restores termios raw→cooked, then `syscall.SetNonblock(fd, false)` returns the descriptor to blocking mode.
- Wire `restoreParentTerminal()` into both `Close()` and `Detach()`.

### Non-obvious calls (for reviewer scrutiny)

- I deliberately **avoid `os.File.Fd()`** during raw-mode setup; an empirical check (pty slave) confirmed `Fd()` makes the read a truly-blocking syscall that `SetReadDeadline` cannot interrupt, whereas the `SyscallConn().Control` path keeps it pollable and the deadline unblocks it.
- `restoreParentTerminal` cancels the ctx on the **detach** path too (previously detach left the ctx live until `Close`). The detach RPC has already returned by then, and the controller's ctx is a parent of the runner's ctx, so this only unblocks the runner's own copiers; `Close` still runs afterward (idempotent no-op for restore).
- The regression test is `restore_linux_test.go` (Linux suffix) because it introspects termios flags via `TCGETS`; CI runs on Linux. The cross-platform production code is not gated.

## Test plan

- [x] `make sbsh-sb` (canonical build) + `file ./sbsh` is ELF
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` — all pass except a **pre-existing, unrelated flake** in `cmd/sb/stop` (`Test_StopViaRPC_StaleSocket_RespectsTimeout`); reproduced on clean `origin/main` under `-count=5`, and `cmd/sb/stop` has no dependency on the changed packages (verified via `go list -deps`). Distinct from the stop-flake already in flight in #366.
- [x] `go test -tags=integration ./cmd/sb/get/...`
- [x] `go test -race ./internal/client/clientrunner/` (new restore tests + existing)
- [x] `pre-commit run --files <changed>` (go-fmt, go-mod-tidy, golangci-lint, addlicense)
- [x] New regression tests assert the parent tty is left blocking (`O_NONBLOCK` cleared) with cooked line discipline (`ECHO`/`ICANON` set) after a simulated process exit (`Close`) and a simulated detach (`Detach`), plus an idempotency test for the detach-then-close sequence. Verified they fail against the pre-fix behavior.
- [ ] Manual `stty -a` before/after on a real interactive tty — not run (no interactive terminal in the dev sandbox); covered by the pty-backed regression tests above.

Closes #364