### PR TITLE
fix: restore mouse-tracking and bracketed-paste modes on client teardown

### DIFF
--- a/internal/client/clientrunner/restore_linux_test.go
+++ b/internal/client/clientrunner/restore_linux_test.go
@@ -173,7 +173,11 @@ func assertNormalizeEmitted(t *testing.T, r *os.File) {
 		t.Fatalf("ReadAll: %v", err)
 	}
 	out := string(buf)
-	for _, want := range []string{"\x1b[?1049l", "\x1b[?25h", "\x1b[0 q"} {
+	for _, want := range []string{
+		"\x1b[?1049l", "\x1b[?25h", "\x1b[0 q",
+		"\x1b[?1000l", "\x1b[?1002l", "\x1b[?1003l",
+		"\x1b[?1006l", "\x1b[?1015l", "\x1b[?2004l",
+	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("missing normalization escape %q in stdout %q", want, out)
 		}

--- a/internal/client/clientrunner/terminal.go
+++ b/internal/client/clientrunner/terminal.go
@@ -73,15 +73,23 @@ const copierWaitTimeout = 500 * time.Millisecond
 
 // escRestoreParentTerm normalizes the parent terminal's output-side DEC private
 // mode state on session teardown: leave the alternate-screen buffer, show the
-// cursor, and reset the cursor style to the terminal default. Symmetric with
-// the modes the server-side attach repaint may set (escEnterAltScreen /
+// cursor, reset the cursor style to the terminal default, disable mouse
+// tracking under every common encoding, and disable bracketed paste. Symmetric
+// with the modes the server-side attach repaint may set (escEnterAltScreen /
 // escHideCursor in internal/terminal/terminalrunner/terminal_screen.go) and
 // with anything a TUI/shell on the remote side wrote through to the parent
 // terminal without a matching reset. Emitted unconditionally per #365 — the
-// client cannot rely on the remote side emitting a matching reset on its own.
+// client cannot rely on the remote side emitting a matching reset on its own;
+// resetting a mode that wasn't set is a no-op on every terminal.
 const escRestoreParentTerm = "\x1b[?1049l" + // leave the alternate screen buffer
 	"\x1b[?25h" + // make the cursor visible
-	"\x1b[0 q" // reset cursor style (DECSCUSR) to terminal default
+	"\x1b[0 q" + // reset cursor style (DECSCUSR) to terminal default
+	"\x1b[?1000l" + // disable X11 mouse reporting (basic)
+	"\x1b[?1002l" + // disable cell-motion mouse tracking
+	"\x1b[?1003l" + // disable all-motion mouse tracking
+	"\x1b[?1006l" + // disable SGR mouse encoding
+	"\x1b[?1015l" + // disable urxvt mouse encoding
+	"\x1b[?2004l" // disable bracketed paste
 
 // restoreParentTerminal performs a single, idempotent "unblock stdin + restore
 // tty" at the session boundary so the parent shell is always handed back a


### PR DESCRIPTION
## Summary

- Extends `escRestoreParentTerm` in `internal/client/clientrunner/terminal.go` to also disable mouse tracking (basic/cell-motion/all-motion/SGR/urxvt) and bracketed paste on every teardown path, alongside the alt-screen / cursor-visible / cursor-style resets already emitted per #365.
- Resetting an unset DEC private mode is a no-op on every terminal, so the additions are safe to send unconditionally — no plumbing changes, same single-point write at `terminal.go:142` covers detach / process exit / peer hangup / ctx-cancel.
- Updates the `assertNormalizeEmitted` substring list in `restore_linux_test.go` so both `TestRestore_EmitsOutputNormalize_OnProcessExit` and `TestRestore_EmitsOutputNormalize_OnDetach` regress on the new escapes.

## Test plan

- [x] `make sbsh-sb` — canonical build produces ELF `sbsh` + `sb` hardlink.
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` — full project test target (unit + integration + e2e) passes; the new substrings are asserted in `internal/client/clientrunner`'s `TestRestore_EmitsOutputNormalize_OnProcessExit` and `TestRestore_EmitsOutputNormalize_OnDetach`.
- [ ] Manual on-device verification of the AC's behavioural smoke (parent shell no longer emits mouse-report CSI on click after detach; pastes are not wrapped in `\x1b[200~`…`\x1b[201~`) — deferred to reviewer's environment. The dev-host sandbox runs the e2e suite that asserts the bytes are *emitted by the client*, but it has no interactive terminal to confirm the parent emulator stops reporting after the bytes land.

## Acceptance criteria

- [x] After detach from a remote that enabled mouse tracking, the client emits `?1000l` / `?1002l` / `?1003l` / `?1006l` / `?1015l` on teardown — asserted by `TestRestore_EmitsOutputNormalize_OnDetach`. Behavioural confirmation that the parent emulator exits mouse-reporting mode is the on-device smoke deferred above.
- [x] After remote process exit the same sequence is emitted on the process-exit path — asserted by `TestRestore_EmitsOutputNormalize_OnProcessExit`.
- [x] After detach from a remote that enabled bracketed paste, the client emits `?2004l` on teardown — asserted by both teardown-path tests.
- [x] All teardown paths covered (detach keystroke, remote process exit, peer hangup, ctx-cancel) — the single-point write at `terminal.go:142` is downstream of `restoreOnce.Do`, which #365 already wired into every teardown path; both regression tests exercise the two distinct entry points, the peer-hangup / ctx-cancel paths re-use the same `restoreParentTerminal` body.
- [x] Restoration is unconditional — `escRestoreParentTerm` is a single literal written on every teardown, independent of any remote-side reset.

Closes #382