### PR TITLE
feat: adopt object source format in kuketeam.yaml

### DIFF
--- a/kuketeam.yaml
+++ b/kuketeam.yaml
@@ -2,7 +2,9 @@ apiVersion: kuketeams.io/v1
 kind: ProjectTeam
 metadata: { name: sbsh }
 spec:
-  source: eminwux/agents@v0.2.0
+  source:
+    repo: github.com/eminwux/agents
+    branch: main
   defaults: { harnesses: [claude, opencode] }
   roles:
     - { ref: dev, needs: { image: [go] } }


### PR DESCRIPTION
## Summary

- `kuketeam.yaml`'s `spec.source` switches from the string form `eminwux/agents@v0.2.0` (which named a non-existent tag — agents' only tag `v0.1.0` predates the `harnesses/`+`images.yaml` layout that lives only on `main`) to the structured object form `{repo: github.com/eminwux/agents, branch: main}`, so sbsh tracks the agents `main` where the harnesses live without requiring a release tag.
- The rest of the roster (roles `dev`/`pm`/`pr-reviewer`, harnesses `claude`/`opencode`) is unchanged.

## Schema verification

The new object form was validated byte-for-byte against kukeon's authoritative `TeamSource` parser — `pkg/api/model/kuketeams/source.go:36-45` on kukeon `origin/main` (commit `e7dad34`, PR eminwux/kukeon#1069). Fields `repo`/`branch` match exactly, and the docstring's own example is `github.com/eminwux/agents`. Exactly one of `tag`/`branch`/`commit` must be set; `branch: main` is the documented floating-ref form (refetched every init), chosen per the issue because no agents tag carries the harness layout yet.

Dependency eminwux/kukeon#1066 (object-`source` support) is **CLOSED/merged** (PR #1069, 2026-06-05), so the format now parses.

## Test plan

- [x] YAML parses (`python3 -c "yaml.safe_load(...)"` → `source = {'repo': 'github.com/eminwux/agents', 'branch': 'main'}`)
- [x] Object form matches kukeon's `TeamSource` schema (`repo`/`branch`), verified against `pkg/api/model/kuketeams/source.go:36-45` on kukeon main
- [x] Old `eminwux/agents@` literal removed — tree-wide `git grep` shows no remaining references (only unrelated `github.com/kr/text v0.2.0` in `go.sum`)
- [x] `make sbsh-sb` builds a clean ELF executable; `go build ./...` and `go vet ./...` pass (change is YAML-only and touches no Go, so the Go test suite is unaffected)
- [ ] `kuke team init` resolves the source and renders the roster — **not runnable on the dev host**: the installed `kuke` binary (commit `03bed0d`, PR eminwux/kukeon#978) predates the object-source commit `e7dad34`, and the kukeond socket is permission-denied (`/run/kukeon/kukeond.sock`). Recommend the reviewer (or a follow-up) re-run this against a `kuke` build that includes #1069. The format itself is schema-verified above.

Closes #378