### PR TITLE
test: write pkg/spawn sleeper once in TestMain to de-flake ETXTBSY

### DIFF
--- a/pkg/spawn/lifecycle_test.go
+++ b/pkg/spawn/lifecycle_test.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -35,17 +36,36 @@ import (
 	"github.com/eminwux/sbsh/pkg/api"
 )
 
-// sleeperBinary writes an executable shell script that sleeps regardless of
-// the argv the handle constructs (NewClient/NewTerminal append their own
-// attach/terminal args, so a real /bin/sleep would reject them and exit). It
-// stands in for a long-lived sb child whose control socket never appears.
+// sharedSleeperPath is the package-shared path to a sleeper.sh script that
+// sleeps regardless of the argv the handle constructs (NewClient/NewTerminal
+// append their own attach/terminal args, so a real /bin/sleep would reject
+// them and exit). Written once in TestMain before any test runs; see #376 —
+// per-test os.WriteFile of an executable then fork+exec from sibling parallel
+// goroutines races on the kernel's writer-FD check and surfaces as ETXTBSY.
+var sharedSleeperPath string
+
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "spawn-test-sleeper-")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "spawn tests: create sleeper tempdir: %v\n", err)
+		os.Exit(1)
+	}
+	sharedSleeperPath = filepath.Join(dir, "sleeper.sh")
+	if err := os.WriteFile(sharedSleeperPath, []byte("#!/bin/sh\nexec sleep 30\n"), 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "spawn tests: write sleeper: %v\n", err)
+		_ = os.RemoveAll(dir)
+		os.Exit(1)
+	}
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}
+
+// sleeperBinary returns the package-shared sleeper.sh path written once in
+// TestMain. See sharedSleeperPath's docstring for the rationale.
 func sleeperBinary(t *testing.T) string {
 	t.Helper()
-	path := filepath.Join(t.TempDir(), "sleeper.sh")
-	if err := os.WriteFile(path, []byte("#!/bin/sh\nexec sleep 30\n"), 0o755); err != nil {
-		t.Fatalf("write sleeper: %v", err)
-	}
-	return path
+	return sharedSleeperPath
 }
 
 // TestClientHandle_Close_NoSocketEscalates spawns a long-lived child whose


### PR DESCRIPTION
## Summary

- The issue lists three fix options. I'm picking **option 2** (write once in `TestMain`) rather than the "simplest" option 1 (`/bin/sh -c`). Reason: `buildClientAttachArgs` unconditionally prepends `--run-path <X>` before `ExtraArgs`, so the `/bin/sh -c "exec sleep 30" sh` shape only works if every caller also clears `RunPath` on the doc — option 2 keeps the fix entirely inside the test helper and the test setup. Happy to swap to option 1 if you prefer.
- `TestMain` writes `sleeper.sh` once to a package-shared temp path before any test runs (no `t.Parallel()` window during the write); all five callers of `sleeperBinary(t)` now read that path with no per-test `os.WriteFile`. Eliminates the sibling-goroutine writer-FD overlap that the issue diagnoses as the ETXTBSY trigger.
- `sleeperBinary(t)`'s signature is preserved — the helper just returns the shared path — so the five call sites are unchanged.
- Option 3 (retry-on-ETXTBSY) was deliberately not picked, per the issue's own "masks the race rather than removing it" note.

## Out of scope

- `TestGracefulShutdown_SIGKILLEscalation` (`pkg/spawn/lifecycle_test.go:248`) has the same write-then-exec pattern with its own `trap.sh`. The issue does not name it as flaking — it writes once (vs. five `sleeperBinary` callers), so the collision window is much smaller — and I deliberately left it alone to keep the PR scoped to the named tests per `dev/CLAUDE.md`'s no-unrelated-cleanups rule. If it surfaces in CI later, the same TestMain-write-once pattern applies.

## Test plan

- [x] `make sbsh-sb` produces an ELF (`od -c`: `\177 E L F`)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/spawn/...` (clean)
- [x] `go test -count=20 -run 'TestClientHandle_WaitReady_Timeout|TestClientHandle_Close_NoSocketEscalates|TestTerminalHandle_WaitReady_Timeout|TestTerminalHandle_Close_NoSocketEscalates|TestClientHandle_WaitClose_ContextCanceled' ./pkg/spawn/...` (20 iterations, all green)
- [x] The issue's exact CI-shape repro: `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` run **three times back-to-back** with `-count=3` on the third run — no `FAIL`, no `text file busy` across all runs

Closes #376