### PR TITLE
fix: restore output-side terminal state on client teardown

### DIFF
--- a/internal/client/clientrunner/restore_io_test.go
+++ b/internal/client/clientrunner/restore_io_test.go
@@ -1,0 +1,125 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clientrunner
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// captureStdoutPipe replaces sr.stdout with the write end of a fresh pipe so
+// the test can inspect the bytes the teardown paths write directly to the
+// parent terminal. The returned write end must be closed after the teardown
+// call so the drain goroutine sees EOF and the returned channel yields the
+// accumulated bytes.
+func captureStdoutPipe(t *testing.T, sr *Exec) (*os.File, <-chan []byte) {
+	t.Helper()
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	t.Cleanup(func() { _ = pr.Close(); _ = pw.Close() })
+	sr.stdout = pw
+
+	ch := make(chan []byte, 1)
+	go func() {
+		buf, _ := io.ReadAll(pr)
+		ch <- buf
+	}()
+	return pw, ch
+}
+
+// TestRestore_OutputReset_OnDetach asserts the detach teardown path writes the
+// output-side normalization sequence (show cursor + DECSCUSR reset + leave
+// alt-screen) to the parent terminal. Regression for issue #365.
+func TestRestore_OutputReset_OnDetach(t *testing.T) {
+	sr, _ := newAttachedExec(t)
+	sr.terminalClient = &mockTerminalClient{} // detach succeeds by default
+	pw, drained := captureStdoutPipe(t, sr)
+
+	if err := sr.Detach(); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+	_ = pw.Close() // EOF the drain so io.ReadAll returns
+
+	got := string(<-drained)
+	if !strings.Contains(got, parentTerminalReset) {
+		t.Errorf("Detach output missing parent-terminal reset sequence;\n got: %q\nwant substring: %q",
+			got, parentTerminalReset)
+	}
+}
+
+// TestRestore_OutputReset_OnProcessExit asserts the process-exit teardown path
+// (EvCmdExited -> Close) writes the output-side normalization sequence to the
+// parent terminal. Regression for issue #365.
+func TestRestore_OutputReset_OnProcessExit(t *testing.T) {
+	sr, _ := newAttachedExec(t)
+	pw, drained := captureStdoutPipe(t, sr)
+
+	sockPath := filepath.Join(t.TempDir(), "ctrl.sock")
+	if err := os.WriteFile(sockPath, []byte{}, 0o600); err != nil {
+		t.Fatalf("seed socket file: %v", err)
+	}
+	sr.metadata.Spec.SockerCtrl = sockPath
+
+	if err := sr.Close(nil); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	_ = pw.Close()
+
+	got := string(<-drained)
+	if !strings.Contains(got, parentTerminalReset) {
+		t.Errorf("Close output missing parent-terminal reset sequence;\n got: %q\nwant substring: %q",
+			got, parentTerminalReset)
+	}
+}
+
+// TestRestore_OutputReset_Once asserts the reset bytes are written exactly
+// once even when both the detach and close teardown paths fire (the live
+// sequence: user detaches, then conn-close EvError drives Close). The
+// sync.Once that guards restoreParentTerminal must make the second teardown a
+// no-op for the output-side write too — emitting the reset twice would
+// double-toggle the alt-screen leave (no-op on the first call, then
+// re-trigger if some intervening write entered it again, which never happens
+// here) and double-show the cursor (idempotent but wasteful).
+func TestRestore_OutputReset_Once(t *testing.T) {
+	sr, _ := newAttachedExec(t)
+	sr.terminalClient = &mockTerminalClient{}
+	pw, drained := captureStdoutPipe(t, sr)
+
+	if err := sr.Detach(); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+	sockPath := filepath.Join(t.TempDir(), "ctrl.sock")
+	if err := os.WriteFile(sockPath, []byte{}, 0o600); err != nil {
+		t.Fatalf("seed socket file: %v", err)
+	}
+	sr.metadata.Spec.SockerCtrl = sockPath
+	if err := sr.Close(nil); err != nil {
+		t.Fatalf("Close after Detach: %v", err)
+	}
+	_ = pw.Close()
+
+	got := string(<-drained)
+	if n := strings.Count(got, parentTerminalReset); n != 1 {
+		t.Errorf("reset sequence appeared %d times after Detach+Close; want exactly 1\n got: %q",
+			n, got)
+	}
+}

--- a/internal/client/clientrunner/terminal.go
+++ b/internal/client/clientrunner/terminal.go
@@ -71,11 +71,25 @@ func (sr *Exec) toExitShell() error {
 // uninterruptible stdin read (see restoreParentTerminal) cannot wedge teardown.
 const copierWaitTimeout = 500 * time.Millisecond
 
-// restoreParentTerminal performs a single, idempotent "unblock stdin + restore
-// tty" at the session boundary so the parent shell is always handed back a
-// usable terminal — on user detach, remote process exit, peer hangup, and
-// ctx cancellation alike. It is safe to call from every teardown path; the
-// sync.Once guarantees the body runs exactly once. See issue #364.
+// parentTerminalReset is the output-side normalization the client writes to
+// the parent terminal on every teardown path so a TUI's hide-cursor /
+// alt-screen / cursor-style mutations do not survive the session. The bytes
+// are pure DEC private-mode resets and are interpreted by the user's terminal
+// emulator independent of termios cooked/raw state, so the write can happen
+// before the termios restore. Symmetric with the modes the server-side
+// repaint can enter (see escEnterAltScreen / escShowCursor in
+// internal/terminal/terminalrunner/terminal_screen.go). See issue #365.
+const parentTerminalReset = "\x1b[?25h" + // show the cursor (DECTCEM)
+	"\x1b[0 q" + // reset cursor style to terminal default (DECSCUSR 0)
+	"\x1b[?1049l" // leave the alternate-screen buffer
+
+// restoreParentTerminal performs a single, idempotent "unblock stdin + reset
+// output-side modes + restore tty" at the session boundary so the parent
+// shell is always handed back a usable terminal — on user detach, remote
+// process exit, peer hangup, and ctx cancellation alike. It is safe to call
+// from every teardown path; the sync.Once guarantees the body runs exactly
+// once. See issues #364 (input-side stdin/termios) and #365 (output-side
+// cursor / alt-screen).
 func (sr *Exec) restoreParentTerminal() {
 	sr.restoreOnce.Do(func() {
 		sr.logger.Debug("restoreParentTerminal: beginning terminal restore")
@@ -116,6 +130,18 @@ func (sr *Exec) restoreParentTerminal() {
 			case <-done:
 			case <-time.After(copierWaitTimeout):
 				sr.logger.Debug("restoreParentTerminal: copier wait timed out; proceeding with restore")
+			}
+		}
+
+		// Write the output-side reset before the termios restore so the parent
+		// terminal is normalized even if the remote side never emitted a matching
+		// show-cursor / leave-alt-screen (TUI hides cursor, attach repaint may
+		// have entered the alt-screen, DECSCUSR may have changed the cursor
+		// style). Best-effort: a closed/unreachable parent tty is no worse than
+		// the pre-fix behavior.
+		if sr.stdout != nil {
+			if _, err := sr.stdout.WriteString(parentTerminalReset); err != nil {
+				sr.logger.Debug("restoreParentTerminal: parent terminal reset write failed", "error", err)
 			}
 		}
 


### PR DESCRIPTION
## Summary

Fixes the broken parent terminal **output state** after every attached-session teardown (issue #365): after detach or remote-process exit, the cursor was gone (a TUI's `\x1b[?25l` or the server's attach-repaint hide-cursor was never undone) and a full-screen program could leave the parent shell stuck on the alternate screen.

Distinct from #364 / PR #367 (input-side stdin non-blocking + termios restore): #367 brought the input fd back to a usable state but emitted no compensating reset for the output-side DEC private modes the remote side may have flipped.

### Approach

- Add a small `parentTerminalReset` constant — the three DEC private-mode resets called out in the issue: show cursor (`\x1b[?25h`), DECSCUSR cursor-style default (`\x1b[0 q`), leave alt-screen (`\x1b[?1049l`).
- Write it to `sr.stdout` inside `restoreParentTerminal()` — between the bounded copier wait and the termios raw→cooked restore. The `sync.Once` that already guards the input-side restore (introduced in #367) covers the output-side write for free, so detach + close (the live "detach then EvError → Close" sequence) writes the reset exactly once.
- Best-effort: a failing write logs Debug and proceeds — a closed/unreachable parent tty is no worse than the pre-fix behavior.

### Why inside `restoreParentTerminal` (and after the copier wait)

`restoreParentTerminal` is invoked from every teardown path #365's AC requires (detach keystroke, remote process exit, peer hangup, ctx-cancel via SIGINT/SIGTERM) — wiring the reset there satisfies the "all teardown paths" criterion without duplicating call sites.

Writing **after** the socket→stdout copier has drained (or its bounded wait has elapsed) means no late `\x1b[?25l` from the remote side overwrites our reset.

Writing **before** the termios `toExitShell()` is fine because the bytes are pure DEC private-mode sequences — the user's terminal emulator interprets them independent of kernel termios cooked/raw state.

### Non-obvious calls (for reviewer scrutiny)

- Constants are defined locally rather than imported from `internal/terminal/terminalrunner` (which has `escShowCursor` / `escEnterAltScreen`). The terminalrunner package is the server side; making the client depend on a server-side internal package for two byte literals would be wrong directionally and only saves three short constants. The terminal.go docstring cross-references the server-side names so future edits stay in sync.
- DECSCUSR `\x1b[0 q` (reset cursor style to terminal default) is included even though the issue body lists it as "at minimum" alongside show-cursor and leave-alt-screen — without it, a remote-side `\x1b[<n> q` (e.g., bar cursor from a vim/neovim config) would survive the session even though `\x1b[?25h` brought the cursor back. Cheap to include and matches the issue's spirit.

## Test plan

- [x] `make sbsh-sb` (canonical build) + first 4 bytes of `./sbsh` confirmed `\x7fELF`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=2 ./internal/client/clientrunner/...` — pass
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` — all pass
- [x] `go test ./e2e/...` — pass
- [x] `go test -tags=integration ./cmd/sb/get/...` — pass
- [x] `pre-commit run --files internal/client/clientrunner/terminal.go internal/client/clientrunner/restore_io_test.go` — all hooks pass (go-fmt, go-mod-tidy, golangci-lint, addlicense)
- [x] New regression tests in `restore_io_test.go` capture `sr.stdout` via `os.Pipe` and assert the reset substring appears (a) on the detach path, (b) on the close path, and (c) exactly once across a detach-then-close sequence. Verified they fail against the pre-fix code (no write call exists).
- [ ] Manual: attach in a real terminal, run a TUI that hides the cursor (e.g. `vim` + `:set guicursor=`), detach with `^]^]`, observe the cursor returns and the parent shell is on the main screen — not run (no interactive terminal in the dev sandbox); covered by the pty-backed pipe-capture tests above.

Closes #365