### PR TITLE
fix: guard nil logger on sb config-error path when --verbose is off

### DIFF
--- a/cmd/sb/sb.go
+++ b/cmd/sb/sb.go
@@ -88,7 +88,9 @@ You can see available options and commands with:
 
 			err := LoadConfig()
 			if err != nil {
-				logger.DebugContext(cmd.Context(), "config error", "error", err)
+				if logger != nil {
+					logger.DebugContext(cmd.Context(), "config error", "error", err)
+				}
 				return fmt.Errorf("%w: %w", errdefs.ErrConfig, err)
 			}
 			return nil

--- a/cmd/sb/sb_coverage_test.go
+++ b/cmd/sb/sb_coverage_test.go
@@ -125,6 +125,34 @@ func Test_PersistentPreRunE_Verbose_ConfigError(t *testing.T) {
 	}
 }
 
+func Test_PersistentPreRunE_NonVerbose_ConfigError(t *testing.T) {
+	t.Cleanup(viper.Reset)
+	viper.Reset()
+
+	bad := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(bad, []byte("\tnot: [valid yaml"), 0o600); err != nil {
+		t.Fatalf("write bad config: %v", err)
+	}
+	t.Setenv(config.SBSH_ROOT_CONFIG_FILE.EnvVar(), bad)
+	_ = config.SBSH_ROOT_CONFIG_FILE.BindEnv()
+	viper.Set(config.SB_ROOT_VERBOSE.ViperKey, false)
+
+	cmd, err := NewSbRootCmd()
+	if err != nil {
+		t.Fatalf("NewSbRootCmd() error = %v", err)
+	}
+	cmd.SetContext(context.Background())
+
+	// With --verbose off the logger is nil; the error path must not panic.
+	err = cmd.PersistentPreRunE(cmd, nil)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+	if !errors.Is(err, errdefs.ErrConfig) {
+		t.Fatalf("expected '%v'; got: '%v'", errdefs.ErrConfig, err)
+	}
+}
+
 func Test_RunE_LoggerNotFound(t *testing.T) {
 	t.Cleanup(viper.Reset)
 


### PR DESCRIPTION
## Summary

- `sb`'s root `PersistentPreRunE` only assigned `logger` inside the `if verbose` branch, but the config-error branch (`cmd/sb/sb.go:91`) dereferenced it unconditionally — so a malformed `config.yaml` with `--verbose` off triggered a nil-pointer panic (SIGSEGV, full stack trace, exit 2) instead of the intended `config error` message.
- Fix: guard the `logger.DebugContext` call with `if logger != nil`. This is the lowest-blast-radius option of the three suggested in the issue — the debug log still fires when verbose is on (logger set) and is skipped when off, leaving the verbose path byte-for-byte unchanged.

## Test plan

- [x] `make test` — full CI suite (cmd/sb, cmd/sbsh, internal/terminal, internal/client, integration get, e2e) all pass.
- [x] `go vet ./cmd/...` clean.
- [x] Manual repro from the issue (`make sbsh-sb`; malformed config + `HOME` override): `--verbose` off now prints `Error: config error: ...` and exits 1, no panic; `-v` on prints the same clean error and exits 1. Both modes verified.
- [x] New `Test_PersistentPreRunE_NonVerbose_ConfigError` exercises the malformed-config + no-verbose path and asserts no panic (returns `errdefs.ErrConfig`).

## Acceptance criteria

- [x] Malformed `config.yaml` with `--verbose` off prints a clean `config error` and exits non-zero (no panic, no stack trace).
- [x] Behavior with `--verbose` on is unchanged.
- [x] A test exercises the malformed-config + no-verbose path for `sb` and asserts no panic.

Closes #387