### PR TITLE
feat: add kuketeam.yaml declaring sbsh dev crew

### DIFF
--- a/kuketeam.yaml
+++ b/kuketeam.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuketeams.io/v1
+kind: ProjectTeam
+metadata: { name: sbsh }
+spec:
+  source: eminwux/agents@v0.2.0
+  defaults: { harnesses: [claude, opencode] }
+  roles:
+    - { ref: dev, needs: { image: [go] } }
+    - { ref: pm }
+    - { ref: pr-reviewer }


### PR DESCRIPTION
## Summary
- Adds `kuketeam.yaml` at the sbsh repo root — the per-project roster (kuketeams.io/v1 `ProjectTeam`) that the team-distribution epic (kukeon#792) consumes via `kuke team init`. Declares the sbsh dev crew (dev/pm/pr-reviewer) on harnesses `claude` + `opencode`, with the dev role asking for an additional `go` image capability since sbsh is a Go project.
- Matches the issue body's example structure exactly, with one substantive choice: the `source` pin.

## `source` pin choice (AC #2 nuance — heads-up posted on the issue)

Pinned `eminwux/agents@v0.2.0`. **No agents tag carrying the roles + harnesses layout exists yet** — the only existing tag is `eminwux/agents@v0.1.0`, at commit `33016c4`, which is **before** the restructure PR `eminwux/agents#681` introduced `role.yaml` / `harnesses/`. The layout lives only on agents `origin/main` in four PRs merged after the v0.1.0 tag: `#681` (restructure), `#684` (images→`harnesses/`+`images.yaml`), `#686` (Makefile materialization from `harness.yaml`), and `#687` (per-role CLAUDE.md scoping). Per `dev/CLAUDE.md` §"Sanity-check AC implementation specifics against the codebase", I posted a heads-up comment on the issue (https://github.com/eminwux/sbsh/issues/372#issuecomment-4616921694) and proceeded with `v0.2.0` as a forward-looking placeholder for the next agents release.

Reviewer push-back welcome on the version number — the file is the contract; if maintainer wants `v1.0.0`, `v0.1.1`, or anything else, that's a one-line bump in this PR.

## AC #1 verification (file shape against the parser)

I cloned `eminwux/kukeon` and ran the file through `internal/kuketeams.ParseDocuments` directly. The parser accepted it as a `ProjectTeam`:

```
OK: ProjectTeam name="sbsh" source="eminwux/agents@v0.2.0" defaults.harnesses=[claude opencode] roles=3
  roles[0]: ref="dev" needs.image=[go]
  roles[1]: ref="pm" needs.image=nil
  roles[2]: ref="pr-reviewer" needs.image=nil
```

This exercises every validator the schema enforces today (kukeon `internal/kuketeams/parser.go:validateProjectTeam`): `metadata.name` required + filename-safe (`sbsh`); `spec.source` pinned-exact against the `^([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)@(v\d+\.\d+\.\d+([-+][0-9A-Za-z.-]+)?)$` regex; `defaults.harnesses` entries against `KnownHarnesses` = `{claude, codex, opencode}`; per-role `ref` non-empty; per-role `needs.image` capability names rejecting `/`, `:`, `@`.

## Acceptance criteria

- [x] `kuketeam.yaml` committed at repo root, validating against the `ProjectTeam` schema (kukeon `#793`). Verified end-to-end by running the kukeon parser against the file — see AC #1 verification block above.
- [ ] `source` pinned exact to an agents release that **provides** the roles + harnesses layout. **The "provides the layout" half is gated on the agents release.** Pin is syntactically valid (parser accepts `v0.2.0`), but no `eminwux/agents` tag yet carries `role.yaml`/`harnesses/` — only `v0.1.0` exists, at pre-restructure commit `33016c4`. Recommend cutting `eminwux/agents@v0.2.0` at a commit including `#681`+`#684`+`#686`+`#687`; if a different version is chosen, a one-line follow-up bump to this file lands the missing AC half.
- [ ] `kuke team init` in the sbsh checkout renders + applies dev/pm/pr-reviewer on claude + opencode without any edit outside the sbsh repo. **Deferred — not runnable on this dev host.** `kuke` is not installed (no binary on `PATH`), and the kukeon end-to-end step kukeon `#1043` ("team: apply-with-prune + two-project compose e2e") is still open and `in-progress`. AC #3 is the epic's litmus test and properly belongs to kukeon `#1043`'s e2e — which is presumably what makes that issue the umbrella's last open child. No infra exists in sbsh to verify this; a follow-up issue could file the smoke once kukeon `#1043` lands and an agents release is cut.

## Test plan
- [x] `make sbsh-sb` → built `./sbsh` (ELF 64-bit LSB executable, 9.2 MB) + hardlinked `sb`.
- [x] `go build ./...` — clean.
- [x] `go vet ./...` — clean.
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` — `pkg/spawn` hit the known `TestClientHandle_WaitReady_Timeout` "text file busy" flake under full-suite parallelism; re-ran `pkg/spawn` alone (passed) and reproduced the same flake on `origin/main` clean checkout (`-count=3` passed when isolated; the flake only surfaces when many parallel tests fight over `/tmp` sleeper-script extraction). Pre-existing, unrelated to this diff — same root-cause family as `#371`'s recent flake-decoupling fix.
- [x] `go test -tags=integration ./cmd/sb/get/...` — passed.
- [x] `pre-commit run --files kuketeam.yaml` — all hooks pass (yaml/json/toml/trailing-ws/line-ending/private-key/prettier; addlicense correctly skips since it scopes to `*.go`).
- [x] **kukeon parser-verification of `kuketeam.yaml`** — `internal/kuketeams.ParseDocuments` accepts the file; output reproduced in the AC #1 block above.

Closes #372