### PR TITLE
fix: synchronize terminal startup fields against Stop-during-startup Close and close orphaned-child hole

### DIFF
--- a/internal/terminal/terminalrunner/lifecycle.go
+++ b/internal/terminal/terminalrunner/lifecycle.go
@@ -170,7 +170,13 @@ func (sr *Exec) watchChildExit() {
 // Grace <= 0 falls back to the package default. Must only be called after
 // startPty has run (cmd and cmd.Process are set).
 func (sr *Exec) shutdownChild(grace time.Duration) {
-	if sr.cmd == nil || sr.cmd.Process == nil {
+	// Snapshot cmd under runtimeMu: a concurrent startPty publishes it (and
+	// its Process) under the same lock, so this read is otherwise a data
+	// race against a Stop-during-startup Close. See #396.
+	sr.runtimeMu.Lock()
+	cmd := sr.cmd
+	sr.runtimeMu.Unlock()
+	if cmd == nil || cmd.Process == nil {
 		return
 	}
 	if sr.childDone() {
@@ -180,7 +186,7 @@ func (sr *Exec) shutdownChild(grace time.Duration) {
 		grace = profile.DefaultShutdownGrace
 	}
 
-	pid := sr.cmd.Process.Pid
+	pid := cmd.Process.Pid
 	// Setsid: true ensures pgid == pid for the child.
 	if err := syscall.Kill(-pid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
 		sr.logger.Warn("could not SIGTERM child process group", "id", sr.id, "pid", pid, "err", err)
@@ -216,6 +222,16 @@ func (sr *Exec) Close(reason error) error {
 		}
 	}
 
+	// Latch `closing` before the graceful child shutdown so a startPty
+	// racing this Close (Stop RPC during startup) observes it under
+	// runtimeMu and aborts before cmd.Start. This closes the orphaned-child
+	// hole: a child forked after shutdownChild's early return (cmd.Process
+	// still nil) would never be signalled, since cmd.Cancel is a deliberate
+	// no-op and Close has already passed its only kill site. See #396.
+	sr.runtimeMu.Lock()
+	sr.closing = true
+	sr.runtimeMu.Unlock()
+
 	// Graceful shutdown of the child before tearing anything else down:
 	// SIGTERM -> wait up to ShutdownGrace -> SIGKILL. This runs regardless
 	// of PID-1 status; removing the always-hard-kill default is correct in
@@ -226,10 +242,14 @@ func (sr *Exec) Close(reason error) error {
 
 	sr.logger.Debug("terminal closed", "id", sr.id)
 
-	// Tear down PID-1 helpers (no-ops outside init mode).
-	if sr.stopSignalForwarder != nil {
-		sr.stopSignalForwarder()
-		sr.stopSignalForwarder = nil
+	// Tear down PID-1 helpers (no-ops outside init mode). Read/clear under
+	// runtimeMu: startPty publishes stopSignalForwarder concurrently. See #396.
+	sr.runtimeMu.Lock()
+	stopForwarder := sr.stopSignalForwarder
+	sr.stopSignalForwarder = nil
+	sr.runtimeMu.Unlock()
+	if stopForwarder != nil {
+		stopForwarder()
 	}
 	if sr.reaper != nil {
 		sr.reaper.Stop()
@@ -284,10 +304,16 @@ func (sr *Exec) Close(reason error) error {
 	// close all output subscribers
 	sr.closeAllSubscribers()
 
-	if sr.ptmx != nil {
+	// Snapshot ptmx under runtimeMu: startPty publishes it concurrently. The
+	// closePTY sync.Once still serializes the actual close against the
+	// terminalManager goroutines' own ctx-cancel close. See #396.
+	sr.runtimeMu.Lock()
+	ptmx := sr.ptmx
+	sr.runtimeMu.Unlock()
+	if ptmx != nil {
 		var err error
 		sr.closePTY.Do(func() {
-			err = sr.ptmx.Close()
+			err = ptmx.Close()
 		})
 		if err != nil {
 			sr.logger.Warn("could not close pty", "id", sr.id, "err", err)
@@ -298,9 +324,14 @@ func (sr *Exec) Close(reason error) error {
 	// and ptmx teardown so the PTY reader has stopped writing to multiOutW
 	// (which holds the rotating capture writer as its always-on sink).
 	// closeCapture guards against double-Close per #229's idempotency AC.
-	if sr.capture != nil && sr.closeCapture != nil {
+	// Snapshot capture under runtimeMu: startPty publishes it concurrently.
+	// closeCapture guards against double-Close per #229's idempotency AC.
+	sr.runtimeMu.Lock()
+	capture := sr.capture
+	sr.runtimeMu.Unlock()
+	if capture != nil && sr.closeCapture != nil {
 		sr.closeCapture.Do(func() {
-			if err := sr.capture.Close(); err != nil {
+			if err := capture.Close(); err != nil {
 				sr.logger.Warn("could not close capture file", "id", sr.id, "err", err)
 			}
 		})

--- a/internal/terminal/terminalrunner/lifecycle_startup_close_race_test.go
+++ b/internal/terminal/terminalrunner/lifecycle_startup_close_race_test.go
@@ -1,0 +1,178 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrunner
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// childPID reads the started child's PID under runtimeMu. Returns 0 when no
+// child was forked (startup aborted, or never reached cmd.Start). Safe to call
+// after the StartTerminal/Close goroutines have joined: nothing writes sr.cmd
+// or cmd.Process at that point in non-init mode.
+func childPID(sr *Exec) int {
+	sr.runtimeMu.Lock()
+	defer sr.runtimeMu.Unlock()
+	if sr.cmd == nil || sr.cmd.Process == nil {
+		return 0
+	}
+	return sr.cmd.Process.Pid
+}
+
+// assertPgroupReaped polls syscall.Kill(-pid, 0) until the child's process
+// group is gone (ESRCH) or the deadline expires. Setsid in
+// prepareTerminalCommand makes pgid == pid, so -pid targets the whole group.
+func assertPgroupReaped(t *testing.T, pid int, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for {
+		err := syscall.Kill(-pid, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			return // no process left in the group
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("child process group %d survived Close (Kill(-%d,0)=%v); orphaned child", pid, pid, err)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// TestStartTerminal_StopDuringStartup_NoRace is the AC1 regression for #396.
+//
+// A Stop RPC during startup runs Close on its own goroutine (controller.go's
+// Stop -> go c.Close) while StartTerminal is still inside
+// prepareTerminalCommand/startPty. Pre-fix the two goroutines touched
+// sr.cmd / sr.ptmx / sr.capture / sr.stopSignalForwarder with no
+// synchronization, and `go test -race` flagged the write/read pairs. This
+// drives the exact interleaving across a swept startup window; the value is in
+// the race detector staying silent (and no panic).
+func TestStartTerminal_StopDuringStartup_NoRace(t *testing.T) {
+	const iterations = 24
+	for i := range iterations {
+		// Sweep the close timing across the startup window: cmd.Start, the
+		// PTY wiring, and the capture/metadata steps each take on the order
+		// of tens of microseconds, so a staggered delay lands Close at a
+		// different point in prepareTerminalCommand/startPty each iteration.
+		stagger := time.Duration(i) * 20 * time.Microsecond
+
+		spec := newLiveSpec(t, "/bin/cat") // idles on the PTY, dies on SIGTERM
+		spec.EnvInherit = true
+		sr := NewTerminalRunnerExec(context.Background(), newDiscardLogger(), spec).(*Exec)
+		if err := sr.CreateMetadata(); err != nil {
+			t.Fatalf("CreateMetadata: %v", err)
+		}
+
+		evCh := make(chan Event, 8)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = sr.StartTerminal(evCh) // may fail when Close wins the race; fine
+		}()
+		go func() {
+			defer wg.Done()
+			time.Sleep(stagger)
+			_ = sr.Close(nil)
+		}()
+		wg.Wait()
+
+		// Whatever the interleaving, a forked child must not survive Close.
+		if pid := childPID(sr); pid > 0 {
+			assertPgroupReaped(t, pid, 3*time.Second)
+		}
+	}
+}
+
+// TestStartPty_AbortsWhenClosing_NoOrphanFork is the deterministic AC2 proof
+// for #396: once Close has latched `closing`, startPty must not fork a child.
+//
+// Pre-fix, shutdownChild returned early while cmd.Process was still nil, Close
+// passed its only kill site, and a cmd.Start that then won the race forked a
+// child nothing would ever signal (cmd.Cancel is a no-op). The `closing`
+// latch, checked under runtimeMu in the same critical section as cmd.Start,
+// closes that window: startPty aborts before the fork.
+func TestStartPty_AbortsWhenClosing_NoOrphanFork(t *testing.T) {
+	spec := newLiveSpec(t, "/bin/cat")
+	spec.EnvInherit = true
+	sr := NewTerminalRunnerExec(context.Background(), newDiscardLogger(), spec).(*Exec)
+	if err := sr.CreateMetadata(); err != nil {
+		t.Fatalf("CreateMetadata: %v", err)
+	}
+
+	// Stage the cmd as StartTerminal would, then simulate Close having
+	// latched `closing` before startPty reaches its fork critical section.
+	if err := sr.prepareTerminalCommand(); err != nil {
+		t.Fatalf("prepareTerminalCommand: %v", err)
+	}
+	sr.runtimeMu.Lock()
+	sr.closing = true
+	sr.runtimeMu.Unlock()
+
+	if err := sr.startPty(); err == nil {
+		t.Fatal("startPty should abort once closing is latched, but returned nil")
+	}
+	if pid := childPID(sr); pid != 0 {
+		t.Fatalf("startPty forked a child (pid %d) despite closing being latched; orphan hole", pid)
+	}
+}
+
+// TestStartTerminal_StopDuringStartup_SignalIgnoringChildAlwaysDies is the
+// end-to-end AC2 regression for #396 with a child that ignores SIGTERM and
+// SIGHUP. Whether startPty aborts (no child) or forks before Close observes
+// it, no process may survive once Close returns: the graceful sweep escalates
+// SIGTERM -> SIGKILL on the child's process group, and SIGKILL is uncatchable.
+func TestStartTerminal_StopDuringStartup_SignalIgnoringChildAlwaysDies(t *testing.T) {
+	const iterations = 16
+	for i := range iterations {
+		stagger := time.Duration(i) * 25 * time.Microsecond
+
+		// trap '' TERM HUP installs an "ignore" disposition for both
+		// signals; only SIGKILL takes the process down. The bare `sleep`
+		// loop keeps it alive and in the foreground PTY pgroup.
+		spec := newLiveSpec(t, "/bin/sh", "-c", `trap '' TERM HUP INT; while :; do sleep 0.05; done`)
+		spec.EnvInherit = true
+		spec.ShutdownGrace = 150 * time.Millisecond
+		sr := NewTerminalRunnerExec(context.Background(), newDiscardLogger(), spec).(*Exec)
+		if err := sr.CreateMetadata(); err != nil {
+			t.Fatalf("CreateMetadata: %v", err)
+		}
+
+		evCh := make(chan Event, 8)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = sr.StartTerminal(evCh)
+		}()
+		go func() {
+			defer wg.Done()
+			time.Sleep(stagger)
+			_ = sr.Close(nil)
+		}()
+		wg.Wait()
+
+		if pid := childPID(sr); pid > 0 {
+			// grace (150ms) + SIGKILL propagation + reaping margin.
+			assertPgroupReaped(t, pid, 3*time.Second)
+		}
+	}
+}

--- a/internal/terminal/terminalrunner/terminal.go
+++ b/internal/terminal/terminalrunner/terminal.go
@@ -107,7 +107,11 @@ func (sr *Exec) prepareTerminalCommand() error {
 		cmd.Env = append(cmd.Env, "TERM=xterm-256color", "COLORTERM=truecolor")
 	}
 
+	// Publish under runtimeMu: a Stop RPC during startup runs Close on
+	// another goroutine, which reads sr.cmd in shutdownChild. See #396.
+	sr.runtimeMu.Lock()
 	sr.cmd = cmd
+	sr.runtimeMu.Unlock()
 
 	return nil
 }
@@ -139,6 +143,22 @@ func (sr *Exec) startPty() error {
 		return fmt.Errorf("error opening pty: %w", errOpen)
 	}
 
+	// Publish the PTY handles and fork the child under runtimeMu so a
+	// concurrent Close (Stop RPC -> go c.Close during startup) observes a
+	// consistent snapshot and can never miss a child we are about to fork.
+	// If Close has already latched `closing`, abort before cmd.Start so the
+	// child is never created — otherwise Close, serialized behind us on
+	// runtimeMu, sees cmd.Process once we publish it and shuts it down
+	// gracefully. cmd.Cancel is a deliberate no-op, so a child forked after
+	// Close passed its only kill site would otherwise be orphaned. See #396.
+	sr.runtimeMu.Lock()
+	if sr.closing {
+		sr.runtimeMu.Unlock()
+		_ = ptmx.Close()
+		_ = pts.Close()
+		return errors.New("terminal is closing; aborting PTY start")
+	}
+
 	sr.ptmx = ptmx
 	sr.pts = pts
 
@@ -147,6 +167,7 @@ func (sr *Exec) startPty() error {
 	sr.cmd.Stderr = sr.pts
 
 	errStart := sr.cmd.Start()
+	sr.runtimeMu.Unlock()
 	if errStart != nil {
 		return fmt.Errorf("error starting command in pty: %w", errStart)
 	}
@@ -179,7 +200,11 @@ func (sr *Exec) startPty() error {
 
 	if sr.initMode && sr.reaper != nil {
 		sr.reaper.RegisterChild(sr.cmd.Process.Pid)
-		sr.stopSignalForwarder = startSignalForwarder(sr.logger, sr.cmd.Process.Pid)
+		forwarder := startSignalForwarder(sr.logger, sr.cmd.Process.Pid)
+		// Publish under runtimeMu: Close reads stopSignalForwarder. See #396.
+		sr.runtimeMu.Lock()
+		sr.stopSignalForwarder = forwarder
+		sr.runtimeMu.Unlock()
 	}
 
 	go sr.watchChildExit()
@@ -217,7 +242,12 @@ func (sr *Exec) startPty() error {
 	// so in-flight multiOutW.Write has settled. See #229. Error returns
 	// after this assignment must close the fd via closeCapture so the
 	// idempotency contract holds whether Close runs or not (see #241).
+	// Publish under runtimeMu: Close reads sr.capture during teardown. See
+	// #396. Subsequent reads of sr.capture below run on this same startup
+	// goroutine (after the write), so they need no further locking.
+	sr.runtimeMu.Lock()
 	sr.capture = capWriter
+	sr.runtimeMu.Unlock()
 
 	if errU := sr.updateMetadata(); errU != nil {
 		sr.closeCapture.Do(func() { _ = sr.capture.Close() })

--- a/internal/terminal/terminalrunner/terminal_runner_exec.go
+++ b/internal/terminal/terminalrunner/terminal_runner_exec.go
@@ -54,6 +54,25 @@ type Exec struct {
 	pts   *os.File // slave
 	state api.TerminalState
 
+	// runtimeMu guards the runtime fields published during StartTerminal
+	// (cmd, ptmx, pts, capture, stopSignalForwarder) against the concurrent
+	// reads in Close. A Stop RPC arriving during startup runs Close on its
+	// own goroutine (controller.go's Stop -> go c.Close), so the RPC server
+	// is answering before StartTerminal completes and Close can interleave
+	// anywhere inside prepareTerminalCommand/startPty. Without this mutex
+	// `go test -race` flags those write/read pairs immediately. See #396.
+	//
+	// closing is the orphan-prevention latch: Close sets it under
+	// runtimeMu before its graceful child-shutdown sweep, and startPty
+	// checks it under the same lock in the critical section that forks the
+	// child (cmd.Start). Either startPty observes closing and aborts before
+	// the fork, or it has already published cmd.Process for Close to shut
+	// down — never both miss. This closes the hole where a child forked
+	// after shutdownChild's early return would never be signalled, since
+	// cmd.Cancel is a deliberate no-op (terminal.go). See #396.
+	runtimeMu sync.Mutex
+	closing   bool
+
 	gates struct {
 		StdinOpen bool
 		OutputOn  bool


### PR DESCRIPTION
## Summary

A `Stop` RPC during terminal startup runs `Exec.Close` on its own goroutine (`controller.go:352-363`'s `Stop` → `go c.Close`) while `StartTerminal` is still inside `prepareTerminalCommand`/`startPty`. The RPC server is answering before `StartTerminal` runs (`controller.go:148-155`), so `Close` can interleave anywhere in the startup path. Two defects fall out of that, both fixed here (#396):

1. **Unsynchronized runtime fields.** `Close` read `sr.cmd` / `sr.ptmx` / `sr.capture` / `sr.stopSignalForwarder` while the startup path wrote them, with no lock — `go test -race` flagged the write/read pairs.
2. **Orphaned-child hole.** If `shutdownChild` ran while `cmd.Process` was still nil it returned early, `Close` then called `ctxCancel` and passed its only kill site, and a `cmd.Start` that won the race forked a child nothing would ever signal (`cmd.Cancel` is a deliberate no-op). A SIGHUP/SIGTERM-ignoring child was then orphaned indefinitely.

### Fix

- Added `runtimeMu sync.Mutex` guarding the runtime fields published during startup (`cmd`, `ptmx`, `pts`, `capture`, `stopSignalForwarder`). The startup writes and `Close`'s reads now both take it, so `Close` reads a consistent snapshot. Reads on the startup goroutine itself, and reads in goroutines started *after* a field's publish (`watchChildExit`, `terminalManager*`), need no lock — the `go` statement is already a happens-before edge, so only the cross-goroutine `Close` reads were racing.
- Closed the orphan hole with a `closing` latch (chosen over re-arming `cmd.Cancel`, which would have SIGKILLed a SIGTERM-respecting child on any parent-ctx cancellation and regressed graceful shutdown). `Close` sets `closing` under `runtimeMu` before its graceful sweep; `startPty` checks it under the same lock in the *same critical section* that runs `cmd.Start`. Either `startPty` observes `closing` and aborts before the fork, or it has already published `cmd.Process` for `Close`'s `shutdownChild` to SIGTERM→SIGKILL — there is no interleaving where a child exists but neither path sees it. The pre-existing graceful path is unchanged: `shutdownChild` completes fully before `ctxCancel`.

## Test plan

- [x] `make test-race` — green (AC item 3); the named `internal/terminal/...` package included.
- [x] `make test` — full CI suite green, including `./e2e`.
- [x] `go build ./...`, `go vet ./...`, `make sbsh-sb` (verified ELF) — all clean.
- [x] New `lifecycle_startup_close_race_test.go`, run under `-race`:
  - `TestStartTerminal_StopDuringStartup_NoRace` — sweeps the close timing across the startup window with a real PTY + `/bin/cat` child; race detector stays silent (AC item 1).
  - `TestStartPty_AbortsWhenClosing_NoOrphanFork` — deterministic proof the `closing` latch makes `startPty` abort before forking (AC item 2).
  - `TestStartTerminal_StopDuringStartup_SignalIgnoringChildAlwaysDies` — swept interleaving with a `trap '' TERM HUP INT` child; asserts no process in the child's group survives `Close` (AC item 2, uncatchable-signal case).

These are real instrumented tests exercising the runtime path (live goroutines, fork, PTY) under `-race`, not pure-function unit tests. The pre-fix `-race` failure is documented in the issue (8 DATA RACE reports); these tests are the positive confirmation the path is now clean.

## Acceptance criteria

- [x] `go test -race` with a Stop-during-startup interleaving test reports no races on `sr.cmd`/`sr.ptmx`/`sr.capture`/`sr.stopSignalForwarder`.
- [x] A child forked concurrently with `Close` is always terminated (no surviving process after `Close` returns, even for a SIGHUP/SIGTERM-ignoring child).
- [x] `make test-race` stays green.

## Notes for the reviewer

- The suggested-fix menu offered two options for the orphan hole; I took the `closing`-latch route (option a) rather than re-arming `cmd.Cancel` (option b). Re-arming `cmd.Cancel` to kill the process group fires the os/exec watchdog on *any* `sr.ctx` cancellation — including a parent-context cancellation during normal daemon shutdown — which would SIGKILL a SIGTERM-respecting child and bypass the graceful `shutdownChild` sequence. The latch is surgical to the startup race and leaves graceful shutdown intact.

Closes #396