### PR TITLE
fix: restore parent terminal output-side DEC mode state on teardown

### DIFF
--- a/internal/client/clientrunner/restore_linux_test.go
+++ b/internal/client/clientrunner/restore_linux_test.go
@@ -18,8 +18,10 @@ package clientrunner
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -158,6 +160,72 @@ func TestRestore_OnDetach(t *testing.T) {
 		t.Fatalf("Detach: %v", err)
 	}
 	assertRestored(t, tty)
+}
+
+// assertNormalizeEmitted reads everything still in r and checks that the
+// output-side normalization escape (leave alt-screen, show cursor, reset
+// cursor style) was written by restoreParentTerminal. The caller closes the
+// pipe writer before calling so ReadAll terminates on EOF.
+func assertNormalizeEmitted(t *testing.T, r *os.File) {
+	t.Helper()
+	buf, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	out := string(buf)
+	for _, want := range []string{"\x1b[?1049l", "\x1b[?25h", "\x1b[0 q"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing normalization escape %q in stdout %q", want, out)
+		}
+	}
+}
+
+// TestRestore_EmitsOutputNormalize_OnProcessExit asserts that the
+// spawned-process-exit teardown path writes the output-side normalization
+// escape to the parent terminal: leave alt-screen, show cursor, reset cursor
+// style. Regression for issue #365.
+func TestRestore_EmitsOutputNormalize_OnProcessExit(t *testing.T) {
+	sr, _ := newAttachedExec(t)
+
+	r, w, errPipe := os.Pipe()
+	if errPipe != nil {
+		t.Fatalf("Pipe: %v", errPipe)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+	sr.stdout = w
+
+	sockPath := filepath.Join(t.TempDir(), "ctrl.sock")
+	if errSeed := os.WriteFile(sockPath, []byte{}, 0o600); errSeed != nil {
+		t.Fatalf("seed socket file: %v", errSeed)
+	}
+	sr.metadata.Spec.SockerCtrl = sockPath
+
+	if errClose := sr.Close(nil); errClose != nil {
+		t.Fatalf("Close: %v", errClose)
+	}
+	_ = w.Close()
+	assertNormalizeEmitted(t, r)
+}
+
+// TestRestore_EmitsOutputNormalize_OnDetach asserts the user-detach teardown
+// path writes the output-side normalization escape, independently of the
+// Close()/EvError path. Regression for issue #365.
+func TestRestore_EmitsOutputNormalize_OnDetach(t *testing.T) {
+	sr, _ := newAttachedExec(t)
+	sr.terminalClient = &mockTerminalClient{}
+
+	r, w, errPipe := os.Pipe()
+	if errPipe != nil {
+		t.Fatalf("Pipe: %v", errPipe)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+	sr.stdout = w
+
+	if errDetach := sr.Detach(); errDetach != nil {
+		t.Fatalf("Detach: %v", errDetach)
+	}
+	_ = w.Close()
+	assertNormalizeEmitted(t, r)
 }
 
 // TestRestore_Idempotent asserts the restore runs exactly once even when both

--- a/internal/client/clientrunner/terminal.go
+++ b/internal/client/clientrunner/terminal.go
@@ -71,6 +71,18 @@ func (sr *Exec) toExitShell() error {
 // uninterruptible stdin read (see restoreParentTerminal) cannot wedge teardown.
 const copierWaitTimeout = 500 * time.Millisecond
 
+// escRestoreParentTerm normalizes the parent terminal's output-side DEC private
+// mode state on session teardown: leave the alternate-screen buffer, show the
+// cursor, and reset the cursor style to the terminal default. Symmetric with
+// the modes the server-side attach repaint may set (escEnterAltScreen /
+// escHideCursor in internal/terminal/terminalrunner/terminal_screen.go) and
+// with anything a TUI/shell on the remote side wrote through to the parent
+// terminal without a matching reset. Emitted unconditionally per #365 — the
+// client cannot rely on the remote side emitting a matching reset on its own.
+const escRestoreParentTerm = "\x1b[?1049l" + // leave the alternate screen buffer
+	"\x1b[?25h" + // make the cursor visible
+	"\x1b[0 q" // reset cursor style (DECSCUSR) to terminal default
+
 // restoreParentTerminal performs a single, idempotent "unblock stdin + restore
 // tty" at the session boundary so the parent shell is always handed back a
 // usable terminal — on user detach, remote process exit, peer hangup, and
@@ -116,6 +128,19 @@ func (sr *Exec) restoreParentTerminal() {
 			case <-done:
 			case <-time.After(copierWaitTimeout):
 				sr.logger.Debug("restoreParentTerminal: copier wait timed out; proceeding with restore")
+			}
+		}
+
+		// Normalize the parent terminal's output-side DEC private mode state
+		// (alt-screen, cursor visibility, cursor style) before handing the
+		// terminal back. Runs after the copier wait so we do not race the
+		// socket->stdout copier still draining remote bytes, and before the
+		// termios restore — these are escape bytes interpreted by the parent
+		// terminal emulator, not line-discipline input, so the active termios
+		// mode does not affect them. See issue #365.
+		if sr.stdout != nil {
+			if _, err := sr.stdout.WriteString(escRestoreParentTerm); err != nil {
+				sr.logger.Debug("restoreParentTerminal: write normalize sequence failed", "error", err)
 			}
 		}
 


### PR DESCRIPTION
## Summary

Fixes the missing cursor and leftover alt-screen buffer left in the parent terminal after every attached-session teardown (issue #365): when a TUI or shell on the remote side hides the cursor (`\x1b[?25l`) or enters the alternate screen (`\x1b[?1049h`) — or when the server's own attach repaint emits those modes — none of it was being undone on the client side, and the parent shell was handed back a terminal with a hidden cursor / wrong screen buffer until a manual `reset`.

Distinct from #364: that fix was input-side (stdin nonblocking leak + termios raw→cooked). #364's `restoreParentTerminal()` already runs on every teardown path (detach keystroke, remote process exit, peer hangup, SIGINT/SIGTERM); this PR adds the output-side normalization to the same helper, so all four teardown paths benefit from the existing sync.Once discipline.

### Approach

- Define `escRestoreParentTerm = "\x1b[?1049l" + "\x1b[?25h" + "\x1b[0 q"` — leave the alternate-screen buffer, show the cursor, reset cursor style (DECSCUSR) to terminal default. Symmetric with the modes the server-side attach repaint can set (`escEnterAltScreen` / `escHideCursor` in `internal/terminal/terminalrunner/terminal_screen.go`).
- Write `escRestoreParentTerm` to `sr.stdout` inside `restoreParentTerminal`, **after the copier wait** (so we do not race the socket→stdout copier still draining remote bytes) and **before the termios restore** (escape bytes are interpreted by the parent terminal emulator, not by the line discipline, so termios mode doesn't affect them).
- Emit unconditionally per the AC — the client cannot rely on the remote side sending the matching reset on its own.

### Non-obvious calls (for reviewer scrutiny)

- Order is `?1049l` (leave alt-screen) → `?25h` (show cursor) → `0 q` (reset cursor style). Leaving alt-screen first means the show-cursor and DECSCUSR land on the main screen buffer the user is about to see, not on the alt-screen that's going away.
- The escape is inside the `sync.Once` body so it runs exactly once per session — same idempotency as the rest of `restoreParentTerminal`, matching the existing detach-then-close test (`TestRestore_Idempotent`).
- I deliberately did **not** issue a soft reset (RIS / `\x1bc`) — soft reset wipes the scrollback and resets colors, which would be visually destructive on every detach. The three-escape minimum named in #365 is the smallest sequence that solves the reported user-visible problems (missing cursor, stuck alt-screen).
- Substitutes `sr.stdout` with an `os.Pipe()` in the new tests rather than reading the master side of the existing pty pair, because `newAttachedExec` wires the socket→stdout copier with the original stdout — and the test cares about what `restoreParentTerminal` writes, not what the copier wrote earlier.

## Test plan

- [x] `make sbsh-sb` (canonical build) + ELF magic verified
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` — all pass
- [x] `go test -race -count=3 -timeout=2m ./internal/client/clientrunner/...` — clean (covers the new tests under repeat + race)
- [x] `pre-commit run --files <changed>` (go-fmt, go-mod-tidy, golangci-lint, addlicense) — passes
- [x] New regression tests `TestRestore_EmitsOutputNormalize_OnProcessExit` and `TestRestore_EmitsOutputNormalize_OnDetach` substitute `sr.stdout` with an `os.Pipe`, drive each teardown path, and assert the three normalization escapes (`\x1b[?1049l`, `\x1b[?25h`, `\x1b[0 q`) appear in the captured output. Verified they fail against the pre-fix code (no escape sequence is written).
- [ ] Manual: attach to a session whose remote side hides the cursor or enters alt-screen, detach, and confirm the parent shell shows a normal blinking cursor on the main screen with no `reset` — not run (no interactive terminal in the dev sandbox); covered by the pipe-backed regression tests above.

Closes #365