### PR TITLE
fix: bound Detach and readiness-wait RPCs so a wedged daemon can't trap the client in raw mode

### DIFF
--- a/internal/client/clientrunner/io.go
+++ b/internal/client/clientrunner/io.go
@@ -248,8 +248,9 @@ func (sr *Exec) waitReady(states ...api.TerminalStatusMode) error {
 			sr.logger.ErrorContext(sr.ctx, "waitReady: context done before ready", "error", ctx.Err())
 			return fmt.Errorf("context done before ready: %w", ctx.Err())
 		case <-ticker.C:
-			// refresh curState
-			curState, err := sr.getTerminalState()
+			// refresh curState — pass the bounded ctx so a wedged State RPC
+			// cannot outlive the readiness deadline (issue #389).
+			curState, err := sr.getTerminalState(ctx)
 			if err != nil {
 				sr.logger.ErrorContext(sr.ctx, "waitReady: getTerminalState failed during wait", "error", err)
 				return fmt.Errorf("get terminal state failed during wait: %w", err)

--- a/internal/client/clientrunner/io_test.go
+++ b/internal/client/clientrunner/io_test.go
@@ -329,6 +329,60 @@ func Test_WaitReady_Timeout(t *testing.T) {
 	}
 }
 
+// Test_WaitReady_WedgedStateRPC covers issue #389: a State RPC that never
+// replies (daemon wedged with the socket still in the kernel backlog) must not
+// trap the readiness loop. Because waitReady passes its bounded context to the
+// State RPC, a blocking RPC is cancelled at the readiness deadline and waitReady
+// returns an error instead of hanging the caller in raw mode forever.
+func Test_WaitReady_WedgedStateRPC(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sr := &Exec{
+		ctx:    ctx,
+		logger: logger,
+		terminal: &api.AttachedTerminal{
+			Spec: &api.TerminalSpec{
+				ID:   api.ID("test-terminal"),
+				Name: "test",
+			},
+		},
+		metadata: api.ClientDoc{
+			APIVersion: api.APIVersionV1Beta1,
+			Kind:       api.KindClient,
+			Metadata: api.ClientMetadata{
+				Name:        "test-client",
+				Labels:      make(map[string]string),
+				Annotations: make(map[string]string),
+			},
+			Spec: api.ClientSpec{},
+		},
+	}
+
+	// Wedged daemon: the State RPC blocks until its context is cancelled.
+	sr.terminalClient = &mockTerminalClient{
+		stateFunc: func(rpcCtx context.Context, _ *api.TerminalStatusMode) error {
+			<-rpcCtx.Done()
+			return rpcCtx.Err()
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- sr.waitReady(api.Ready)
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("waitReady returned nil against a wedged State RPC; want an error so the caller can restore the terminal")
+		}
+	case <-time.After(waitReadyTimeoutSeconds*time.Second + 3*time.Second):
+		t.Fatal("waitReady hung on a wedged State RPC; the readiness wait did not bound the RPC (issue #389)")
+	}
+}
+
 func Test_WaitReady_StateTransition(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/client/clientrunner/lifecycle.go
+++ b/internal/client/clientrunner/lifecycle.go
@@ -18,6 +18,7 @@ package clientrunner
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -33,6 +34,12 @@ import (
 
 const (
 	deleteClientDir bool = false
+
+	// detachTimeout bounds the Detach RPC so a wedged daemon (one that accepts
+	// the connection and request-write but never replies) cannot block the
+	// controller event loop indefinitely and leave the parent terminal stuck in
+	// raw mode. Matches the Ping deadline in io.go. See issue #389.
+	detachTimeout = 3 * time.Second
 )
 
 func (sr *Exec) StartTerminalCmd(terminal *api.AttachedTerminal) error {
@@ -217,7 +224,14 @@ func (sr *Exec) Detach() error {
 	// RPC timeout) — rather than relying on Close() being driven later via the
 	// conn-close EvError, which is not guaranteed to fire on the same tick. See
 	// issues #364 and #383.
-	if err := sr.terminalClient.Detach(sr.ctx, &sr.id); err != nil {
+	//
+	// Bound the RPC so a daemon that accepts the connection but never replies
+	// cannot block here forever — on timeout the ctx-cancel branch in
+	// callWithCodec returns, and we fall through to the restore path exactly as
+	// the Detach-RPC-failure case from #385 does. See issue #389.
+	ctx, cancel := context.WithTimeout(sr.ctx, detachTimeout)
+	defer cancel()
+	if err := sr.terminalClient.Detach(ctx, &sr.id); err != nil {
 		sr.logger.Warn("Detach RPC failed; restoring parent terminal anyway", "client_id", sr.id, "error", err)
 		// Suppress the "Detached" banner — it would be misleading when the RPC
 		// failed — but the restore still runs. See #383.

--- a/internal/client/clientrunner/lifecycle_test.go
+++ b/internal/client/clientrunner/lifecycle_test.go
@@ -195,6 +195,44 @@ func TestDetach_RPCError(t *testing.T) {
 	}
 }
 
+// TestDetach_RPCBounded covers issue #389: the Detach RPC must carry a bounded
+// context so a wedged daemon cannot block the controller event loop forever. We
+// assert the context handed to the terminal client carries a deadline derived
+// from sr.ctx, and that a Detach RPC which blocks until that deadline still
+// returns (falling through to the restore path) rather than hanging.
+func TestDetach_RPCBounded(t *testing.T) {
+	sr, _ := newLifecycleExec(t)
+
+	var gotDeadline bool
+	sr.terminalClient = &mockTerminalClient{
+		detachFunc: func(ctx context.Context, _ *api.ID) error {
+			_, gotDeadline = ctx.Deadline()
+			// Emulate a wedged daemon: block until the bounded context fires,
+			// then surface its error exactly as callWithCodec's ctx-done branch
+			// does. Without the bound this would block until the test's parent
+			// ctx is cancelled and hang the controller event loop.
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- sr.Detach() }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Detach returned nil error when the RPC timed out; want the bounded-ctx error")
+		}
+	case <-time.After(detachTimeout + 2*time.Second):
+		t.Fatal("Detach did not return within the bounded timeout; the Detach RPC is not bounded")
+	}
+
+	if !gotDeadline {
+		t.Fatal("Detach RPC context carried no deadline; the controller event loop can wedge indefinitely")
+	}
+}
+
 // TestDetach_StdoutWriteError covers the branch where the detach succeeds at
 // the RPC layer but writing the confirmation banner to stdout fails. As of #383
 // the banner is a best-effort post-drain message inside restoreParentTerminal,

--- a/internal/client/clientrunner/metadata.go
+++ b/internal/client/clientrunner/metadata.go
@@ -17,6 +17,7 @@
 package clientrunner
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -109,13 +110,18 @@ func (sr *Exec) getTerminalMetadata() (*api.TerminalDoc, error) {
 	return &metadata, nil
 }
 
-func (sr *Exec) getTerminalState() (*api.TerminalStatusMode, error) {
+// getTerminalState fetches the terminal's lifecycle state over the control
+// socket. The caller supplies the context so the State RPC honors the caller's
+// deadline — waitReady passes its bounded context so a wedged server (one that
+// accepts the connection but never replies) cannot block the readiness loop and
+// trap the client in raw mode. See issue #389.
+func (sr *Exec) getTerminalState(ctx context.Context) (*api.TerminalStatusMode, error) {
 	if sr.terminalClient == nil {
 		return nil, errors.New("getTerminalState: terminal client is nil")
 	}
 
 	var state api.TerminalStatusMode
-	if err := sr.terminalClient.State(sr.ctx, &state); err != nil {
+	if err := sr.terminalClient.State(ctx, &state); err != nil {
 		sr.logger.ErrorContext(sr.ctx, "getTerminalState: failed to get state", "error", err)
 		return nil, fmt.Errorf("get state RPC failed: %w", err)
 	}

--- a/internal/client/clientrunner/metadata_test.go
+++ b/internal/client/clientrunner/metadata_test.go
@@ -142,7 +142,7 @@ func TestState_ReturnsCurrentState(t *testing.T) {
 // terminal client has been dialled yet.
 func TestGetTerminalState_NilClient(t *testing.T) {
 	sr, _ := newMetadataExec(t)
-	if _, err := sr.getTerminalState(); err == nil {
+	if _, err := sr.getTerminalState(context.Background()); err == nil {
 		t.Fatal("getTerminalState with nil client returned nil error")
 	}
 }
@@ -154,7 +154,7 @@ func TestGetTerminalState_PropagatesRPCError(t *testing.T) {
 	sr.terminalClient = &mockTerminalClient{
 		stateFunc: func(_ context.Context, _ *api.TerminalStatusMode) error { return wantErr },
 	}
-	if _, err := sr.getTerminalState(); err == nil {
+	if _, err := sr.getTerminalState(context.Background()); err == nil {
 		t.Fatal("getTerminalState returned nil error on RPC failure")
 	}
 }


### PR DESCRIPTION
## Summary

A wedged terminal daemon (one that accepts the connection and request-write but never replies — e.g. `kill -STOP` on the daemon while the socket stays in the kernel backlog) could leave the client permanently stuck in raw mode, unrecoverable from the keyboard. Two RPC paths on the client lacked a deadline:

- **Detach RPC** (`^]^]`): issued synchronously inside the controller event loop with `sr.ctx` (only cancelled by `Close()`/restore itself), so a never-returning Detach blocked forever and `restoreParentTerminal` — which runs only *after* Detach returns — never ran.
- **Post-raw-mode readiness wait**: `waitReady`'s 2s loop budget did not bound the `State` RPC it calls each tick (`getTerminalState` used `sr.ctx`), so a `State` RPC that wedged blocked the loop *inside* `getTerminalState`, and the 2s `ctx.Done()` escape never got a chance to fire.

### Changes

- `lifecycle.go` — `Detach()` now derives a `context.WithTimeout(sr.ctx, detachTimeout)` (3s, matching the Ping deadline) for the Detach RPC. On timeout the RPC returns via `callWithCodec`'s ctx-cancel branch and falls through to the existing #385 restore-on-failure path (`restoreParentTerminal("")`), so the parent terminal is always restored.
- `metadata.go` — `getTerminalState` now takes a `ctx context.Context` instead of using `sr.ctx`, so the `State` RPC honors the caller's deadline.
- `io.go` — `waitReady` passes its bounded 2s `ctx` into `getTerminalState`, so a wedged `State` RPC is cancelled at the readiness deadline and `waitReady` returns an error. The caller (`controller.go:251`) then runs `Close` → `restoreParentTerminal`, releasing raw mode.

### Notes for the reviewer

- The Detach timeout reuses the existing #385 failure path rather than adding a new branch — a timeout is just another RPC error, and that path already clears raw mode, mouse-tracking, and bracketed-paste via `restoreParentTerminal` (no banner on the error path, per #383). Verified `controller.go:249-257` calls `s.Close(errAttach)` → `sr.Close` → `restoreParentTerminal` on a post-raw-mode `waitReady` error, so AC#3's restore is covered without new wiring.
- `getTerminalState`'s only non-test caller is `waitReady`; signature change is contained (two test call sites updated).

## Test plan

- [x] `make sbsh-sb` — canonical build; binary is ELF (`7f 45 4c 46`)
- [x] `go build ./...`
- [x] `go vet ./internal/client/...`
- [x] `make test` — full CI suite incl. e2e, exit 0
- [x] New `TestDetach_RPCBounded` — asserts the Detach RPC ctx carries a deadline and a blocking RPC returns within the bound
- [x] New `Test_WaitReady_WedgedStateRPC` — asserts a wedged `State` RPC no longer hangs `waitReady`

## Acceptance criteria

- [x] The Detach RPC uses a bounded context; a non-responding daemon does not block the controller event loop indefinitely.
- [x] On Detach RPC timeout, the parent terminal is restored (raw mode, mouse-tracking, bracketed-paste cleared) before the client exits.
- [x] The post-raw-mode readiness wait cannot trap the client in raw mode against a wedged server.

Closes #389