### PR TITLE
fix: swallow clean session-end sentinels in sbsh runClient

### DIFF
--- a/cmd/sbsh/sbsh.go
+++ b/cmd/sbsh/sbsh.go
@@ -524,7 +524,7 @@ func runClient(
 
 	case err := <-errCh:
 		logger.DebugContext(ctx, "controller stopped", "error", err)
-		if err != nil && !errors.Is(err, context.Canceled) {
+		if err != nil && !isCleanSessionEnd(err) {
 			err = fmt.Errorf("%w: %w", errdefs.ErrChildExit, err)
 			if errC := ctrl.WaitClose(); errC != nil {
 				err = fmt.Errorf("%w: %w: %w", err, errdefs.ErrWaitOnClose, errC)
@@ -534,6 +534,21 @@ func runClient(
 		}
 	}
 	return nil
+}
+
+// isCleanSessionEnd reports whether err signals an end-of-session that
+// runClient must swallow rather than surface to cobra as `Error: …`:
+// context cancellation, an operator-initiated detach (errdefs.ErrClientDetached
+// — chained on the close cause by Controller.classifySessionEnd when
+// detachRequested is set), or the remote workload closing the IO
+// connection on a clean exit (errdefs.ErrPeerClosed). Mirrors pkg/attach.Run's
+// classifySessionEnd remap and cmd/sb/attach's nil-return on those
+// public sentinels; sbsh consumes the controller directly so the swallow
+// has to live here. See issue #380.
+func isCleanSessionEnd(err error) bool {
+	return errors.Is(err, context.Canceled) ||
+		errors.Is(err, errdefs.ErrClientDetached) ||
+		errors.Is(err, errdefs.ErrPeerClosed)
 }
 
 // readRootSocketGID resolves --terminal-socket-gid: explicit flag wins,

--- a/cmd/sbsh/sbsh_test.go
+++ b/cmd/sbsh/sbsh_test.go
@@ -19,6 +19,7 @@ package sbsh
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -437,6 +438,123 @@ func TestRunTerminal_SuccessWithNilError(t *testing.T) {
 	case err := <-done:
 		if err != nil {
 			t.Fatalf("expected nil error; got: '%v'", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for runClient to return")
+	}
+}
+
+// TestRunTerminal_CleanDetach asserts runClient swallows the error chain
+// Controller.Run produces on operator-initiated detach (ErrCloseReq wrapping
+// ErrClientDetached wrapping the dual-copier exit cause) — without this,
+// cobra prints "Error: child routine exited: close requested: client detached: …"
+// to stderr immediately after the yellow "Detached" line. See issue #380.
+func TestRunTerminal_CleanDetach(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	runErr := fmt.Errorf("%w: %w: %w",
+		errdefs.ErrCloseReq,
+		errdefs.ErrClientDetached,
+		errors.New("read/write routines exited"),
+	)
+	newClientController := func(_ context.Context) api.ClientController {
+		return &client.ControllerTest{
+			RunFunc:       func(_ *api.ClientDoc) error { return runErr },
+			WaitReadyFunc: func() error { return nil },
+			WaitCloseFunc: func() error { return nil },
+			StartFunc:     func() error { return nil },
+		}
+	}
+
+	ctrl := newClientController(context.Background())
+	t.Cleanup(func() {})
+
+	doc := &api.ClientDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindClient,
+		Metadata: api.ClientMetadata{
+			Name:        naming.RandomName(),
+			Labels:      make(map[string]string),
+			Annotations: make(map[string]string),
+		},
+		Spec: api.ClientSpec{
+			ID:           api.ID(naming.RandomID()),
+			LogFile:      "/tmp/sbsh-logs/s0",
+			RunPath:      viper.GetString(config.SBSH_ROOT_RUN_PATH.ViperKey),
+			TerminalSpec: nil,
+		},
+	}
+
+	done := make(chan error)
+	defer close(done)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		done <- runClient(ctx, cancel, logger, ctrl, doc)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected nil on clean detach; got: '%v'", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for runClient to return")
+	}
+}
+
+// TestRunTerminal_CleanPeerClosed asserts runClient swallows the chain
+// Controller.Run produces on a clean remote-side workload exit (ErrCloseReq
+// wrapping ErrPeerClosed) — symmetric to the detach path, so a normal
+// `exit 0` from the shell does not print "Error: …" either. See issue #380.
+func TestRunTerminal_CleanPeerClosed(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	runErr := fmt.Errorf("%w: %w: %w",
+		errdefs.ErrCloseReq,
+		errdefs.ErrPeerClosed,
+		errors.New("read/write routines exited"),
+	)
+	newClientController := func(_ context.Context) api.ClientController {
+		return &client.ControllerTest{
+			RunFunc:       func(_ *api.ClientDoc) error { return runErr },
+			WaitReadyFunc: func() error { return nil },
+			WaitCloseFunc: func() error { return nil },
+			StartFunc:     func() error { return nil },
+		}
+	}
+
+	ctrl := newClientController(context.Background())
+	t.Cleanup(func() {})
+
+	doc := &api.ClientDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindClient,
+		Metadata: api.ClientMetadata{
+			Name:        naming.RandomName(),
+			Labels:      make(map[string]string),
+			Annotations: make(map[string]string),
+		},
+		Spec: api.ClientSpec{
+			ID:           api.ID(naming.RandomID()),
+			LogFile:      "/tmp/sbsh-logs/s0",
+			RunPath:      viper.GetString(config.SBSH_ROOT_RUN_PATH.ViperKey),
+			TerminalSpec: nil,
+		},
+	}
+
+	done := make(chan error)
+	defer close(done)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		done <- runClient(ctx, cancel, logger, ctrl, doc)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected nil on clean peer-close; got: '%v'", err)
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for runClient to return")


### PR DESCRIPTION
## Summary

- `cmd/sbsh/sbsh.go:runClient` now treats `errdefs.ErrClientDetached` and `errdefs.ErrPeerClosed` as clean session-end sentinels alongside `context.Canceled`. Without this, the controller's `ErrCloseReq: ErrClientDetached: read/write routines exited` chain reaches cobra and prints `Error: child routine exited: …` immediately after the yellow `Detached` line on a successful operator detach (`Ctrl+]` `Ctrl+]`). Mirrors the swallow-on-clean-exit behavior `pkg/attach.Run` already provides via `classifySessionEnd` → `attach.ErrDetached` / `attach.ErrPeerClosed` and `cmd/sb/attach/attach.go:222` consumes; `sbsh` consumes the controller directly so the swallow has to live in `runClient`.
- Genuine failures (`ErrRPCServerExited`, `ErrStartTerminal`, `ErrWaitOnReady`, `ErrChildExit`-wrapped runtime errors, …) still surface as cobra `Error: …` — the existing `TestRunTerminal_ErrChildExit`/`ErrChildExitWithWaitCloseError`/`ErrWaitOnReady` tests keep covering that arm.

### `ErrPeerClosed` inclusion

The issue's "Suggested fix" calls out `ErrPeerClosed` as a "separate observation worth verifying as part of the fix" — the controller produces the same chain on a clean `exit 0` from the shell (`Controller.classifySessionEnd` wraps with `ErrPeerClosed` when `detachRequested` is unset). I verified that path by reading `internal/client/controller.go:467-476` and included it as a lower-blast-radius default: this matches the symmetric behavior `cmd/sb/attach` and `pkg/attach.Run` already provide, and AC item 4's "RPC server crash, terminal start failure, etc." enumeration does not include either sentinel. Reviewer can push back if narrower scope (only `ErrClientDetached`) is preferred — drop the `ErrPeerClosed` clause from `isCleanSessionEnd` and the corresponding test.

## Test plan

- [x] `make sbsh-sb` — canonical build produces ELF binary + hardlink (verified via ELF magic).
- [x] `go build ./...` — clean.
- [x] `go vet ./...` — clean.
- [x] `make test` — full CI test suite (`cmd/sb...`, `cmd/sbsh...`, `internal/terminal...`, `internal/client...`, integration-tagged `cmd/sb/get/...`, `e2e`) passes locally with `EXIT=0`.
- [x] `go test -run 'TestRunTerminal_CleanDetach|TestRunTerminal_CleanPeerClosed' -v ./cmd/sbsh` — new regression tests pass.
- [x] `pre-commit run --files cmd/sbsh/sbsh.go cmd/sbsh/sbsh_test.go` — clean (go-fmt, golangci-lint, addlicense, etc.).
- [ ] Live `./sbsh` → `Ctrl+]` `Ctrl+]` interactive smoke — dev host has no interactive TTY; the unit tests construct the exact error chain `Controller.Run` produces on operator detach (`ErrCloseReq` wrapping `ErrClientDetached` wrapping `read/write routines exited`) and assert `runClient` returns nil.

## Acceptance criteria

- [ ] `sbsh` → `Ctrl+]` `Ctrl+]` exits cleanly: only the yellow `Detached` line, no trailing `Error: child routine exited: …`, exit code 0. — *Verified via the regression test that drives the documented error chain through `runClient`; the live TTY-interactive smoke is left unticked because the dev host has no interactive TTY (see "Test plan" above).*
- [x] `errdefs.ErrClientDetached` (and the chained `ErrCloseReq` wrapper from `Controller.Run`) is treated as a clean exit by `cmd/sbsh/sbsh.go:runClient` — implemented via `isCleanSessionEnd` in `cmd/sbsh/sbsh.go`.
- [x] Regression test in `cmd/sbsh/` covers `runClient` returning nil when the controller returns an error chain that wraps `errdefs.ErrClientDetached` — `TestRunTerminal_CleanDetach` in `cmd/sbsh/sbsh_test.go` (and symmetric `TestRunTerminal_CleanPeerClosed`).
- [x] No regression in genuine failure surfacing — RPC server crash, terminal start failure, etc. still surface as cobra `Error: …`. `isCleanSessionEnd` only matches `context.Canceled`, `ErrClientDetached`, `ErrPeerClosed`; the pre-existing `TestRunTerminal_ErrChildExit`, `TestRunTerminal_ErrChildExitWithWaitCloseError`, and `TestRunTerminal_ErrWaitOnReady` tests still pass and continue to enforce the failure-surfacing path.

Closes #380