### PR TITLE
fix: restore parent terminal on Detach RPC failure and drain before banner

### DIFF
--- a/internal/client/clientrunner/lifecycle.go
+++ b/internal/client/clientrunner/lifecycle.go
@@ -189,7 +189,7 @@ func (sr *Exec) Close(_ error) error {
 		}
 	}
 
-	sr.restoreParentTerminal()
+	sr.restoreParentTerminal("")
 	sr.logger.Debug("Close: cleanup complete")
 
 	sr.metadataMu.Lock()
@@ -211,20 +211,26 @@ func (sr *Exec) Resize(_ api.ResizeArgs) {
 }
 
 func (sr *Exec) Detach() error {
+	// The user has committed to leaving by pressing ^]^]; the local parent-terminal
+	// restore is non-negotiable once we are here. Restore on every exit path —
+	// including a failed Detach RPC (broken control socket, server crash mid-RPC,
+	// RPC timeout) — rather than relying on Close() being driven later via the
+	// conn-close EvError, which is not guaranteed to fire on the same tick. See
+	// issues #364 and #383.
 	if err := sr.terminalClient.Detach(sr.ctx, &sr.id); err != nil {
+		sr.logger.Warn("Detach RPC failed; restoring parent terminal anyway", "client_id", sr.id, "error", err)
+		// Suppress the "Detached" banner — it would be misleading when the RPC
+		// failed — but the restore still runs. See #383.
+		sr.restoreParentTerminal("")
 		return err
 	}
 
 	sr.logger.Info("Client detached", "client_id", sr.id)
-	// Write the confirmation while still in raw mode (explicit \r\n), then
-	// restore the parent terminal unconditionally — the detach path must not
-	// rely on Close() being driven later via the conn-close EvError. See #364.
-	_, werr := sr.stdout.WriteString("\x1b[93m\r\nDetached\x1b[0m\r\n")
-	sr.restoreParentTerminal()
-	if werr != nil {
-		sr.logger.Warn("Failed to write detach message to stdout", "error", werr)
-		return werr
-	}
+	// Hand the confirmation banner to restoreParentTerminal as a post-drain
+	// message so it is written after the inbound copier has drained (no
+	// interleave with mid-flush remote bytes) but while raw mode is still active
+	// so the embedded \r\n behaves. See issues #364 and #383.
+	sr.restoreParentTerminal("\x1b[93m\r\nDetached\x1b[0m\r\n")
 
 	return nil
 }

--- a/internal/client/clientrunner/lifecycle_test.go
+++ b/internal/client/clientrunner/lifecycle_test.go
@@ -196,7 +196,10 @@ func TestDetach_RPCError(t *testing.T) {
 }
 
 // TestDetach_StdoutWriteError covers the branch where the detach succeeds at
-// the RPC layer but writing the confirmation to stdout fails.
+// the RPC layer but writing the confirmation banner to stdout fails. As of #383
+// the banner is a best-effort post-drain message inside restoreParentTerminal,
+// not Detach's return value — the parent-terminal restore is non-negotiable and
+// a failed banner write must not turn a successful detach into an error.
 func TestDetach_StdoutWriteError(t *testing.T) {
 	sr, _ := newLifecycleExec(t)
 	r, w, err := os.Pipe()
@@ -204,12 +207,12 @@ func TestDetach_StdoutWriteError(t *testing.T) {
 		t.Fatalf("pipe: %v", err)
 	}
 	_ = r.Close()
-	_ = w.Close() // closed write end -> WriteString fails
+	_ = w.Close() // closed write end -> banner WriteString fails (best-effort, logged)
 	sr.stdout = w
 	sr.terminalClient = &mockTerminalClient{} // detach succeeds by default
 
-	if errDetach := sr.Detach(); errDetach == nil {
-		t.Fatal("Detach returned nil error when stdout write failed")
+	if errDetach := sr.Detach(); errDetach != nil {
+		t.Fatalf("Detach returned %v on banner-write failure; want nil (RPC succeeded, banner is best-effort)", errDetach)
 	}
 }
 

--- a/internal/client/clientrunner/restore_linux_test.go
+++ b/internal/client/clientrunner/restore_linux_test.go
@@ -18,6 +18,7 @@ package clientrunner
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -29,6 +30,10 @@ import (
 	"github.com/eminwux/sbsh/pkg/api"
 	"golang.org/x/sys/unix"
 )
+
+// errMockDetach is the sentinel a Detach-RPC-failure mock returns so a test can
+// assert Exec.Detach propagates it while still restoring the parent terminal.
+var errMockDetach = errors.New("detach rpc failed")
 
 // ttyState reports the descriptor's blocking flag and the ECHO/ICANON termios
 // line-discipline flags. It reads them through SyscallConn().Control so the
@@ -226,6 +231,90 @@ func TestRestore_EmitsOutputNormalize_OnDetach(t *testing.T) {
 	}
 	_ = w.Close()
 	assertNormalizeEmitted(t, r)
+}
+
+// TestRestore_OnDetach_RPCFailure asserts that when the Detach control-socket
+// RPC fails, Exec.Detach still restores the parent terminal (cooked line
+// discipline + blocking descriptor) and still emits the output normalization
+// sequence, rather than returning early and stranding the terminal in raw mode.
+// The user has committed to leaving via ^]^]; a server-side RPC failure is not a
+// reason to keep the parent terminal broken. The "Detached" banner is suppressed
+// on this path because it would be misleading. Regression for #383 Gap 1.
+func TestRestore_OnDetach_RPCFailure(t *testing.T) {
+	sr, tty := newAttachedExec(t)
+	sr.terminalClient = &mockTerminalClient{
+		detachFunc: func(_ context.Context, _ *api.ID) error { return errMockDetach },
+	}
+
+	r, w, errPipe := os.Pipe()
+	if errPipe != nil {
+		t.Fatalf("Pipe: %v", errPipe)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+	sr.stdout = w
+
+	err := sr.Detach()
+	if !errors.Is(err, errMockDetach) {
+		t.Fatalf("Detach: want errMockDetach, got %v", err)
+	}
+	_ = w.Close()
+
+	// Termios cooked + blocking descriptor restored despite the RPC failure.
+	assertRestored(t, tty)
+
+	buf, errRead := io.ReadAll(r)
+	if errRead != nil {
+		t.Fatalf("ReadAll: %v", errRead)
+	}
+	out := string(buf)
+	for _, want := range []string{"\x1b[?1049l", "\x1b[?25h", "\x1b[0 q"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing normalization escape %q in stdout %q on RPC-failure path", want, out)
+		}
+	}
+	if strings.Contains(out, "Detached") {
+		t.Errorf("Detached banner should be suppressed on RPC-failure path, got %q", out)
+	}
+}
+
+// TestDetach_BannerWrittenBeforeNormalize asserts that on the successful detach
+// path the "Detached" banner is emitted from within restoreParentTerminal — at
+// the post-drain, pre-termios-restore point — and precedes the output
+// normalization sequence. This is the same relative order as before #383, but
+// now downstream of the copier drain so the banner cannot interleave with
+// mid-flush remote bytes. Regression for #383 Gap 2.
+func TestDetach_BannerWrittenBeforeNormalize(t *testing.T) {
+	sr, _ := newAttachedExec(t)
+	sr.terminalClient = &mockTerminalClient{}
+
+	r, w, errPipe := os.Pipe()
+	if errPipe != nil {
+		t.Fatalf("Pipe: %v", errPipe)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+	sr.stdout = w
+
+	if err := sr.Detach(); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+	_ = w.Close()
+
+	buf, errRead := io.ReadAll(r)
+	if errRead != nil {
+		t.Fatalf("ReadAll: %v", errRead)
+	}
+	out := string(buf)
+	bannerIdx := strings.Index(out, "Detached")
+	normIdx := strings.Index(out, "\x1b[?1049l")
+	if bannerIdx < 0 {
+		t.Errorf("Detached banner missing on successful detach in stdout %q", out)
+	}
+	if normIdx < 0 {
+		t.Errorf("normalization sequence missing on successful detach in stdout %q", out)
+	}
+	if bannerIdx >= 0 && normIdx >= 0 && bannerIdx > normIdx {
+		t.Errorf("banner should precede normalize sequence; banner@%d normalize@%d in %q", bannerIdx, normIdx, out)
+	}
 }
 
 // TestRestore_Idempotent asserts the restore runs exactly once even when both

--- a/internal/client/clientrunner/terminal.go
+++ b/internal/client/clientrunner/terminal.go
@@ -88,7 +88,14 @@ const escRestoreParentTerm = "\x1b[?1049l" + // leave the alternate screen buffe
 // usable terminal — on user detach, remote process exit, peer hangup, and
 // ctx cancellation alike. It is safe to call from every teardown path; the
 // sync.Once guarantees the body runs exactly once. See issue #364.
-func (sr *Exec) restoreParentTerminal() {
+//
+// postDrainMsg, when non-empty, is written to stdout after the inbound
+// socket->stdout copier has drained but before the termios raw->cooked restore
+// — the safe point at which a teardown-confirmation banner (e.g. the detach
+// "Detached" notice) cannot interleave with mid-flush remote bytes yet raw mode
+// is still active so its embedded \r\n behaves correctly. The Close()/exit
+// paths pass "". See issues #364 and #383.
+func (sr *Exec) restoreParentTerminal(postDrainMsg string) {
 	sr.restoreOnce.Do(func() {
 		sr.logger.Debug("restoreParentTerminal: beginning terminal restore")
 
@@ -128,6 +135,18 @@ func (sr *Exec) restoreParentTerminal() {
 			case <-done:
 			case <-time.After(copierWaitTimeout):
 				sr.logger.Debug("restoreParentTerminal: copier wait timed out; proceeding with restore")
+			}
+		}
+
+		// Write any teardown-confirmation banner now: the inbound copier has
+		// drained (so this cannot interleave with mid-flush remote bytes) and the
+		// termios restore below has not yet run (so raw mode is still active and
+		// the banner's embedded \r\n behaves). Emitted before the normalize
+		// sequence so it lands while any alt-screen the remote set is still
+		// active, matching the pre-#383 relative ordering. See issue #383.
+		if postDrainMsg != "" && sr.stdout != nil {
+			if _, err := sr.stdout.WriteString(postDrainMsg); err != nil {
+				sr.logger.Debug("restoreParentTerminal: write post-drain message failed", "error", err)
 			}
 		}
 


### PR DESCRIPTION
## Summary

Closes two control-flow gaps in `Exec.Detach` (`internal/client/clientrunner/lifecycle.go`) surfaced during the #364/#365/#382 cleanup review. Both are about *whether* and *when* the existing restore sequence fires, not its contents.

- **Gap 1 — restore skipped on RPC failure.** Previously `Detach` returned early when `terminalClient.Detach` failed (broken control socket, server crash mid-RPC, RPC timeout), leaving the parent terminal stranded in raw mode until the secondary `EvError → Close` path *might* fire — with no contract that the IO copier observes the failure on the same tick. The user has already committed to leaving via `^]^]`; the local restore is non-negotiable regardless of the server-side RPC outcome. `Detach` now calls `restoreParentTerminal` on the failure path too, suppressing the (now-misleading) "Detached" banner, and still propagates the RPC error.

- **Gap 2 — banner raced inbound copier bytes.** The "Detached" banner was written *before* `restoreParentTerminal`'s copier-drain wait, so it could interleave with bytes the socket→stdout copier was mid-flush (e.g. a TUI's final repaint frame). The banner is now handed to `restoreParentTerminal` as an optional `postDrainMsg`, written after the inbound copier drains (or the bounded `copierWaitTimeout`) but before the termios raw→cooked restore — so raw mode is still active and the embedded `\r\n` behaves, and it can no longer interleave with mid-flush remote bytes. This is the issue's endorsed "simpler reading."

### Design note (reviewer please confirm)

The banner write is now a best-effort, logged operation inside `restoreParentTerminal` rather than `Detach`'s return value. Under the old code a failed banner `WriteString` (RPC succeeded) turned a successful detach into an error return; under the new contract the restore is non-negotiable and the banner is best-effort, so a banner-write failure on a successful RPC no longer fails `Detach`. `TestDetach_StdoutWriteError` was updated to encode this new contract (it now asserts `Detach` returns `nil` on banner-write failure when the RPC succeeded). This follows directly from the issue's Gap-1 framing ("the banner is meaningless if the RPC failed; the restore is not"); flagging it so the reviewer can push back if the error-propagation behavior should be preserved instead.

## Test plan

- [x] `go build ./...`
- [x] `make sbsh-sb` (canonical build; verified ELF magic `7f 45 4c 46`)
- [x] `go vet ./...`
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` — full non-e2e suite, all pass
- [x] `go test -tags=integration ./cmd/sb/get/...`
- [x] `make e2e` — all pass; `TestSbsh_Detach` runtime output confirms the new ordering: banner + normalize emitted as one coherent post-drain block `\x1b[93m\r\nDetached\x1b[0m\r\n\x1b[?1049l\x1b[?25h\x1b[0 q`
- [x] `TestRestore_OnDetach` and `TestRestore_EmitsOutputNormalize_OnDetach` regressions still pass (AC item 3)

### Acceptance criteria

- [x] `Exec.Detach` calls `restoreParentTerminal` unconditionally once entered, including the RPC-failure path. New `TestRestore_OnDetach_RPCFailure` injects an RPC-returning-error `mockTerminalClient` and asserts the parent terminal is restored (cooked termios + blocking descriptor) and the normalize sequence is emitted.
- [x] The "Detached" banner is written after the inbound socket→stdout copier drains (or after the bounded drain timeout). New `TestDetach_BannerWrittenBeforeNormalize` asserts the banner is emitted from within `restoreParentTerminal` and precedes the normalize sequence; e2e `TestSbsh_Detach` output confirms it at runtime.
- [x] Existing `TestRestore_OnDetach` and `TestRestore_EmitsOutputNormalize_OnDetach` continue to pass.
- [x] New RPC-failure regression test uses a `mockTerminalClient` whose `Detach` returns an error and verifies the parent terminal is still restored (termios cooked, normalize sequence emitted, banner suppressed).

## Out of scope

- Missing DEC mode constants in `escRestoreParentTerm` (mouse modes, bracketed paste) — tracked in #382 (`terminal.go`, not `lifecycle.go`).
- The 500ms `copierWaitTimeout` bound itself — documented and correct for the `os.Stdin` non-pollable case.

Closes #383