### PR TITLE
fix: refuse duplicate --id start that clobbers a live terminal's metadata

### DIFF
--- a/cmd/sbsh/terminal/terminal.go
+++ b/cmd/sbsh/terminal/terminal.go
@@ -402,6 +402,15 @@ that have exited can be reused.
 				return errAvail
 			}
 
+			if errIDAvail := discovery.VerifyTerminalIDAvailable(
+				cmd.Context(),
+				logger,
+				terminalSpec.RunPath,
+				string(terminalSpec.ID),
+			); errIDAvail != nil {
+				return errIDAvail
+			}
+
 			logger.Debug("Built terminal spec", "terminalSpec", fmt.Sprintf("%+v", terminalSpec))
 
 			if logger.Enabled(context.Background(), slog.LevelDebug) {

--- a/internal/discovery/reconcile.go
+++ b/internal/discovery/reconcile.go
@@ -57,6 +57,15 @@ func isProcessAlive(pid int) bool {
 	return false
 }
 
+// IsInstanceAlive reports whether the process instance identified by
+// (pid, pidStart) is still running, using the same liveness+PID-reuse rules
+// reconcile and prune rely on. Exported so the terminal runner can refuse to
+// clobber a live owner's metadata before it overwrites the ID-derived path,
+// keeping the runner's notion of "live" identical to reconcile's. See #386.
+func IsInstanceAlive(pid int, pidStart uint64) bool {
+	return isInstanceAlive(pid, pidStart)
+}
+
 // isInstanceAlive extends isProcessAlive with PID-reuse rejection: if a
 // start-time token was recorded, the live PID must still belong to the same
 // process instance that produced it. A zero token degrades to liveness-only,

--- a/internal/discovery/terminals.go
+++ b/internal/discovery/terminals.go
@@ -314,6 +314,40 @@ func VerifyTerminalNameAvailable(
 	return nil
 }
 
+// VerifyTerminalIDAvailable returns errdefs.ErrTerminalIDInUse if an active
+// (non-Exited) terminal under runPath already carries id. It mirrors
+// VerifyTerminalNameAvailable: a different --name sails past the name check, so
+// the ID needs its own pre-launch guard to fail fast before the runner would
+// otherwise clobber the live owner's metadata (the runner-level backstop lives
+// in CreateMetadata). Stale metadata whose owner is gone is reconciled to
+// Exited and does not block reuse, so an exited terminal's ID can be recycled.
+// An empty id or runPath is treated as unconditionally available. See #386.
+func VerifyTerminalIDAvailable(
+	ctx context.Context,
+	logger *slog.Logger,
+	runPath string,
+	id string,
+) error {
+	if id == "" || runPath == "" {
+		return nil
+	}
+	terminals, err := ScanTerminals(ctx, logger, runPath)
+	if err != nil {
+		return err
+	}
+	ReconcileTerminals(ctx, logger, runPath, terminals)
+	for _, t := range terminals {
+		if t.Status.State == api.Exited {
+			continue
+		}
+		if pkgdiscovery.TerminalID(t) != id {
+			continue
+		}
+		return fmt.Errorf("%w: %q (name %s)", errdefs.ErrTerminalIDInUse, id, pkgdiscovery.TerminalName(t))
+	}
+	return nil
+}
+
 func PrintTerminalSpec(s *api.TerminalSpec, logger *slog.Logger) error {
 	if s == nil {
 		logger.Info("nil terminal spec")

--- a/internal/discovery/terminals_test.go
+++ b/internal/discovery/terminals_test.go
@@ -146,3 +146,75 @@ func TestVerifyTerminalNameAvailable(t *testing.T) {
 		}
 	})
 }
+
+// TestVerifyTerminalIDAvailable mirrors the name-availability checks for the
+// ID pre-launch guard added in #386: a same-ID start (which a different --name
+// slips past VerifyTerminalNameAvailable) must be rejected before the runner
+// would clobber the live owner's metadata.
+func TestVerifyTerminalIDAvailable(t *testing.T) {
+	ctx := context.Background()
+	logger := discardLogger()
+	livePid := os.Getpid()
+	// PID 0 is reserved on Unix; isProcessAlive treats it as "unknown / alive",
+	// so a defunct PID like a very high number signals a dead process.
+	const deadPid = 0x7fffffff
+
+	t.Run("empty id is always available", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeTerminalDoc(t, runPath, "id-1", "alpha", api.Ready, livePid)
+		if err := discovery.VerifyTerminalIDAvailable(ctx, logger, runPath, ""); err != nil {
+			t.Fatalf("expected nil for empty id, got: %v", err)
+		}
+	})
+
+	t.Run("empty runPath is always available", func(t *testing.T) {
+		if err := discovery.VerifyTerminalIDAvailable(ctx, logger, "", "id-1"); err != nil {
+			t.Fatalf("expected nil for empty runPath, got: %v", err)
+		}
+	})
+
+	t.Run("no terminals", func(t *testing.T) {
+		runPath := t.TempDir()
+		if err := discovery.VerifyTerminalIDAvailable(ctx, logger, runPath, "id-1"); err != nil {
+			t.Fatalf("expected nil, got: %v", err)
+		}
+	})
+
+	t.Run("active id blocks reuse even with a different name", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeTerminalDoc(t, runPath, "id-1", "alpha", api.Ready, livePid)
+		// Same ID, the launcher's name (beta) differs — this is exactly the
+		// gap VerifyTerminalNameAvailable misses.
+		err := discovery.VerifyTerminalIDAvailable(ctx, logger, runPath, "id-1")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !errors.Is(err, errdefs.ErrTerminalIDInUse) {
+			t.Fatalf("expected ErrTerminalIDInUse, got: %v", err)
+		}
+	})
+
+	t.Run("active terminal does not block a different id", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeTerminalDoc(t, runPath, "id-1", "alpha", api.Ready, livePid)
+		if err := discovery.VerifyTerminalIDAvailable(ctx, logger, runPath, "id-2"); err != nil {
+			t.Fatalf("expected nil for non-colliding id, got: %v", err)
+		}
+	})
+
+	t.Run("exited terminal allows id reuse", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeTerminalDoc(t, runPath, "id-1", "alpha", api.Exited, livePid)
+		if err := discovery.VerifyTerminalIDAvailable(ctx, logger, runPath, "id-1"); err != nil {
+			t.Fatalf("expected nil for exited terminal, got: %v", err)
+		}
+	})
+
+	t.Run("stale active terminal is reconciled to exited and allows id reuse", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeTerminalDoc(t, runPath, "id-1", "alpha", api.Ready, deadPid)
+		if err := discovery.VerifyTerminalIDAvailable(ctx, logger, runPath, "id-1"); err != nil {
+			t.Fatalf("expected nil after stale-state reconciliation, got: %v", err)
+		}
+	})
+}

--- a/internal/errdefs/errdefs.go
+++ b/internal/errdefs/errdefs.go
@@ -45,6 +45,7 @@ var (
 	ErrTerminalNotFoundByID     = errors.New("could not find terminal by ID")
 	ErrTerminalNotFoundByName   = errors.New("could not find terminal by Name")
 	ErrTerminalNameInUse        = errors.New("terminal name already in use by an active terminal")
+	ErrTerminalIDInUse          = errors.New("terminal id already in use by an active terminal")
 	ErrTerminalMetadataNotFound = errors.New("no terminal metadata found to attach")
 	ErrNoTerminalSpec           = errors.New("no terminal spec found")
 	ErrConfig                   = errors.New("config error")

--- a/internal/errdefs/errdefs_test.go
+++ b/internal/errdefs/errdefs_test.go
@@ -35,7 +35,7 @@ func TestSentinels_NonNilWithMessage(t *testing.T) {
 		ErrClientMode, ErrRPCServerExited, ErrOnClose, ErrCloseReq, ErrTerminalCmdStart,
 		ErrWriteMetadata, ErrStartCmd, ErrDetachTerminal, ErrSetupShell, ErrInitShell,
 		ErrProgramExited, ErrNoSpecDefined, ErrAttachNoTerminalSpec, ErrTerminalNotFoundByID,
-		ErrTerminalNotFoundByName, ErrTerminalNameInUse, ErrTerminalMetadataNotFound,
+		ErrTerminalNotFoundByName, ErrTerminalNameInUse, ErrTerminalIDInUse, ErrTerminalMetadataNotFound,
 		ErrNoTerminalSpec, ErrConfig, ErrLoggerNotFound, ErrInvalidFlag, ErrInvalidOption,
 		ErrStdinStat, ErrStdinEmpty, ErrInvalidArgument, ErrOpenSpecFile, ErrInvalidJSONSpec,
 		ErrTerminalSpecNotFound, ErrBuildTerminalSpec, ErrNoTerminalIdentifier,

--- a/internal/terminal/terminalrunner/metadata.go
+++ b/internal/terminal/terminalrunner/metadata.go
@@ -17,6 +17,7 @@
 package terminalrunner
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -25,6 +26,8 @@ import (
 	"time"
 
 	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/internal/discovery"
+	"github.com/eminwux/sbsh/internal/errdefs"
 	"github.com/eminwux/sbsh/internal/pidutil"
 	"github.com/eminwux/sbsh/internal/shared"
 	"github.com/eminwux/sbsh/pkg/api"
@@ -58,6 +61,25 @@ func (sr *Exec) CreateMetadata() error {
 	sr.metadataMu.Unlock()
 
 	dir, embedderOwnsDir := resolveMetadataDir(runPath, metadataDirOverride, sr.id)
+
+	// Refuse to overwrite metadata.json at a path whose current owner is still
+	// alive. CreateMetadata writes the ID-derived path unconditionally; without
+	// this guard a second start reusing a live terminal's --id (which a
+	// different --name sails past the CLI name check) clobbers the live
+	// terminal's pid/name/state, making it invisible and letting prune
+	// os.RemoveAll a still-running terminal's run dir. The socket probe in
+	// OpenSocketCtrl runs only after this write, so detection has to happen
+	// here, before the overwrite. See #386.
+	if owner := liveMetadataOwner(dir); owner != nil {
+		sr.logger.Error(
+			"CreateMetadata: refusing to overwrite metadata owned by a live terminal",
+			"dir", dir,
+			"owner_id", owner.Spec.ID,
+			"owner_name", owner.Spec.Name,
+			"owner_pid", owner.Status.Pid,
+		)
+		return fmt.Errorf("%w: %q (pid %d)", errdefs.ErrTerminalIDInUse, owner.Spec.ID, owner.Status.Pid)
+	}
 
 	if embedderOwnsDir {
 		// MetadataDir is set: the embedder pre-allocated this directory
@@ -106,6 +128,41 @@ func (sr *Exec) CreateMetadata() error {
 	}
 	sr.logger.Info("CreateMetadata: metadata created successfully")
 	return nil
+}
+
+// liveMetadataOwner reads an existing metadata.json under dir and returns the
+// decoded doc when it represents an active owner — recorded state is not Exited
+// and the owner process instance is still alive — or nil when no metadata
+// exists, it is unreadable/corrupt, the prior owner already exited, or its
+// process is gone. This is the reconcile/prune notion of "active": a terminal
+// is live iff State != Exited and IsInstanceAlive(pid, pidStart), so a recycled
+// ID whose prior owner exited cleanly (State==Exited) or died (pid gone) is
+// correctly treated as free for reuse — matching the name-recycling semantics
+// of VerifyTerminalNameAvailable. CreateMetadata is called once per runner
+// lifecycle before the runner writes any metadata of its own, so a fresh start
+// never matches itself here.
+func liveMetadataOwner(dir string) *api.TerminalDoc {
+	if dir == "" {
+		return nil
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "metadata.json"))
+	if err != nil {
+		// ENOENT (fresh ID) or any read error: no live owner to protect.
+		return nil
+	}
+	var doc api.TerminalDoc
+	if err := json.Unmarshal(b, &doc); err != nil {
+		// Corrupt metadata cannot identify a live owner; do not block the start.
+		return nil
+	}
+	if doc.Status.State == api.Exited {
+		// Prior owner exited cleanly; the ID is free to recycle.
+		return nil
+	}
+	if !discovery.IsInstanceAlive(doc.Status.Pid, doc.Status.PidStart) {
+		return nil
+	}
+	return &doc
 }
 
 func (sr *Exec) getTerminalDir() string {

--- a/internal/terminal/terminalrunner/metadata_dup_id_test.go
+++ b/internal/terminal/terminalrunner/metadata_dup_id_test.go
@@ -1,0 +1,143 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrunner
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/internal/discovery"
+	"github.com/eminwux/sbsh/internal/errdefs"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+func readMetadataDoc(t *testing.T, dir string) api.TerminalDoc {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dir, "metadata.json"))
+	if err != nil {
+		t.Fatalf("read metadata.json in %q: %v", dir, err)
+	}
+	var doc api.TerminalDoc
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatalf("unmarshal metadata.json: %v", err)
+	}
+	return doc
+}
+
+// TestCreateMetadata_RefusesLiveOwnerDuplicateID reproduces issue #386 at the
+// runner level: a second start reusing a live terminal's --id (with a different
+// --name, which sails past the CLI name check) must be refused *without*
+// clobbering the live owner's metadata.json. The clobber was the root cause of
+// the live terminal going invisible/unaddressable and prune deleting its still-
+// running run dir.
+func TestCreateMetadata_RefusesLiveOwnerDuplicateID(t *testing.T) {
+	runPath := t.TempDir()
+	id := api.ID("aaaa1111")
+	dir := filepath.Join(runPath, defaults.TerminalsRunPath, string(id))
+
+	// Terminal A: alive (this test process is the recorded owner pid).
+	srA := newMetadataExec(t, runPath, "", id)
+	srA.metadata.Spec.Name = "terma"
+	if err := srA.CreateMetadata(); err != nil {
+		t.Fatalf("A CreateMetadata: %v", err)
+	}
+	before := readMetadataDoc(t, dir)
+	if before.Spec.Name != "terma" || before.Status.Pid != os.Getpid() {
+		t.Fatalf("A metadata not as expected: name=%q pid=%d", before.Spec.Name, before.Status.Pid)
+	}
+
+	// Terminal B: same --id, different --name. Must be refused.
+	srB := newMetadataExec(t, runPath, "", id)
+	srB.metadata.Spec.Name = "termb"
+	err := srB.CreateMetadata()
+	if err == nil {
+		t.Fatal("B CreateMetadata: expected refusal, got nil")
+	}
+	if !errors.Is(err, errdefs.ErrTerminalIDInUse) {
+		t.Fatalf("B CreateMetadata: expected ErrTerminalIDInUse, got: %v", err)
+	}
+
+	// AC: A's metadata.json is intact — name, pid, and state unchanged.
+	after := readMetadataDoc(t, dir)
+	if after.Spec.Name != "terma" {
+		t.Fatalf("A metadata name clobbered: got %q, want terma", after.Spec.Name)
+	}
+	if after.Status.Pid != before.Status.Pid {
+		t.Fatalf("A metadata pid clobbered: got %d, want %d", after.Status.Pid, before.Status.Pid)
+	}
+	if after.Status.State != before.Status.State {
+		t.Fatalf("A metadata state clobbered: got %v, want %v", after.Status.State, before.Status.State)
+	}
+
+	// AC: prune-safe. PruneTerminal removes only entries reconciled to Exited;
+	// reconciling A's intact (live pid, non-Exited) metadata keeps it active, so
+	// prune leaves the running terminal's run dir alone.
+	terminals, scanErr := discovery.ScanTerminals(srB.ctx, srB.logger, runPath)
+	if scanErr != nil {
+		t.Fatalf("ScanTerminals: %v", scanErr)
+	}
+	discovery.ReconcileTerminals(srB.ctx, srB.logger, runPath, terminals)
+	if len(terminals) != 1 {
+		t.Fatalf("expected exactly 1 terminal on disk, got %d", len(terminals))
+	}
+	if terminals[0].Status.State == api.Exited {
+		t.Fatal("live terminal reconciled to Exited — prune would delete a running terminal's dir")
+	}
+}
+
+// TestCreateMetadata_RecyclesExitedOwnerID confirms the guard does not
+// over-block: an --id whose prior owner exited cleanly (State==Exited) is free
+// to recycle, matching the name-recycling semantics of
+// VerifyTerminalNameAvailable.
+func TestCreateMetadata_RecyclesExitedOwnerID(t *testing.T) {
+	runPath := t.TempDir()
+	id := api.ID("bbbb2222")
+	dir := filepath.Join(runPath, defaults.TerminalsRunPath, string(id))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+
+	// Pre-seed an exited owner with a live pid: state, not liveness, marks it
+	// reusable.
+	prior := api.TerminalDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindTerminal,
+		Spec:       api.TerminalSpec{ID: id, Name: "old", RunPath: runPath},
+		Status:     api.TerminalStatus{State: api.Exited, Pid: os.Getpid(), TerminalRunPath: dir},
+	}
+	b, err := json.Marshal(prior)
+	if err != nil {
+		t.Fatalf("marshal prior: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "metadata.json"), b, 0o600); err != nil {
+		t.Fatalf("write prior metadata: %v", err)
+	}
+
+	sr := newMetadataExec(t, runPath, "", id)
+	sr.metadata.Spec.Name = "new"
+	if err := sr.CreateMetadata(); err != nil {
+		t.Fatalf("CreateMetadata on exited-owner id: expected nil, got: %v", err)
+	}
+	got := readMetadataDoc(t, dir)
+	if got.Status.State != api.Initializing {
+		t.Fatalf("recycled metadata state = %v, want Initializing", got.Status.State)
+	}
+}


### PR DESCRIPTION
## Summary

Starting a terminal with an `--id` already owned by a **live** terminal corrupted the running terminal's on-disk state: the only ID-collision guard (the socket live-peer probe in `OpenSocketCtrl`) ran *after* `CreateMetadata` had already overwritten `metadata.json` at the shared ID-derived path, and the CLI pre-launch guard checked the **name** only (so a different `--name` sailed past). The live terminal's metadata got clobbered with the dead duplicate's pid/name/state, making it invisible/unaddressable, and `sb prune terminals` then `os.RemoveAll`'d the still-running terminal's run dir.

This adds detection of a live owner *before* the metadata write, at two layers:

- **Runner backstop (load-bearing):** `CreateMetadata` now refuses to overwrite `metadata.json` when its current owner is an active terminal — `State != Exited` **and** `IsInstanceAlive(pid, pidStart)`, the same liveness notion reconcile/prune use. This covers embedders that drive the controller directly, not just the CLI. Returns `errdefs.ErrTerminalIDInUse` without touching the live owner's metadata.
- **CLI fail-fast:** new `discovery.VerifyTerminalIDAvailable`, mirroring `VerifyTerminalNameAvailable`, wired alongside the existing name check in `cmd/sbsh/terminal`. Gives a clear pre-launch error instead of the confusing `context canceled` from the repro.

To keep "is this terminal alive" defined in one place, the existing unexported `isInstanceAlive` is exposed as `discovery.IsInstanceAlive` and reused by the runner (no terminalrunner→discovery import cycle — discovery imports neither package).

### Notes for the reviewer (non-obvious calls)

- **Gate vs. flip / blast radius:** the issue's suggested fix was "move the socket probe ahead of the write, **and/or** extend the name guard to reject in-use ID." I implemented **both** as defense-in-depth — the runner backstop is mandatory (it's the only layer covering embedders), and the CLI check is a small fail-fast UX win mirroring the existing name guard exactly. Both are purely additive: no existing valid flow changes.
- **Owner liveness uses `State != Exited && alive`, not pid-liveness alone.** A pid-only check would wrongly block an embedder that reuses one process+id after a clean close (prior `State==Exited` but the hosting process is still alive). Keying on the reconcile/prune notion of "active" makes ID-recycling semantics identical to name-recycling: an exited-or-dead prior owner frees the ID.

## Test plan
- [x] `make sbsh-sb` — canonical build; `./sbsh` is ELF (`7f 45 4c 46`)
- [x] `go build ./...`
- [x] `go vet ./internal/... ./cmd/sbsh/...`
- [x] `make test` (full CI suite incl. e2e) — exit 0
- [x] New `TestCreateMetadata_RefusesLiveOwnerDuplicateID` — end-to-end repro: duplicate-id/different-name start refused, live owner's metadata intact, and a reconcile pass confirms the entry is not flipped to Exited (so prune leaves the running dir alone)
- [x] New `TestCreateMetadata_RecyclesExitedOwnerID` — exited-owner ID is free to recycle (guard doesn't over-block)
- [x] New `TestVerifyTerminalIDAvailable` — CLI guard: active id blocks reuse with a different name, exited/stale ids recycle

## Acceptance criteria
- [x] Starting a terminal with an `--id` already owned by a live terminal fails *without* modifying the live terminal's `metadata.json`
- [x] The live terminal remains visible and addressable by its real name after the rejected duplicate start (metadata untouched)
- [x] `sb prune terminals` never removes the run directory of a still-alive process (intact `State != Exited` + live pid is not reconciled to Exited; prune acts only on Exited)
- [x] A regression test covers the duplicate-ID/different-name start path end to end (metadata intact, prune-safe)

Closes #386