### PR TITLE
fix: sanitize control/escape bytes in sb get human-readable listings

### DIFF
--- a/internal/discovery/clients.go
+++ b/internal/discovery/clients.go
@@ -163,14 +163,14 @@ func printClients(w io.Writer, clients []api.ClientDoc, printAll, wide bool) err
 		}
 		if wide {
 			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
-				pkgdiscovery.ClientID(s),
-				pkgdiscovery.ClientName(s),
+				sanitizeField(pkgdiscovery.ClientID(s)),
+				sanitizeField(pkgdiscovery.ClientName(s)),
 				s.Status.State.String(),
-				joinLabels(clientLabels(s)),
+				sanitizeField(joinLabels(clientLabels(s))),
 			)
 		} else {
 			fmt.Fprintf(tw, "%s\t%s\n",
-				pkgdiscovery.ClientName(s),
+				sanitizeField(pkgdiscovery.ClientName(s)),
 				s.Status.State.String(),
 			)
 		}

--- a/internal/discovery/injection_test.go
+++ b/internal/discovery/injection_test.go
@@ -1,0 +1,147 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package discovery_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/eminwux/sbsh/internal/discovery"
+	"github.com/eminwux/sbsh/pkg/api"
+	"go.yaml.in/yaml/v3"
+)
+
+// evilName carries an OSC title-set, a colour CSI, and a clear-screen CSI — the
+// classic terminal-output-injection payloads an attacker can smuggle through a
+// terminal/profile/client name (#390).
+const evilName = "evil\x1b]0;pwned\x07\x1b[31m\x1b[2J"
+
+// assertNoRawEscapes fails if out carries any byte a terminal would interpret as
+// a control/escape command, and confirms the row was actually rendered (the
+// visible "evil" prefix survives, escaped ESC bytes are present) rather than
+// silently dropped.
+func assertNoRawEscapes(t *testing.T, label, out string) {
+	t.Helper()
+	for i := 0; i < len(out); i++ {
+		if b := out[i]; b < 0x20 && b != '\n' && b != '\t' || b == 0x7f {
+			t.Fatalf("%s: raw control byte %#x emitted to terminal: %q", label, b, out)
+		}
+	}
+	if !strings.Contains(out, "evil") {
+		t.Fatalf("%s: expected the sanitized row to still render the visible name, got %q", label, out)
+	}
+	if !strings.Contains(out, `\x1b`) {
+		t.Fatalf("%s: expected ESC bytes to be escaped as \\x1b, got %q", label, out)
+	}
+}
+
+func TestScanAndPrintTerminals_SanitizesName(t *testing.T) {
+	ctx := context.Background()
+	logger := discardLogger()
+	runPath := t.TempDir()
+	writeTerminalDoc(t, runPath, "id-1", evilName, api.Ready, os.Getpid())
+
+	for _, format := range []string{"", "wide"} {
+		var buf bytes.Buffer
+		if err := discovery.ScanAndPrintTerminals(ctx, logger, runPath, &buf, false, format); err != nil {
+			t.Fatalf("format %q: unexpected error: %v", format, err)
+		}
+		assertNoRawEscapes(t, "terminals "+format, buf.String())
+	}
+}
+
+func TestScanAndPrintClients_SanitizesName(t *testing.T) {
+	ctx := context.Background()
+	logger := discardLogger()
+	runPath := t.TempDir()
+	writeNamedClientDoc(t, runPath, "id-1", evilName, api.ClientReady, os.Getpid())
+
+	for _, format := range []string{"", "wide"} {
+		var buf bytes.Buffer
+		if err := discovery.ScanAndPrintClients(ctx, logger, runPath, &buf, false, format); err != nil {
+			t.Fatalf("format %q: unexpected error: %v", format, err)
+		}
+		assertNoRawEscapes(t, "clients "+format, buf.String())
+	}
+}
+
+func TestScanAndPrintProfiles_SanitizesName(t *testing.T) {
+	ctx := context.Background()
+	logger := discardLogger()
+	dir := t.TempDir()
+	// The double-quoted YAML scalar decodes / to the raw control
+	// bytes, mirroring a metadata.name an attacker authored on disk.
+	evilProfile := "apiVersion: sbsh/v1beta1\n" +
+		"kind: TerminalProfile\n" +
+		"metadata:\n" +
+		"  name: \"evil\\u001b]0;pwned\\u0007\\u001b[31m\\u001b[2J\"\n" +
+		"spec:\n" +
+		"  runTarget: local\n" +
+		"  shell:\n" +
+		"    cmd: /bin/bash\n"
+	writeProfileFile(t, dir, "evil.yaml", evilProfile)
+
+	for _, format := range []string{"", "wide"} {
+		var buf, warn bytes.Buffer
+		if err := discovery.ScanAndPrintProfiles(ctx, logger, dir, &buf, &warn, format); err != nil {
+			t.Fatalf("format %q: unexpected error: %v", format, err)
+		}
+		assertNoRawEscapes(t, "profiles "+format, buf.String())
+	}
+}
+
+// TestMachineReadableOutputKeepsRawName covers the AC counterpart: -o json and
+// -o yaml are not terminal-rendered, so they must carry the exact original name
+// byte-for-byte after a decode round-trip.
+func TestMachineReadableOutputKeepsRawName(t *testing.T) {
+	ctx := context.Background()
+	logger := discardLogger()
+	runPath := t.TempDir()
+	writeTerminalDoc(t, runPath, "id-1", evilName, api.Ready, os.Getpid())
+
+	t.Run("json", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := discovery.ScanAndPrintTerminals(ctx, logger, runPath, &buf, true, "json"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var docs []api.TerminalDoc
+		if err := json.Unmarshal(buf.Bytes(), &docs); err != nil {
+			t.Fatalf("decode json: %v", err)
+		}
+		if len(docs) != 1 || docs[0].Spec.Name != evilName {
+			t.Fatalf("json did not preserve the exact name; got %+v", docs)
+		}
+	})
+
+	t.Run("yaml", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := discovery.ScanAndPrintTerminals(ctx, logger, runPath, &buf, true, "yaml"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var docs []api.TerminalDoc
+		if err := yaml.Unmarshal(buf.Bytes(), &docs); err != nil {
+			t.Fatalf("decode yaml: %v", err)
+		}
+		if len(docs) != 1 || docs[0].Spec.Name != evilName {
+			t.Fatalf("yaml did not preserve the exact name; got %+v", docs)
+		}
+	})
+}

--- a/internal/discovery/profiles.go
+++ b/internal/discovery/profiles.go
@@ -123,13 +123,13 @@ func PrintProfilesTable(w io.Writer, profiles []api.TerminalProfileDoc, wide boo
 				envCount = len(p.Spec.Shell.Env)
 			}
 			fmt.Fprintf(tw, "%s\t%s\t%d vars\t%s\n",
-				p.Metadata.Name,
-				p.Spec.RunTarget,
+				sanitizeField(p.Metadata.Name),
+				sanitizeField(string(p.Spec.RunTarget)),
 				envCount,
-				cmd,
+				sanitizeField(cmd),
 			)
 		} else {
-			fmt.Fprintf(tw, "%s\t%s\n", p.Metadata.Name, cmd)
+			fmt.Fprintf(tw, "%s\t%s\n", sanitizeField(p.Metadata.Name), sanitizeField(cmd))
 		}
 	}
 

--- a/internal/discovery/sanitize.go
+++ b/internal/discovery/sanitize.go
@@ -1,0 +1,79 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package discovery
+
+import "strings"
+
+// sanitizeField neutralizes terminal control/escape bytes in an
+// externally-sourced string before it is written to the operator's terminal in
+// a human-readable listing. Names and commands originate from attacker-
+// controllable inputs (--name, profile metadata.name, any writer of
+// metadata.json under the run path), so a value carrying raw C0/C1 control
+// characters or ESC/CSI/OSC sequences would otherwise be rendered verbatim and
+// could spoof rows, hide entries, move the cursor, set the title bar, or clear
+// the screen of whoever runs `sb get`.
+//
+// Each control rune — C0 (0x00–0x1F), DEL (0x7F), and C1 (0x80–0x9F, which
+// includes the single-byte CSI/OSC introducers a UTF-8 terminal still
+// interprets) — is replaced with a printable \xNN escape. Escaping ESC (0x1B)
+// alone defangs every CSI/OSC sequence, since the trailing bytes are inert
+// printable characters once the introducer is gone. Tab and newline are escaped
+// too: they are the tabwriter column/row delimiters, so a raw one embedded in a
+// field would corrupt the table layout. Raw bytes that are not valid UTF-8 are
+// decoded by the range loop to the printable replacement rune (U+FFFD) and pass
+// through harmlessly.
+//
+// Machine-readable output (-o json / -o yaml) must NOT pass through this — those
+// renderings are not terminal-interpreted and callers rely on the exact original
+// bytes — so sanitization is applied only at the human-table print sites.
+func sanitizeField(s string) string {
+	if !needsSanitize(s) {
+		return s
+	}
+	const hex = "0123456789abcdef"
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if isControlRune(r) {
+			//nolint:mnd // 0x00..0x9F all fit in two hex digits
+			b.WriteString(`\x`)
+			b.WriteByte(hex[byte(r)>>4])
+			b.WriteByte(hex[byte(r)&0x0f])
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// needsSanitize reports whether s contains any control rune sanitizeField would
+// rewrite. The common case is a clean name, so this fast path lets sanitizeField
+// return the input unchanged without allocating a builder.
+func needsSanitize(s string) bool {
+	for _, r := range s {
+		if isControlRune(r) {
+			return true
+		}
+	}
+	return false
+}
+
+// isControlRune reports whether r is a C0 control (0x00–0x1F), DEL (0x7F), or a
+// C1 control (0x80–0x9F) — the runes a terminal may interpret as commands.
+func isControlRune(r rune) bool {
+	return r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f)
+}

--- a/internal/discovery/sanitize_test.go
+++ b/internal/discovery/sanitize_test.go
@@ -1,0 +1,58 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package discovery
+
+import "testing"
+
+func TestSanitizeField(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"clean ascii is untouched", "alpha-beta_1", "alpha-beta_1"},
+		{"unicode letters pass through", "café-Ω-名前", "café-Ω-名前"},
+		{"space is preserved", "two words", "two words"},
+		{"ESC is escaped", "evil\x1b[31mRED\x1b[0m", `evil\x1b[31mRED\x1b[0m`},
+		{"OSC title-set is defanged", "x\x1b]0;pwned\x07y", `x\x1b]0;pwned\x07y`},
+		{"clear-screen CSI is defanged", "a\x1b[2Jb", `a\x1b[2Jb`},
+		{"NUL is escaped", "a\x00b", `a\x00b`},
+		{"DEL is escaped", "a\x7fb", `a\x7fb`},
+		{"tab is escaped so the table cannot be split", "a\tb", `a\x09b`},
+		{"newline is escaped so rows cannot be forged", "a\nb", `a\x0ab`},
+		{"C1 CSI introducer is escaped", "am", `a\x9bm`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeField(tt.in); got != tt.want {
+				t.Fatalf("sanitizeField(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSanitizeFieldNeutralizesControlBytes is the security invariant: no output
+// of sanitizeField ever carries a raw control byte the terminal could act on.
+func TestSanitizeFieldNeutralizesControlBytes(t *testing.T) {
+	in := "name\x1b[31m\x1b]0;t\x07\x00\x7f"
+	got := sanitizeField(in)
+	for _, r := range got {
+		if isControlRune(r) {
+			t.Fatalf("sanitizeField left a raw control rune %#x in %q", r, got)
+		}
+	}
+}

--- a/internal/discovery/terminals.go
+++ b/internal/discovery/terminals.go
@@ -164,22 +164,22 @@ func printTerminals(w io.Writer, terminals []api.TerminalDoc, printAll, wide boo
 		}
 		if wide {
 			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-				pkgdiscovery.TerminalID(s),
-				pkgdiscovery.TerminalName(s),
-				terminalProfile(s),
-				terminalCmd(s),
-				terminalPty(s),
+				sanitizeField(pkgdiscovery.TerminalID(s)),
+				sanitizeField(pkgdiscovery.TerminalName(s)),
+				sanitizeField(terminalProfile(s)),
+				sanitizeField(terminalCmd(s)),
+				sanitizeField(terminalPty(s)),
 				s.Status.State.String(),
-				terminalAttachers(s),
+				sanitizeField(terminalAttachers(s)),
 				formatAge(s.Metadata.CreatedAt),
 				formatAge(s.Status.LastAttachedAt),
-				joinLabels(terminalLabels(s)),
+				sanitizeField(joinLabels(terminalLabels(s))),
 			)
 		} else {
 			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
-				pkgdiscovery.TerminalName(s),
-				terminalProfile(s),
-				terminalPty(s),
+				sanitizeField(pkgdiscovery.TerminalName(s)),
+				sanitizeField(terminalProfile(s)),
+				sanitizeField(terminalPty(s)),
 				formatAge(s.Metadata.CreatedAt),
 			)
 		}


### PR DESCRIPTION
## Summary

- `sb get terminals` / `get profiles` / `get clients` wrote name and command fields straight to the operator's terminal via `fmt.Fprintf("%s", …)`. Names originate from attacker-controllable inputs (`--name`, profile `metadata.name`, any writer of `metadata.json` under the run path), so a name carrying raw ANSI/OSC bytes was rendered verbatim — classic terminal-output injection (spoof rows, hide entries, move the cursor, set the title bar, clear the screen) against whoever runs `sb get`.
- New shared helper `sanitizeField` (`internal/discovery/sanitize.go`) replaces every C0 (0x00–0x1F), DEL (0x7F), and C1 (0x80–0x9F) control rune with a printable `\xNN` escape. Escaping the ESC introducer alone defangs every CSI/OSC sequence; tab/newline are escaped too since they are the tabwriter column/row delimiters and a raw one would corrupt the table.
- Applied at the human-table print sites in `internal/discovery/{terminals,profiles,clients}.go`, to **all** externally-sourced free-form fields rendered there (name, profile, command, pty, attachers, labels, id, run-target) — not only the two the AC names. The root cause is shared by every metadata-sourced string in the row, so a name-only fix would leave the same injection reachable through, e.g., a profile name or a label value. Enum-derived (`STATUS`) and numeric (`CREATED`/`ATTACHED`/`vars`) columns are left untouched.
- `-o json` / `-o yaml` paths are deliberately **not** sanitized — they are not terminal-interpreted and consumers rely on the exact original bytes.

### Scope note for the reviewer

The AC enumerates name + cmd; the diff sanitizes the full set of externally-sourced fields in the same rows (lower-blast-radius would be name-only, but that leaves the identical injection reachable via sibling fields, so the security-correct reading is to neutralize every metadata-sourced field at the print boundary). Push back if you'd prefer the narrower name+cmd-only scope.

## Test plan

- [x] `make test` — full CI suite green (cmd/sb, cmd/sbsh, internal/terminal, internal/client, `-tags=integration` cmd/sb/get, e2e)
- [x] `go build ./...`
- [x] `go vet ./internal/discovery/...`
- [x] `make sbsh-sb` — produces an ELF executable (verified `7f 45 4c 46` magic; `sbsh version` runs)
- [x] New `internal/discovery/sanitize_test.go` — unit-tests the helper (ESC/OSC/CSI/NUL/DEL/tab/newline/C1 all escaped; clean ASCII + Unicode untouched) and asserts no raw control rune survives.
- [x] New `internal/discovery/injection_test.go` — listing-level tests that an evil name (`\x1b]0;…\x07\x1b[31m\x1b[2J`) emits no raw control byte in the compact or wide views for terminals/profiles/clients, and that `-o json` / `-o yaml` preserve the exact original name through a decode round-trip.

## Acceptance criteria

- [x] Listing a terminal/profile/client whose name contains ESC/CSI/OSC bytes does not emit those bytes verbatim to the terminal in the compact or wide views.
- [x] `-o json` / `-o yaml` still carry the exact original name.
- [x] A test asserts control bytes are neutralized in the human-readable listing.

Closes #390
