### PR TITLE
fix: never strand terminal state in-memory on metadata write failure

### DIFF
--- a/internal/terminal/terminalrunner/capture_metadata_cluster_test.go
+++ b/internal/terminal/terminalrunner/capture_metadata_cluster_test.go
@@ -229,6 +229,54 @@ func TestUpdateTerminalState_WriteFailure(t *testing.T) {
 	}
 }
 
+// updateTerminalState's write-first-then-commit ordering must not strand
+// Status.State at an intermediate value when the disk write fails: a
+// stranded PostAttach value would deadlock PostAttachShell's
+// `for State != Ready` spin on every subsequent attach until the runner
+// is recreated. See #373.
+func TestUpdateTerminalState_WriteFailure_DoesNotStrandInMemory(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory DAC, so a non-writable dir cannot deny the write")
+	}
+
+	runPath := t.TempDir()
+	id := api.ID("term-strand")
+	dir := filepath.Join(runPath, defaults.TerminalsRunPath, string(id))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir terminal dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	sr := newMetadataExec(t, runPath, "", id)
+	// Reach Ready while the dir is still writable.
+	if err := sr.updateTerminalState(api.Ready); err != nil {
+		t.Fatalf("updateTerminalState(Ready) preflight: %v", err)
+	}
+
+	// Now make the next write fail.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod terminal dir: %v", err)
+	}
+
+	if err := sr.updateTerminalState(api.PostAttach); err == nil {
+		t.Fatal("updateTerminalState(PostAttach): want write error on un-writable dir, got nil")
+	}
+	if doc, _ := sr.Metadata(); doc.Status.State != api.Ready {
+		t.Fatalf("in-memory state stranded at %v on write failure; want unchanged Ready", doc.Status.State)
+	}
+
+	// Restore writability — subsequent updates must still advance.
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("restore chmod: %v", err)
+	}
+	if err := sr.updateTerminalState(api.PostAttach); err != nil {
+		t.Fatalf("updateTerminalState(PostAttach) after restore: %v", err)
+	}
+	if doc, _ := sr.Metadata(); doc.Status.State != api.PostAttach {
+		t.Fatalf("state after successful retry = %v, want PostAttach", doc.Status.State)
+	}
+}
+
 // When create and close run under different uids the terminal dir is not
 // writable by the closing uid, so every close/cleanup hook's metadata write is
 // denied. The close path must surface this once, actionably, instead of

--- a/internal/terminal/terminalrunner/lifecycle.go
+++ b/internal/terminal/terminalrunner/lifecycle.go
@@ -527,9 +527,15 @@ func (sr *Exec) PostAttachShell() error {
 
 	sr.logger.Info("PostAttachShell: updating terminal state to post attach", "id", sr.id)
 
+	// Attach-time metadata writes are best-effort: metadata.json is an
+	// observability/reconnect artifact, not the source of truth for the
+	// live PTY, and aborting attach on a persistence failure (ENOSPC,
+	// perm-denied) leaves a healthy terminal unreachable. The error is
+	// already actionably logged by noteMetadataWriteErr; demote the
+	// return so the attach proceeds. updateTerminalState's write-first
+	// commit guarantees no strand on in-memory state. See #345, #373.
 	if err := sr.updateTerminalState(api.PostAttach); err != nil {
-		sr.logger.Error("failed to update terminal state on post attach", "id", sr.id, "err", err)
-		return fmt.Errorf("failed to update terminal state on post attach: %w", err)
+		sr.logger.Warn("PostAttachShell: state write failed, continuing", "id", sr.id, "err", err)
 	}
 
 	if err := sr.writeStage(&sr.metadata.Spec.Stages.PostAttach); err != nil {
@@ -537,8 +543,7 @@ func (sr *Exec) PostAttachShell() error {
 	}
 
 	if err := sr.updateTerminalState(api.Ready); err != nil {
-		sr.logger.Error("failed to update terminal state on ready", "id", sr.id, "err", err)
-		return fmt.Errorf("failed to update terminal state on ready: %w", err)
+		sr.logger.Warn("PostAttachShell: state write failed, continuing", "id", sr.id, "err", err)
 	}
 	return nil
 }

--- a/internal/terminal/terminalrunner/lifecycle_pty_cluster_test.go
+++ b/internal/terminal/terminalrunner/lifecycle_pty_cluster_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/eminwux/sbsh/internal/defaults"
 	"github.com/eminwux/sbsh/pkg/api"
 )
 
@@ -392,6 +393,61 @@ func TestPostAttachShellCtxCancelled(t *testing.T) {
 
 	if err := sr.PostAttachShell(); err == nil {
 		t.Fatal("expected PostAttachShell to return the context error")
+	}
+}
+
+// PostAttachShell must remain best-effort against transient metadata-write
+// failures: after a write fails mid-flow (e.g. ENOSPC on the embedder's
+// terminal dir), a subsequent attach with the failure cleared must still
+// reach Ready. Pre-fix, the in-memory state stranded at PostAttach made
+// `for State != Ready` spin until the client's context deadline on every
+// future attach. See #373.
+func TestPostAttachShell_RecoversAfterTransientWriteFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory DAC, so a non-writable dir cannot deny the write")
+	}
+
+	runPath := t.TempDir()
+	id := api.ID("term-postattach-recover")
+	dir := filepath.Join(runPath, defaults.TerminalsRunPath, string(id))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir terminal dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	sr := newBareExec(t)
+	sr.id = id
+	sr.metadata.Spec.ID = id
+	sr.metadata.Spec.RunPath = runPath
+	if err := sr.updateTerminalState(api.Ready); err != nil {
+		t.Fatalf("updateTerminalState(Ready) preflight: %v", err)
+	}
+
+	// Trigger the ENOSPC-equivalent: dir not writable.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod terminal dir: %v", err)
+	}
+
+	// Attach-time metadata writes are best-effort: PostAttachShell returns
+	// nil despite the inner write failures.
+	if err := sr.PostAttachShell(); err != nil {
+		t.Fatalf("PostAttachShell during write failure = %v, want nil (best-effort)", err)
+	}
+	// In-memory state must remain Ready — not stranded at PostAttach.
+	if doc, _ := sr.Metadata(); doc.Status.State != api.Ready {
+		t.Fatalf("State after failing PostAttachShell = %v, want unchanged Ready", doc.Status.State)
+	}
+
+	// Restore writability; a subsequent PostAttachShell must reach Ready
+	// (pre-fix it would spin forever because State was stuck at PostAttach).
+	if err := os.Chmod(dir, 0o700); err != nil {
+		t.Fatalf("restore chmod: %v", err)
+	}
+	if err := sr.PostAttachShell(); err != nil {
+		t.Fatalf("PostAttachShell after restore: %v", err)
+	}
+	if doc, _ := sr.Metadata(); doc.Status.State != api.Ready {
+		t.Fatalf("Final State = %v, want Ready", doc.Status.State)
 	}
 }
 

--- a/internal/terminal/terminalrunner/metadata.go
+++ b/internal/terminal/terminalrunner/metadata.go
@@ -158,15 +158,29 @@ func (sr *Exec) noteMetadataWriteErr(where string, err error) {
 	sr.logger.Warn("failed to update metadata on close", "id", sr.id, "where", where, "err", err)
 }
 
+// updateTerminalState advances the persisted Status.State by writing the new
+// state to disk first and committing it in-memory only on a successful
+// persist. The in-memory commit is gated on the write so a transient
+// persistence failure (ENOSPC, perm-denied — #345, #373) cannot strand
+// Status.State at an intermediate value (e.g. PostAttach) that no future
+// caller can advance past — `PostAttachShell`'s `for State != Ready` spin
+// would then deadlock every subsequent attach until the runner is
+// recreated. See #373.
 func (sr *Exec) updateTerminalState(status api.TerminalStatusMode) error {
-	sr.metadataMu.Lock()
-	sr.metadata.Status.State = status
-	sr.metadataMu.Unlock()
+	sr.metadataMu.RLock()
+	metadataCopy := sr.metadata
+	dir, _ := resolveMetadataDir(sr.metadata.Spec.RunPath, sr.metadata.Spec.MetadataDir, sr.id)
+	sr.metadataMu.RUnlock()
+	metadataCopy.Status.State = status
 
-	if err := sr.updateMetadata(); err != nil {
+	if err := shared.WriteMetadata(sr.ctx, metadataCopy, dir); err != nil {
 		sr.noteMetadataWriteErr("updateTerminalState", err)
 		return err
 	}
+
+	sr.metadataMu.Lock()
+	sr.metadata.Status.State = status
+	sr.metadataMu.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- `updateTerminalState` now writes to disk *first* and commits in-memory only on success, so a transient persistence failure (ENOSPC, perm-denied) can no longer leave `Status.State` stranded at an intermediate value. Pre-fix, a failed `PostAttach` write left in-memory `State = PostAttach` forever, and `PostAttachShell`'s `for State != Ready` spin then deadlocked every future attach until the runner was recreated.
- `PostAttachShell` demotes the `updateTerminalState` returns to log-and-continue: `metadata.json` is an observability/reconnect artifact, not the source of truth for the live PTY, and aborting attach on a persistence failure leaves a healthy terminal unreachable. Same shape as the close-time `noteMetadataWriteErr` log-and-continue pattern from #345.

Both fixes apply (the issue notes "ideally both"): fix #2 — the rollback / write-first ordering — is the foundational fix that hardens the state machine against any future caller; fix #1 keeps attach working through transient disk/perm failures.

## Test plan

- [x] `go test ./internal/terminal/terminalrunner/ -run 'TestUpdateTerminalState|TestPostAttachShell|TestShellStateUpdateError|TestUpdateMetadata_PermissionDeniedLoggedOnce|TestUpdateTerminalAttachers' -v -count=1` — including the two new tests:
  - `TestUpdateTerminalState_WriteFailure_DoesNotStrandInMemory` — drives a Ready→PostAttach write under a non-writable dir, asserts in-memory state stays Ready, then restores writability and confirms the next call advances.
  - `TestPostAttachShell_RecoversAfterTransientWriteFailure` — drives the issue's reproducer: `PostAttachShell` under a non-writable dir returns nil (best-effort), state stays Ready, restored dir, second `PostAttachShell` reaches Ready.
- [x] `make sbsh-sb` — canonical build (`sbsh` + `sb` hardlink).
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -count=1` — one unrelated pre-existing flake in `pkg/spawn` (`TestGracefulShutdown_SIGKILLEscalation`, `text file busy` on the trap.sh exec) — re-run passes; same test category as the recent flake-fix #371; not touched by this PR (pkg/spawn unchanged).

Closes #373