### PR TITLE
fix: cancel forwardResize per-resize context inline instead of deferring per loop iteration

### DIFF
--- a/internal/client/clientrunner/io.go
+++ b/internal/client/clientrunner/io.go
@@ -194,8 +194,6 @@ func (sr *Exec) forwardResize() error {
 		for {
 			select {
 			case <-sr.ctx.Done():
-				signal.Stop(ch)
-				defer close(ch)
 				sr.logger.WarnContext(sr.ctx, "forwardResize: context done")
 				return
 			case <-ch:
@@ -206,12 +204,15 @@ func (sr *Exec) forwardResize() error {
 					continue
 				}
 				ctx, cancel := context.WithTimeout(sr.ctx, resizeTimeout*time.Millisecond)
-				defer cancel()
 				if errResize := sr.terminalClient.Resize(ctx, &api.ResizeArgs{Cols: cols, Rows: rows}); errResize != nil {
 					sr.logger.ErrorContext(sr.ctx, "forwardResize: resize RPC failed", "error", errResize)
 				} else {
 					sr.logger.DebugContext(sr.ctx, "forwardResize: resize sent", "rows", rows, "cols", cols)
 				}
+				// Cancel inline (not via defer) so each per-resize context is
+				// released promptly instead of accumulating on the goroutine's
+				// defer stack for the whole session lifetime.
+				cancel()
 			}
 		}
 	}()


### PR DESCRIPTION
## Summary

- `forwardResize`'s SIGWINCH goroutine lives for the whole attach session, but registered `defer cancel()` **inside** the session-lifetime loop (`internal/client/clientrunner/io.go:208-209`). Deferred functions only run on function return, so every terminal resize permanently stacked one `cancel` closure plus its retained context object on the goroutine's defer stack — unbounded, memory-only growth over the session under resize-heavy use (tmux/WM drag-resize SIGWINCH storms). This swaps the per-iteration `defer cancel()` for an inline `cancel()` after the `Resize` RPC returns, so each per-resize context is released promptly.
- While in there (explicitly flagged in the issue): the `case <-sr.ctx.Done():` arm called `signal.Stop(ch)` a second time (the function-level `defer signal.Stop(ch)` at `:193` already covers it) and registered `defer close(ch)` — closing a `signal.Notify` channel is against the package's guidance (`Stop` is sufficient). Both removed; cleanup on return is handled by the existing function-level `defer signal.Stop(ch)`.

The `cancel()` is placed after the if/else so it runs on both the success and error branches. The 100ms-timeout child contexts self-cancel and detach from the parent promptly regardless, so there was no timer/parent-link leak — only the defer-stack accumulation, which this removes.

## Test plan

- [x] `make sbsh-sb` — build green; output verified ELF executable (`7f 45 4c 46` magic)
- [x] `go build ./...` — green
- [x] `go vet ./internal/client/clientrunner/...` — green
- [x] `make test-race` — green (including `internal/client/clientrunner`)
- [x] Full non-e2e + integration suite (`go test $(go list ./... | grep -v /e2e$)`, `go test -tags=integration ./cmd/sb/get/...`) — green
- [x] `make e2e` — green

Note: one full-suite run flaked on `cmd/sb/stop` `Test_StopOneTerminal_KillAfterEscalates` (a 200ms SIGKILL-escalation timing test, unrelated to the resize path). Confirmed pre-existing/load-dependent: it passes 10/10 in isolation on both clean `origin/main` and this branch, and the suite re-ran fully green.

## Acceptance criteria

- [x] No `defer` registered per loop iteration in `forwardResize`; each per-resize context is cancelled promptly after its RPC completes.
- [x] `make test-race` stays green.

Closes #400