### PR TITLE
fix: guard Attach against nil multiOutW before startPty publishes ptyPipes

### DIFF
--- a/internal/terminal/terminalrunner/lifecycle.go
+++ b/internal/terminal/terminalrunner/lifecycle.go
@@ -379,6 +379,22 @@ func (sr *Exec) Write(p []byte) (int, error) {
 }
 
 func (sr *Exec) Attach(req *api.AttachRequest, response *api.ResponseWithFD) error {
+	// Reject an Attach that lands in the window between the control RPC
+	// server becoming ready and startPty publishing ptyPipes. multiOutW
+	// (and pipeInW) are published together at terminal.go's
+	// ptyPipes.multiOutW assignment, so a nil multiOutW means the PTY
+	// fan-out is not wired yet. Without this guard handleClient would call
+	// multiOutW.Add on a nil *DynamicMultiWriter and panic on a bare
+	// goroutine with no recover, killing the daemon. Failing here surfaces
+	// a clean RPC error to the caller and avoids allocating the socketpair
+	// at all. Mirrors the sibling Subscribe guard (subscribe.go). See #395.
+	sr.ptyPipesMu.RLock()
+	multiOutW := sr.ptyPipes.multiOutW
+	sr.ptyPipesMu.RUnlock()
+	if multiOutW == nil {
+		return fmt.Errorf("Attach: terminal not running")
+	}
+
 	cliFD, err := sr.CreateNewClient(&req.ClientID, req.FullCapture)
 	if err != nil {
 		return err

--- a/internal/terminal/terminalrunner/socket_rpc_cluster_test.go
+++ b/internal/terminal/terminalrunner/socket_rpc_cluster_test.go
@@ -423,6 +423,35 @@ func TestSubscribe_NotRunning(t *testing.T) {
 	}
 }
 
+// Attach rejects the attach when the PTY fan-out is not wired (an Attach RPC
+// that lands before startPty publishes ptyPipes) and returns a clean
+// "terminal not running" error instead of panicking the daemon on a bare
+// handleClient goroutine. Same shape as TestSubscribe_NotRunning. See #395.
+func TestAttach_NotRunning(t *testing.T) {
+	sr := newWiredExec(t)
+	// Clear the fan-out so Attach's "terminal not running" guard fires —
+	// exactly the pre-startPty state (ptyPipes published but multiOutW nil).
+	sr.ptyPipesMu.Lock()
+	sr.ptyPipes.multiOutW = nil
+	sr.ptyPipesMu.Unlock()
+
+	var resp api.ResponseWithFD
+	err := sr.Attach(&api.AttachRequest{ClientID: api.ID("att-1")}, &resp)
+	if err == nil {
+		t.Fatal("Attach with nil multiOutW returned nil; want terminal-not-running error")
+	}
+	if len(resp.FDs) != 0 {
+		t.Errorf("Attach returned FDs on the not-running path: %v", resp.FDs)
+	}
+	// No client should have been registered (socketpair never allocated).
+	sr.clientsMu.RLock()
+	n := len(sr.clients)
+	sr.clientsMu.RUnlock()
+	if n != 0 {
+		t.Errorf("Attach registered %d clients on the not-running path; want 0", n)
+	}
+}
+
 // Subscribe's early-shutdown guard rejects a registration that arrives after
 // the runner's context has been canceled, returning errTerminalClosing and
 // registering no subscriber.


### PR DESCRIPTION
## Summary

- An `Attach` RPC that arrives in the window between the control RPC server becoming ready and `startPty` publishing `ptyPipes` previously called `multiOutW.Add(aw)` on a **nil** `*DynamicMultiWriter`. `Add` dereferences `dmw.logger`, and because `handleClient` runs on a bare goroutine spawned by `CreateNewClient` with no `recover`, the nil-pointer panic killed the entire terminal daemon.
- This mirrors the sibling `Subscribe` guard (`subscribe.go:95-102`): `Attach` now snapshots `multiOutW` under `ptyPipesMu` and returns `"Attach: terminal not running"` when it is nil. Failing in `Attach` (the issue's preferred location) surfaces a deterministic RPC error to the caller and avoids allocating the socketpair at all — `CreateNewClient` is the sole consumer, so the bare goroutine is never spawned.
- `multiOutW` and `pipeInW` are published together under the same lock at `terminal.go:248-253`, so the single `multiOutW == nil` check is the canonical "not wired yet" gate — same field the existing `Subscribe`, `cleanupClient`, and `Close` guards already nil-check.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./internal/terminal/terminalrunner/...` — clean
- [x] `make test-race` — green (exit 0)
- [x] `make sbsh-sb` — produces an ELF executable (verified magic bytes `7f 45 4c 46`)
- [x] New regression test `TestAttach_NotRunning` — drives `Attach` with `multiOutW` nilled (the pre-`startPty` state), asserts a clean error, no FDs returned, and no client registered. Same shape as the existing `TestSubscribe_NotRunning`.

## Acceptance criteria

- [x] An `Attach` RPC issued before `StartTerminal` completes returns a clean RPC error ("terminal not running" shape) instead of panicking the daemon.
- [x] A regression test covers Attach-before-startPty (same shape as the existing `Subscribe` nil-`multiOutW` coverage).
- [x] `make test-race` stays green.

Closes #395