### PR TITLE
fix: clean SIGTERM to attached client exits 0, no spurious context-cancelled error

### DIFF
--- a/cmd/sbsh/sbsh.go
+++ b/cmd/sbsh/sbsh.go
@@ -510,17 +510,22 @@ func runClient(
 	logger.DebugContext(ctx, "controller ready, entering client event loop")
 	select {
 	case <-ctx.Done():
-		var err error
 		logger.DebugContext(ctx, "context canceled, waiting for controller to exit")
+		// ctx is signal.NotifyContext(...), so ctx.Err() is context.Canceled
+		// on a SIGTERM/SIGINT. Route it through the same isCleanSessionEnd
+		// filter the errCh arm uses so a handled signal exits 0 with no
+		// spurious `Error: context has been cancelled` line — matching the
+		// clean-session-end contract from #380/#381. A real WaitClose failure
+		// during teardown is not clean and still surfaces.
+		err := ctx.Err()
 		if errC := ctrl.WaitClose(); errC != nil {
 			err = fmt.Errorf("%w: %w", errdefs.ErrWaitOnClose, errC)
 		}
 		logger.DebugContext(ctx, "context canceled, controller exited")
-		if err != nil {
+		if err != nil && !isCleanSessionEnd(err) {
 			return fmt.Errorf("%w: %w", errdefs.ErrContextDone, err)
 		}
-		// return fmt.Errorf("%w: %w", errdefs.ErrContextDone, err)
-		return errdefs.ErrContextDone
+		return nil
 
 	case err := <-errCh:
 		logger.DebugContext(ctx, "controller stopped", "error", err)

--- a/internal/client/controller.go
+++ b/internal/client/controller.go
@@ -297,6 +297,18 @@ func (s *Controller) Run(doc *api.ClientDoc) error {
 			s.handleEvent(ev)
 
 		case errRPC := <-s.rpcDoneCh:
+			// The accept loop delivers nil on ctx-cancel (a graceful RPC
+			// server exit); wrapping it with %w would render
+			// `rpc server exited: %!w(<nil>)`. Mirror the nil-aware branch
+			// in internal/terminal/controller.go.
+			if errRPC == nil {
+				s.logger.Info("rpc server exited gracefully")
+				if errC := s.Close(nil); errC != nil {
+					s.logger.Error("error during Close after rpc server graceful exit", "error", errC)
+					return fmt.Errorf("%w: %w", errdefs.ErrRPCServerExited, errC)
+				}
+				return errdefs.ErrRPCServerExited
+			}
 			s.logger.Error("rpc server exited", "error", errRPC)
 			if errC := s.Close(errRPC); errC != nil {
 				s.logger.Error("error during Close after rpc server failure", "error", errC)


### PR DESCRIPTION
## Summary

- A clean `SIGTERM`/`SIGINT` to an attached `sbsh` client deterministically exited **1** with a spurious `Error: context has been cancelled` line (20/20 in the issue's measured loop). The cause: `runClient`'s select has two arms for the same `signal.NotifyContext` cancellation, and they disagreed. The `errCh` arm runs `context.Canceled` through `isCleanSessionEnd` and swallows it (the #380/#381 contract); the `ctx.Done()` arm returned `errdefs.ErrContextDone` unconditionally. On a signal the `ctx.Done()` arm wins deterministically, so users always saw the error path.
- Fix: in the `ctx.Done()` arm, take `ctx.Err()` (== `context.Canceled` on a handled signal) and route it through the same `isCleanSessionEnd` filter — return `nil` on a clean cancellation, while a real `WaitClose` teardown failure still surfaces (wrapped in `ErrContextDone`).
- Secondary (latent): `internal/client/controller.go`'s `rpcDoneCh` branch wrapped a possibly-nil error with `%w` (→ `rpc server exited: %!w(<nil>)` when the accept loop delivers `nil` on ctx-cancel). Added the nil-aware branch already present in `internal/terminal/controller.go:218-226`.

## Test plan

- [x] `make test` — full CI suite (cmd/sb, cmd/sbsh, internal/terminal, internal/client, integration-tagged get, e2e) — all green.
- [x] `make sbsh-sb` — canonical build; binary verified ELF (magic `7f 45 4c 46`).
- [x] `go build ./...`, `go vet ./cmd/... ./internal/client/...` — clean.
- [x] Issue repro on-device: `kill -TERM <attached sbsh client>` → `exit=0`, zero `Error:` lines, terminal restore sequences (`[?1049l` …) unchanged. Looped 5× — 5/5 `exit=0 errlines=0`.

## Acceptance criteria

- [x] `kill -TERM <attached sbsh client>` ends the session with exit code 0 and no `Error:` line (terminal restore unchanged) — verified on-device, 5/5.
- [x] The client controller's `rpcDoneCh` branch handles a nil error without producing a `%!w(<nil>)` string — nil branch added, mirrors the terminal controller.
- [x] Existing #380/#381 detach/peer-close swallow behavior unchanged — `isCleanSessionEnd` reused as-is, errCh arm untouched; `internal/client` + `cmd/sbsh` tests pass.

Closes #401