### PR TITLE
fix: route terminal metadata accesses in SetupShell/PostAttachShell through metadataMu

### DIFF
--- a/internal/terminal/terminalrunner/lifecycle.go
+++ b/internal/terminal/terminalrunner/lifecycle.go
@@ -468,11 +468,21 @@ func (sr *Exec) SetupShell() error {
 	// 	sr.logger.Error("failed to send CTRL-L", "id", sr.id, "err", err)
 	// 	return fmt.Errorf("failed to send CTRL-L: %w", err)
 	// }
-	if sr.metadata.Spec.SetPrompt {
-		if sr.metadata.Spec.Prompt == "" {
-			sr.metadata.Spec.Prompt = "(sbsh-" + string(sr.metadata.Spec.ID) + ")"
-		}
-		promptCmd := `export PS1=` + sr.metadata.Spec.Prompt + "\n"
+	// Take metadataMu around the Spec.Prompt read-modify-write: an attaching
+	// client polls the State RPC (which copies sr.metadata under metadataMu)
+	// every ~50ms during setup, and an RLock'd reader does not exclude a
+	// lock-free writer. Snapshot the resolved prompt under the lock and write
+	// it to the PTY outside the critical section. See #388.
+	sr.metadataMu.Lock()
+	setPrompt := sr.metadata.Spec.SetPrompt
+	if setPrompt && sr.metadata.Spec.Prompt == "" {
+		sr.metadata.Spec.Prompt = "(sbsh-" + string(sr.metadata.Spec.ID) + ")"
+	}
+	prompt := sr.metadata.Spec.Prompt
+	sr.metadataMu.Unlock()
+
+	if setPrompt {
+		promptCmd := `export PS1=` + prompt + "\n"
 
 		sr.logger.Debug("setupShell: setting prompt", "cmd", promptCmd)
 		if _, err := sr.Write([]byte(promptCmd)); err != nil {
@@ -515,7 +525,7 @@ func (sr *Exec) writeStage(stage *[]api.ExecStep) error {
 func (sr *Exec) PostAttachShell() error {
 	sr.logger.Info("PostAttachShell: waiting for terminal to be ready", "id", sr.id)
 
-	for sr.metadata.Status.State != api.Ready {
+	for sr.currentState() != api.Ready {
 		select {
 		case <-sr.ctx.Done():
 			sr.logger.Error("PostAttachShell: context done", "id", sr.id)
@@ -538,7 +548,13 @@ func (sr *Exec) PostAttachShell() error {
 		sr.logger.Warn("PostAttachShell: state write failed, continuing", "id", sr.id, "err", err)
 	}
 
-	if err := sr.writeStage(&sr.metadata.Spec.Stages.PostAttach); err != nil {
+	// Snapshot the PostAttach stage slice under the read lock: SetupShell
+	// writes Spec.Prompt under metadataMu, so Spec is not immutable and a
+	// lock-free read here would not be excluded by that writer. See #388.
+	sr.metadataMu.RLock()
+	postAttachStages := sr.metadata.Spec.Stages.PostAttach
+	sr.metadataMu.RUnlock()
+	if err := sr.writeStage(&postAttachStages); err != nil {
 		return err
 	}
 

--- a/internal/terminal/terminalrunner/metadata.go
+++ b/internal/terminal/terminalrunner/metadata.go
@@ -264,6 +264,16 @@ func (sr *Exec) updateTerminalAttachers() error {
 	return nil
 }
 
+// currentState returns the current Status.State under the metadata read lock.
+// It gives PostAttachShell's readiness spin a locked accessor so it neither
+// reads Status.State while updateTerminalState writes it under metadataMu nor
+// relies on a lock-free read having acquire semantics. See #388.
+func (sr *Exec) currentState() api.TerminalStatusMode {
+	sr.metadataMu.RLock()
+	defer sr.metadataMu.RUnlock()
+	return sr.metadata.Status.State
+}
+
 func (sr *Exec) Metadata() (*api.TerminalDoc, error) {
 	sr.metadataMu.RLock()
 	defer sr.metadataMu.RUnlock()

--- a/internal/terminal/terminalrunner/metadata_lock_race_test.go
+++ b/internal/terminal/terminalrunner/metadata_lock_race_test.go
@@ -1,0 +1,113 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrunner
+
+import (
+	"io"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// TestSetupShell_StatePollRace reproduces issue #388 Pair B: an attaching
+// client polls the State RPC (which copies the whole sr.metadata struct under
+// metadataMu.RLock via Metadata()) while the controller goroutine runs
+// SetupShell, which read-modify-writes sr.metadata.Spec.Prompt. With the
+// pre-fix code the write is lock-free, so a -race build flags the unlocked
+// write against the RLock'd reader; the fix routes the write through
+// metadataMu. Prompt is reset to "" under the lock between iterations so the
+// resolve-default write fires every pass, widening the detection window.
+func TestSetupShell_StatePollRace(t *testing.T) {
+	sr := newWiredExec(t)
+	sr.metadata.Spec.SetPrompt = true
+
+	// Wire a drained pipe as the PTY so SetupShell's Write() neither nil-panics
+	// nor blocks on a full pipe buffer.
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = pr.Close()
+		_ = pw.Close()
+	})
+	go func() { _, _ = io.Copy(io.Discard, pr) }()
+	sr.ptmx = pw
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_, _ = sr.Metadata()
+			}
+		}
+	}()
+
+	const iterations = 50
+	for i := 0; i < iterations; i++ {
+		sr.metadataMu.Lock()
+		sr.metadata.Spec.Prompt = ""
+		sr.metadataMu.Unlock()
+		if err := sr.SetupShell(); err != nil {
+			t.Fatalf("SetupShell: %v", err)
+		}
+	}
+
+	close(stop)
+	wg.Wait()
+}
+
+// TestPostAttachShell_OverlappingAttachesRace reproduces issue #388 Pair A: two
+// clients attach concurrently, so two PostAttachShell calls run on separate
+// goroutines. One advances Status.State through updateTerminalState (a locked
+// write) while the other spin-reads Status.State at the readiness loop. With
+// the pre-fix code that spin-read was lock-free, so a -race build flags it
+// against the locked write; the fix reads via the state() accessor. The
+// terminal is seeded Ready (as OnInitShell leaves it before attaches arrive),
+// and each PostAttachShell cycles it back through PostAttach -> Ready, so the
+// two goroutines drive interleaved unlocked reads and locked writes.
+func TestPostAttachShell_OverlappingAttachesRace(t *testing.T) {
+	sr := newWiredExec(t)
+	sr.metadata.Status.State = api.Ready
+
+	const (
+		attachers  = 2
+		iterations = 200
+	)
+	var wg sync.WaitGroup
+	for g := 0; g < attachers; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				if err := sr.PostAttachShell(); err != nil {
+					t.Errorf("PostAttachShell: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

- `SetupShell` read-modify-wrote `sr.metadata.Spec.Prompt` with **no lock held** (`lifecycle.go:471-475`), while an attaching client polls the `State` RPC every ~50ms — which copies the whole `sr.metadata` struct under `metadataMu.RLock` via `Metadata()`. An `RLock`'d reader does not exclude a lock-free writer, so this is a genuine data race in the normal single-client flow (issue Pair B).
- `PostAttachShell` spin-read `sr.metadata.Status.State` unlocked (`lifecycle.go:518`) while `updateTerminalState` writes the same field under `metadataMu.Lock` — racy under two overlapping attaches, and with no acquire semantics observing `Ready` wasn't guaranteed (issue Pair A).
- Fix: take `metadataMu.Lock` around the `Spec.Prompt` read-modify-write in `SetupShell` (snapshot the resolved prompt, write to the PTY outside the critical section); add a small `currentState()` read-locked accessor and use it for `PostAttachShell`'s readiness spin. Also snapshot `Spec.Stages.PostAttach` under `RLock` before `writeStage`, since `SetupShell`'s `Spec.Prompt` write means `Spec` is not immutable — so AC #1's "no unlocked reads or writes" holds for the whole of both functions.

Note: the accessor is named `currentState()` rather than the issue's suggested `state()` because `Exec` already has a `state api.TerminalState` field (a different type from `Status.State`'s `api.TerminalStatusMode`); a method named `state` collides with the field.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] New `-race` tests in `metadata_lock_race_test.go`:
  - `TestSetupShell_StatePollRace` — polls `Metadata()` concurrently with `SetupShell` (Pair B)
  - `TestPostAttachShell_OverlappingAttachesRace` — two goroutines drive interleaved `PostAttachShell` readiness spins and `updateTerminalState` writes (Pair A)
- [x] **Demonstrated the tests fail on pre-fix code** — stashed the production fix and re-ran under `-race`: both fail with the exact races the issue named (`lifecycle.go:473` write vs `metadata.go:271` `Metadata()` read; `lifecycle.go:518` read vs `metadata.go:239` `updateTerminalState` write).
- [x] `make test` — pass (incl. e2e)
- [x] `make test-race` — pass (all packages clean)

## Acceptance criteria

- [x] No unlocked reads or writes of `sr.metadata` remain in `lifecycle.go` (`SetupShell`, `PostAttachShell`).
- [x] A `-race` test that polls the `State` RPC concurrently with terminal setup, and one that overlaps two attaches, both pass clean.
- [x] The new tests fail on the current code (demonstrated via stash + `-race`).

Closes #388