### PR TITLE
fix: wait for SIGKILLed child to be reaped before reaper teardown so PID-1 zombie can't leak

### DIFF
--- a/internal/terminal/terminalrunner/lifecycle.go
+++ b/internal/terminal/terminalrunner/lifecycle.go
@@ -34,6 +34,17 @@ import (
 const (
 	deleteTerminalsDir bool = false
 	waitReadyPeriod         = 10 * time.Millisecond
+	// reapAfterKillGrace bounds how long shutdownChild waits for the tracked
+	// child to actually be reaped after the SIGKILL escalation. SIGKILL only
+	// queues the signal; the kernel still has to schedule the child, turn it
+	// into a zombie, and the harvester (the PID-1 reaper in init mode, or
+	// watchChildExit's cmd.Wait otherwise) still has to reap it. Close tears
+	// the reaper down via reaper.Stop right after shutdownChild returns, so
+	// without this wait the reaper's final drain races the kill-to-zombie
+	// window: a late zombie is never reaped and watchChildExit parks forever on
+	// TrackedExitCh. Bounded so an unkillable (D-state) child cannot wedge
+	// Close. See #398.
+	reapAfterKillGrace = 5 * time.Second
 )
 
 func (sr *Exec) StartTerminal(evCh chan<- Event) error {
@@ -127,18 +138,34 @@ func (sr *Exec) watchChildExit() {
 
 	var exitErr error
 	if sr.initMode && sr.reaper != nil {
-		code, ok := <-sr.reaper.TrackedExitCh()
-		if ok {
-			exitErr = fmt.Errorf("shell process exited: code=%d", code)
-		} else {
-			exitErr = errors.New("shell process exited")
+		select {
+		case code, ok := <-sr.reaper.TrackedExitCh():
+			if ok {
+				exitErr = fmt.Errorf("shell process exited: code=%d", code)
+			} else {
+				exitErr = errors.New("shell process exited")
+			}
+		case <-sr.ctx.Done():
+			// Close cancelled the context before the reaper delivered the
+			// tracked exit — e.g. the child became a zombie only after the
+			// post-SIGKILL reap window (reapAfterKillGrace) elapsed. Escape
+			// rather than park forever on TrackedExitCh; the closeReqCh send
+			// below is itself ctx-guarded, so this goroutine always
+			// terminates regardless. See #398.
+			exitErr = errors.New("shell process exited (close cancelled tracked-exit wait)")
 		}
 		// Release the os.Process handle so Go doesn't hold on to the
 		// kernel reference now that the reaper has already reaped the
 		// PID. A subsequent cmd.Wait() would return ECHILD — we skip it.
+		// Take runtimeMu around the Release: it mutates the shared
+		// *os.Process, and shutdownChild reads cmd.Process.Pid under the
+		// same lock, so without it the two race once Close's post-SIGKILL
+		// wait lets this goroutine proceed. See #398.
+		sr.runtimeMu.Lock()
 		if sr.cmd != nil && sr.cmd.Process != nil {
 			_ = sr.cmd.Process.Release()
 		}
+		sr.runtimeMu.Unlock()
 	} else {
 		// cmd.Wait()'s *exec.ExitError carries the real exit code (and signal
 		// info on signaled deaths) — propagate it so EvCmdExited consumers can
@@ -166,15 +193,25 @@ func (sr *Exec) watchChildExit() {
 //  2. Send SIGTERM to the child's process group.
 //  3. Wait up to grace for child exit.
 //  4. If still alive, send SIGKILL to the process group.
+//  5. After SIGKILL, wait (bounded by reapAfterKillGrace) for the child to be
+//     reaped so Close does not tear the reaper down before the zombie forms.
 //
 // Grace <= 0 falls back to the package default. Must only be called after
 // startPty has run (cmd and cmd.Process are set).
 func (sr *Exec) shutdownChild(grace time.Duration) {
-	// Snapshot cmd under runtimeMu: a concurrent startPty publishes it (and
-	// its Process) under the same lock, so this read is otherwise a data
-	// race against a Stop-during-startup Close. See #396.
+	// Snapshot cmd and the child's pid under runtimeMu. startPty publishes cmd
+	// (and its Process) under the same lock, so this is otherwise a data race
+	// against a Stop-during-startup Close (#396). Reading cmd.Process.Pid under
+	// the lock also serializes it against watchChildExit's cmd.Process.Release
+	// (also taken under runtimeMu): once the post-SIGKILL reap wait below lets
+	// watchChildExit run to completion, an unlocked pid read here would race
+	// that Release write on the shared *os.Process. See #398.
 	sr.runtimeMu.Lock()
 	cmd := sr.cmd
+	var pid int
+	if cmd != nil && cmd.Process != nil {
+		pid = cmd.Process.Pid
+	}
 	sr.runtimeMu.Unlock()
 	if cmd == nil || cmd.Process == nil {
 		return
@@ -186,7 +223,6 @@ func (sr *Exec) shutdownChild(grace time.Duration) {
 		grace = profile.DefaultShutdownGrace
 	}
 
-	pid := cmd.Process.Pid
 	// Setsid: true ensures pgid == pid for the child.
 	if err := syscall.Kill(-pid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
 		sr.logger.Warn("could not SIGTERM child process group", "id", sr.id, "pid", pid, "err", err)
@@ -205,6 +241,24 @@ func (sr *Exec) shutdownChild(grace time.Duration) {
 
 	if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
 		sr.logger.Warn("could not SIGKILL child process group", "id", sr.id, "pid", pid, "err", err)
+	}
+
+	// SIGKILL is asynchronous: it only queues the signal. The child still has
+	// to be scheduled, die, transition to a zombie, and be harvested — by the
+	// PID-1 reaper in init mode, or by watchChildExit's cmd.Wait otherwise —
+	// before childDoneCh closes. Block (bounded) until that happens so Close
+	// does not call reaper.Stop while the zombie has not formed yet:
+	// reaper.Stop's final drain would otherwise miss it and the child would
+	// leak as a permanent zombie with watchChildExit parked on TrackedExitCh.
+	// See #398.
+	killTimer := time.NewTimer(reapAfterKillGrace)
+	defer killTimer.Stop()
+	select {
+	case <-sr.childDoneCh:
+		sr.logger.Debug("child reaped after SIGKILL escalation", "id", sr.id, "pid", pid)
+	case <-killTimer.C:
+		sr.logger.Warn("child not reaped within grace after SIGKILL; reaper teardown may leak a zombie",
+			"id", sr.id, "pid", pid, "grace", reapAfterKillGrace)
 	}
 }
 

--- a/internal/terminal/terminalrunner/lifecycle_reaper_shutdown_test.go
+++ b/internal/terminal/terminalrunner/lifecycle_reaper_shutdown_test.go
@@ -1,0 +1,101 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package terminalrunner
+
+import (
+	"context"
+	"os/exec"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestShutdownChild_InitMode_ReapsAfterSIGKILL reconstructs the #398 race: in
+// PID-1 init mode, Close's SIGKILL escalation used to return before the child
+// was a zombie, so reaper.Stop's final drain ran before the kernel turned the
+// child into a zombie — leaving a permanent zombie and parking watchChildExit
+// forever on TrackedExitCh.
+//
+// The fix makes shutdownChild block (bounded) on childDoneCh after SIGKILL so
+// the still-running reaper harvests the zombie before Close tears it down. This
+// test drives the exact Close-order sequence (shutdownChild -> ctxCancel ->
+// reaper.Stop) against a child that ignores SIGTERM and asserts both ACs: the
+// child is reaped (no zombie) and watchChildExit is not parked.
+func TestShutdownChild_InitMode_ReapsAfterSIGKILL(t *testing.T) {
+	rp := newReaper(discardLogger())
+	rp.Start()
+
+	// Child ignores SIGTERM; only the uncatchable SIGKILL takes it down.
+	// Setsid makes pgid == pid so the process-group kill in shutdownChild
+	// targets exactly this child.
+	cmd := exec.Command("/bin/sh", "-c", `trap '' TERM; while :; do sleep 1; done`)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	pid := cmd.Process.Pid
+	rp.RegisterChild(pid)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sr := &Exec{
+		ctx:           ctx,
+		ctxCancel:     cancel,
+		logger:        discardLogger(),
+		id:            "test",
+		cmd:           cmd,
+		closeReqCh:    make(chan error, 1),
+		childDoneCh:   make(chan struct{}),
+		childDoneOnce: &sync.Once{},
+		initMode:      true,
+		reaper:        rp,
+	}
+	sr.metadata.Spec.ShutdownGrace = 100 * time.Millisecond
+
+	// watchChildExit is the production consumer of TrackedExitCh; on delivery
+	// it calls markChildDone, which closes childDoneCh and unblocks
+	// shutdownChild's post-SIGKILL wait.
+	go sr.watchChildExit()
+
+	// Let the shell install `trap '' TERM` before we start signaling, so
+	// SIGTERM is genuinely ignored and the escalation path under test fires.
+	time.Sleep(150 * time.Millisecond)
+
+	// Drive the Close-order sequence the bug is about.
+	sr.shutdownChild(sr.metadata.Spec.ShutdownGrace)
+	sr.ctxCancel()
+	rp.Stop()
+
+	// AC1: the tracked child must be reaped — no zombie left behind. A zombie
+	// is still addressable (Kill(pid, 0) returns nil) until it is reaped;
+	// after reaping the pid is gone and Kill returns ESRCH.
+	if err := syscall.Kill(pid, 0); err != syscall.ESRCH {
+		t.Fatalf("tracked child pid %d not reaped after Close sequence (Kill(0)=%v); want ESRCH (zombie leaked)",
+			pid, err)
+	}
+
+	// AC2: watchChildExit must not be parked — childDoneCh closed means it
+	// received the tracked exit (or escaped on ctx.Done) and ran markChildDone.
+	select {
+	case <-sr.childDoneCh:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("watchChildExit still parked: childDoneCh not closed after Close sequence")
+	}
+}


### PR DESCRIPTION
## Summary

In PID-1 init mode, `Close`'s SIGKILL escalation returned before the child was a zombie, and `reaper.Stop()` then ran its **final** `drainOnce` before the kernel had transitioned the killed child. The final `Wait4(-1, WNOHANG)` saw nothing, the loop exited, and SIGCHLD was unregistered — so the child (which dies a moment later) is **never reaped** (permanent zombie for the life of the PID-1 process) and `trackedExitCh` is never delivered nor closed, leaving `watchChildExit` parked forever at `lifecycle.go`'s bare `TrackedExitCh()` receive (and `markChildDone`/`closeReqCh` never fire). The audience that pays is a long-lived `pkg/terminal/server` running as container init. Fixes #398.

The fix closes the kill-to-zombie race at its sequencing root, plus a defensive escape:

- **`shutdownChild`: block (bounded) on `childDoneCh` after SIGKILL.** `reaper.Stop()` runs *after* `shutdownChild` returns and *after* the reaper loop is still live, so waiting for the child to actually be reaped keeps the reaper running until the zombie has been harvested. The wait is event-driven (the still-running reaper reaps the zombie → delivers `TrackedExitCh` → `watchChildExit` closes `childDoneCh`), no polling. Bounded by `reapAfterKillGrace` (5s) so an unkillable D-state child cannot wedge `Close`.
- **`watchChildExit`: `ctx.Done()` escape on the `TrackedExitCh()` receive.** Guarantees the goroutine can never park permanently even in the pathological case where the bounded reap wait elapses (`Close` calls `ctxCancel` right after `shutdownChild`). On the normal path the context is still live during the reap wait, so the escape never fires prematurely.

### Why not the other two suggested mechanisms
The issue suggested three options. I implemented the first ("block on `childDoneCh` before `reaper.Stop`") and third ("`ctx.Done()` escape"). I deliberately did **not** implement "have `Stop` keep draining until `Wait4` reports ECHILD": draining-until-ECHILD means "until I have no children at all", which is wrong for a real container init that legitimately has other live children — it would block `Stop` indefinitely. The targeted `childDoneCh` wait reaps the *tracked* child without that hazard.

### In-scope concurrency fix surfaced by the change (please review)
Making `watchChildExit` correctly *proceed* (AC #2) unmasked a latent data race in the close path: `watchChildExit`'s `cmd.Process.Release()` (a write to the shared `*os.Process`) raced `shutdownChild`'s unsynchronized `cmd.Process.Pid` read. Before this fix the race was hidden because `watchChildExit` parked forever and never reached `Release()`. I serialized both `*os.Process` accesses under the existing `runtimeMu` (pid read moved under the lock in `shutdownChild`; `Release()` wrapped in the lock in `watchChildExit`). This is intrinsic to the sequencing the issue is about, not an unrelated cleanup, and `make test-race` requires it to be green.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make sbsh-sb` (canonical build; verified ELF magic `7f 45 4c 46`, `sb`↔`sbsh` hardlink)
- [x] New regression test `TestShutdownChild_InitMode_ReapsAfterSIGKILL` (Linux) — reconstructs the exact race (SIGTERM-ignored child, real reaper, real `watchChildExit` goroutine), drives the `shutdownChild → ctxCancel → reaper.Stop` close sequence, and asserts on the real runtime observables: the tracked child is reaped (`Kill(pid,0) == ESRCH`, i.e. no zombie) and `watchChildExit` is not parked (`childDoneCh` closed). Run `-count=5 -race`, green. Fails on pre-fix code (zombie persists → `Kill(0)` returns nil).
- [x] `go test ./internal/terminal/terminalrunner/` (full package, non-race)
- [x] `make test-race` (full target: `cmd/sb`, `cmd/sbsh`, `internal/terminal`, `internal/client`, `pkg/...`) — green

## Acceptance criteria
- [x] After `Close` returns in init mode, the tracked child is reaped (no `Z` under `/proc`) even when it ignored SIGTERM and was SIGKILLed at the grace boundary — verified by the new test's `Kill(pid,0) == ESRCH` assertion exercising the real reaper + kill path.
- [x] No goroutine remains parked in `watchChildExit` after `Close` — verified by the `childDoneCh`-closed assertion, plus the `ctx.Done()` escape guaranteeing termination even if the bounded reap wait elapses.
- [x] `make test-race` stays green.

Closes #398