### PR TITLE
fix: persist stdin reader so sequential attach reuse keeps input

### DIFF
--- a/internal/client/clientrunner/io.go
+++ b/internal/client/clientrunner/io.go
@@ -93,9 +93,14 @@ func (sr *Exec) startConnectionManager() error {
 		})
 	}
 
-	// WRITER: stdin -> socket
+	// WRITER: stdin -> socket. Read through the process-wide persistent pump
+	// rather than sr.stdin directly so this session's teardown (ctx-cancel)
+	// unblocks the copier without abandoning a blocking read on the descriptor;
+	// the pump survives to hand any already-read byte to the next session. See
+	// issue #399.
+	stdinSrc := &pumpReader{ctx: sr.ctx, pump: pumpForStdin(sr.stdin)}
 	readyWriter := make(chan struct{})
-	go dc.RunCopier(sr.stdin, sr.ioConn, readyWriter, func() {
+	go dc.RunCopier(stdinSrc, sr.ioConn, readyWriter, func() {
 		if uc != nil {
 			sr.logger.DebugContext(sr.ctx, "stdin->socket: closing write side of UnixConn")
 			_ = uc.CloseWrite()

--- a/internal/client/clientrunner/stdin_pump.go
+++ b/internal/client/clientrunner/stdin_pump.go
@@ -1,0 +1,174 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clientrunner
+
+import (
+	"context"
+	"io"
+	"os"
+	"sync"
+)
+
+// stdinPump is a single persistent reader over a stdin *os.File (typically the
+// process's os.Stdin) that outlives any one attach session. Reading the
+// descriptor in one long-lived, process-scoped goroutine — rather than
+// directly inside each session's stdin->socket copier — is what makes
+// sequential pkg/attach.Run reuse safe (issue #399):
+//
+//   - On teardown a session detaches its consumer via context cancellation
+//     (see pumpReader) instead of abandoning a blocking Read on the
+//     descriptor. The dualcopier goroutine therefore exits promptly and does
+//     not survive into the next session.
+//   - Any byte the pump has already pulled off the descriptor but not yet
+//     handed to a consumer is buffered and delivered to the next consumer
+//     rather than written at the torn-down session's dead socket.
+//
+// The real os.Stdin (a blocking fd 0) is non-pollable: SetReadDeadline is a
+// no-op on it, so the pre-#399 deadline-based unblock could not interrupt the
+// parked read. The bounded copier wait then gave up and left the reader
+// parked, where it consumed and mis-delivered the next session's first byte.
+type stdinPump struct {
+	ch chan pumpResult
+
+	mu       sync.Mutex
+	leftover []byte // bytes read but not yet consumed; survives across sessions
+	readErr  error  // sticky: once the source errors, every read returns it
+}
+
+type pumpResult struct {
+	data []byte
+	err  error
+}
+
+//nolint:gochecknoglobals // process-wide registry: one persistent stdin reader per descriptor, shared across sequential attach sessions
+var (
+	stdinPumpMu       sync.Mutex
+	stdinPumpRegistry = map[*os.File]*stdinPump{}
+)
+
+// pumpForStdin returns the process-wide pump for f, creating and starting it on
+// first use. Keying on the *os.File pointer — not the int fd — avoids aliasing
+// a closed descriptor whose number was later reused by a different file.
+func pumpForStdin(f *os.File) *stdinPump {
+	stdinPumpMu.Lock()
+	defer stdinPumpMu.Unlock()
+	if p, ok := stdinPumpRegistry[f]; ok {
+		return p
+	}
+	p := newStdinPump(f)
+	stdinPumpRegistry[f] = p
+	return p
+}
+
+func newStdinPump(src io.Reader) *stdinPump {
+	p := &stdinPump{ch: make(chan pumpResult)}
+	go p.run(src)
+	return p
+}
+
+// run is the single descriptor-owning goroutine. The unbuffered channel makes
+// it park on the send after each read until a consumer receives, so at most one
+// read's worth of input is ever held outside the descriptor — and that held
+// input is what gets delivered to the next session rather than lost.
+func (p *stdinPump) run(src io.Reader) {
+	for {
+		buf := make([]byte, 32*1024) //nolint:mnd // 32 KiB, matches dualcopier's buffer
+		n, err := src.Read(buf)
+		if n > 0 {
+			p.ch <- pumpResult{data: buf[:n]}
+		}
+		if err != nil {
+			p.ch <- pumpResult{err: err}
+			return
+		}
+	}
+}
+
+// read serves bytes to the current consumer, honoring ctx. It returns ctx.Err()
+// promptly on cancellation. Crucially, once ctx is cancelled it never hands
+// bytes to the cancelled consumer: any data already pulled from the source is
+// stashed for the next consumer, so a torn-down session cannot write a stale
+// byte at its dead socket and the next session receives it intact.
+func (p *stdinPump) read(ctx context.Context, b []byte) (int, error) {
+	p.mu.Lock()
+	if len(p.leftover) > 0 {
+		n := copy(b, p.leftover)
+		p.leftover = p.leftover[n:]
+		if len(p.leftover) == 0 {
+			p.leftover = nil
+		}
+		p.mu.Unlock()
+		return n, nil
+	}
+	if p.readErr != nil {
+		err := p.readErr
+		p.mu.Unlock()
+		return 0, err
+	}
+	p.mu.Unlock()
+
+	// Prefer an already-cancelled context over a byte that happens to be ready
+	// on the channel: a tearing-down consumer must not win the race and forward
+	// the byte to its dead socket.
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	default:
+	}
+
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	case res := <-p.ch:
+		if res.err != nil {
+			p.mu.Lock()
+			p.readErr = res.err
+			p.mu.Unlock()
+			return 0, res.err
+		}
+		// If ctx fired concurrently with the receive, do not deliver to the
+		// cancelled consumer — stash the bytes for the next one. leftover is
+		// empty here (checked above), so ordering is preserved.
+		select {
+		case <-ctx.Done():
+			p.mu.Lock()
+			p.leftover = append(p.leftover, res.data...)
+			p.mu.Unlock()
+			return 0, ctx.Err()
+		default:
+		}
+		n := copy(b, res.data)
+		if n < len(res.data) {
+			p.mu.Lock()
+			p.leftover = append(p.leftover, res.data[n:]...)
+			p.mu.Unlock()
+		}
+		return n, nil
+	}
+}
+
+// pumpReader adapts a stdinPump to the io.Reader the dualcopier expects,
+// binding reads to a single session's context so that session teardown
+// unblocks the copier without disturbing the persistent pump.
+type pumpReader struct {
+	ctx  context.Context
+	pump *stdinPump
+}
+
+func (r *pumpReader) Read(b []byte) (int, error) {
+	return r.pump.read(r.ctx, b)
+}

--- a/internal/client/clientrunner/stdin_pump_test.go
+++ b/internal/client/clientrunner/stdin_pump_test.go
@@ -1,0 +1,210 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clientrunner
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// countCopierGoroutines reports how many dualcopier read/write loops are
+// currently running, by counting runReadWriter frames in the full goroutine
+// dump. Each live copier (stdin->socket, socket->stdout) sits in exactly one.
+func countCopierGoroutines() int {
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	return strings.Count(string(buf[:n]), "dualcopier.(*Copier).runReadWriter")
+}
+
+// waitCopierGoroutines polls until countCopierGoroutines() reaches want or the
+// deadline elapses, returning the final count.
+func waitCopierGoroutines(want int, timeout time.Duration) int {
+	deadline := time.Now().Add(timeout)
+	for {
+		got := countCopierGoroutines()
+		if got == want || time.Now().After(deadline) {
+			return got
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+type pumpReadOut struct {
+	n   int
+	buf []byte
+	err error
+}
+
+// TestStdinPump_ByteSurvivesConsumerCancellation is the pump-level invariant
+// behind issue #399: cancelling a consumer returns promptly without consuming
+// from the source, and a byte the source produces while no consumer is active
+// is delivered to the next consumer rather than lost or stolen.
+func TestStdinPump_ByteSurvivesConsumerCancellation(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close(); _ = w.Close() })
+
+	p := newStdinPump(r)
+
+	// Consumer 1 parks on an empty source, then is cancelled.
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	done := make(chan pumpReadOut, 1)
+	go func() {
+		buf := make([]byte, 16)
+		n, rerr := p.read(ctx1, buf)
+		done <- pumpReadOut{n, append([]byte(nil), buf[:n]...), rerr}
+	}()
+
+	time.Sleep(50 * time.Millisecond) // best-effort: let consumer 1 park
+	cancel1()
+
+	select {
+	case out := <-done:
+		if !errors.Is(out.err, context.Canceled) {
+			t.Fatalf("consumer 1: want context.Canceled, got n=%d err=%v", out.n, out.err)
+		}
+		if out.n != 0 {
+			t.Fatalf("consumer 1 consumed %d bytes on cancellation; want 0", out.n)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("consumer 1 did not return within 2s of cancellation")
+	}
+
+	// A byte arrives while no consumer is active.
+	if _, werr := w.WriteString("Z"); werr != nil {
+		t.Fatalf("write between consumers: %v", werr)
+	}
+
+	// Consumer 2 must receive that exact byte.
+	buf := make([]byte, 16)
+	n, rerr := p.read(context.Background(), buf)
+	if rerr != nil {
+		t.Fatalf("consumer 2 read: %v", rerr)
+	}
+	if n != 1 || buf[0] != 'Z' {
+		t.Fatalf("consumer 2: got n=%d buf=%q; want 1 byte %q", n, buf[:n], "Z")
+	}
+}
+
+// newPumpExec wires a minimal Exec onto the given stdin/stdout handles and a
+// pre-connected socket, suitable for driving startConnectionManager and
+// restoreParentTerminal directly. DetachKeystroke is off so no escape filter
+// rewrites the byte stream. The session context is created internally and torn
+// down on test cleanup.
+func newPumpExec(t *testing.T, stdin, stdout *os.File, ioConn net.Conn) *Exec {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return &Exec{
+		id:         api.ID("client-pump"),
+		ctx:        ctx,
+		ctxCancel:  cancel,
+		logger:     testLogger(),
+		events:     make(chan Event, 8),
+		metadataMu: sync.RWMutex{},
+		stdin:      stdin,
+		stdout:     stdout,
+		stderr:     stdout,
+		ioConn:     ioConn,
+		terminal:   &api.AttachedTerminal{Spec: &api.TerminalSpec{ID: api.ID("term-pump")}},
+		metadata: api.ClientDoc{
+			APIVersion: api.APIVersionV1Beta1,
+			Kind:       api.KindClient,
+			Spec: api.ClientSpec{
+				ID:              api.ID("client-pump"),
+				DetachKeystroke: false,
+			},
+		},
+	}
+}
+
+// TestStdinPump_SequentialAttachReuse is the issue #399 acceptance criterion at
+// the layer the bug lives in: two sequential attach sessions over a
+// non-pollable stdin (an os.Pipe, same pollability as the real os.Stdin) must
+// leave no copier goroutine from session 1 alive into session 2, and a byte
+// written between the sessions must be delivered to session 2's socket rather
+// than stolen by an abandoned session-1 reader.
+func TestStdinPump_SequentialAttachReuse(t *testing.T) {
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	t.Cleanup(func() { _ = stdinR.Close(); _ = stdinW.Close() })
+
+	devnull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open %s: %v", os.DevNull, err)
+	}
+	t.Cleanup(func() { _ = devnull.Close() })
+
+	baseline := countCopierGoroutines()
+
+	// ---- session 1 ----
+	client1, server1 := unixSocketPair(t)
+	sr1 := newPumpExec(t, stdinR, devnull, client1)
+	if startErr := sr1.startConnectionManager(); startErr != nil {
+		t.Fatalf("session 1 startConnectionManager: %v", startErr)
+	}
+	if got := waitCopierGoroutines(baseline+2, 2*time.Second); got != baseline+2 {
+		t.Fatalf("session 1: want %d copier goroutines running, got %d", baseline+2, got)
+	}
+	_ = server1 // session 1 sends nothing; the connection is torn down below.
+
+	// Tear session 1 down. No copier goroutine from it may survive.
+	sr1.restoreParentTerminal("")
+	if got := waitCopierGoroutines(baseline, 2*time.Second); got != baseline {
+		t.Fatalf("after session 1 teardown: %d copier goroutines survived; want %d", got, baseline)
+	}
+
+	// A byte typed between sessions must not be lost.
+	if _, werr := stdinW.WriteString("Z"); werr != nil {
+		t.Fatalf("write between sessions: %v", werr)
+	}
+
+	// ---- session 2 (same stdin) ----
+	client2, server2 := unixSocketPair(t)
+	sr2 := newPumpExec(t, stdinR, devnull, client2)
+	if startErr := sr2.startConnectionManager(); startErr != nil {
+		t.Fatalf("session 2 startConnectionManager: %v", startErr)
+	}
+
+	// The between-sessions byte must arrive at session 2's socket.
+	if derr := server2.SetReadDeadline(time.Now().Add(2 * time.Second)); derr != nil {
+		t.Fatalf("set read deadline: %v", derr)
+	}
+	rb := make([]byte, 1)
+	n, rerr := server2.Read(rb)
+	if rerr != nil {
+		t.Fatalf("session 2 socket read: %v (byte written between sessions was lost or stolen)", rerr)
+	}
+	if n != 1 || rb[0] != 'Z' {
+		t.Fatalf("session 2 received n=%d %q; want the between-sessions byte %q", n, rb[:n], "Z")
+	}
+
+	sr2.restoreParentTerminal("")
+}

--- a/internal/client/clientrunner/terminal.go
+++ b/internal/client/clientrunner/terminal.go
@@ -45,10 +45,11 @@ func (sr *Exec) toBashUIMode() error {
 //
 // The restore ioctl is issued through SyscallConn().Control rather than
 // term.Restore(int(stdin.Fd()), …) on purpose: os.File.Fd() pulls the
-// descriptor out of the runtime poller and flips it to blocking mode, which
-// would defeat the deadline-based unblock of the stdin copier in
-// restoreParentTerminal. Control hands us the fd without disturbing the
-// poller registration. See issue #364.
+// descriptor out of the runtime poller and flips it to blocking mode. Keeping
+// the descriptor pollable until the final SetNonblock in restoreParentTerminal
+// lets the persistent stdin pump read it efficiently without mode flapping.
+// Control hands us the fd without disturbing the poller registration. See
+// issues #364 and #399.
 func (sr *Exec) toExitShell() error {
 	sr.logger.Debug("toExitShell: switching to cooked mode")
 	if sr.lastTermState != nil && sr.stdin != nil {
@@ -107,32 +108,21 @@ func (sr *Exec) restoreParentTerminal(postDrainMsg string) {
 	sr.restoreOnce.Do(func() {
 		sr.logger.Debug("restoreParentTerminal: beginning terminal restore")
 
-		// Cancel the context so the socket-side copier is unblocked by
-		// CopierManager (it sets read/write deadlines on the UnixConn on
-		// ctx.Done) and the copier loops observe shutdown.
+		// Cancel the context so both copiers observe shutdown: the socket-side
+		// copier is unblocked by CopierManager (it sets read/write deadlines on
+		// the UnixConn on ctx.Done), and the stdin->socket copier reads through
+		// the persistent pump's context-bound pumpReader, whose Read returns
+		// promptly on cancellation regardless of the descriptor's pollability.
+		// The pump goroutine itself keeps owning sr.stdin so a byte it already
+		// read is handed to the next session, not lost. See issues #364 and #399.
 		sr.ctxCancel()
 
-		// Best-effort unblock of the stdin->socket copier parked in
-		// sr.stdin.Read(). This works only when the descriptor is pollable — a
-		// freshly-opened *os.File over the tty. The real attach path reads
-		// os.Stdin, which the Go runtime constructs non-pollable (it is not
-		// registered with the runtime poller regardless of how the fd is later
-		// accessed), so SetReadDeadline is a no-op there and the parked read
-		// cannot be interrupted. The bounded wait below is what keeps that case
-		// from wedging teardown.
-		if sr.stdin != nil {
-			if err := sr.stdin.SetReadDeadline(time.Now()); err != nil {
-				sr.logger.Debug("restoreParentTerminal: SetReadDeadline failed", "error", err)
-			}
-		}
-
 		// Wait for the copier goroutines to drain so nobody is mid-read when we
-		// hand the descriptor back to blocking mode — but bound it. The
-		// socket->stdout copier exits promptly on ctx-cancel; the stdin->socket
-		// copier may be parked in an uninterruptible os.Stdin.Read() (see above)
-		// that only process exit reaps. Blocking unconditionally on it hangs
-		// every teardown path (#364 e2e detach/exit timeouts). The leaked reader
-		// is harmless: the process exits immediately after restore.
+		// hand the descriptor back to blocking mode — but bound it. Both copiers
+		// now exit on ctx-cancel (the stdin->socket copier via pumpReader, the
+		// socket->stdout copier via the UnixConn deadline), so this returns
+		// promptly on every path. The bound remains a safety net against a
+		// wedged socket read so teardown can never hang (#364 e2e timeouts).
 		if sr.copier != nil {
 			done := make(chan struct{})
 			go func() {
@@ -238,8 +228,8 @@ func toRawMode(logger *slog.Logger, stdin *os.File) (*term.State, error) {
 // withRawFd invokes fn with stdin's underlying descriptor obtained through
 // SyscallConn().Control, which — unlike os.File.Fd() — leaves the descriptor
 // registered with the runtime poller and in non-blocking mode. Keeping the
-// descriptor pollable is what lets restoreParentTerminal interrupt the parked
-// stdin read via SetReadDeadline. See issue #364.
+// descriptor pollable across MakeRaw/Restore/getsize avoids prematurely
+// dropping the persistent stdin pump's poller registration. See issue #364.
 func withRawFd(f *os.File, fn func(fd int) error) error {
 	rc, err := f.SyscallConn()
 	if err != nil {


### PR DESCRIPTION
## Summary

`pkg/attach.Run` documents that it is "safe to call multiple times sequentially from the same process," but it wasn't (#399). The stdin->socket copier read `sr.stdin` **directly**. On teardown, `restoreParentTerminal` tried to unblock the parked read with `SetReadDeadline(now)` — a no-op on the non-pollable real `os.Stdin` — then gave up after a bounded 500 ms wait and left the copier goroutine parked mid-`Read`. The leaked reader then consumed the next sequential `Run`'s first byte and wrote it at the dead session's socket (input loss / theft).

This change stops reading the descriptor inside the per-session copier. Instead:

- **`internal/client/clientrunner/stdin_pump.go`** (new) — a process-wide persistent reader keyed by the stdin `*os.File`, with one long-lived goroutine that owns the descriptor across sessions. Each session's copier reads through a context-bound `pumpReader` whose `Read` returns promptly on `ctx`-cancel regardless of pollability, so no `dualcopier` goroutine survives teardown. Any byte the pump already pulled off the descriptor is buffered (or held parked on its send) and handed to the **next** session rather than written at the dead socket. The `read` path deterministically prefers an already-cancelled context over a racing pending byte, and stashes a byte for the next consumer if cancellation and delivery race — so a tearing-down session can never forward a stale byte.
- **`io.go`** — the stdin->socket copier now reads the `pumpReader` instead of `sr.stdin`.
- **`terminal.go`** — removed the now-defunct `SetReadDeadline` unblock (the copier no longer reads the descriptor directly; keeping it would have killed the persistent pump on pollable fds). Both copiers now exit on `ctx`-cancel; the bounded wait remains a safety net against a wedged socket read. Refreshed the stale `#364` rationale comments (the "leaked reader is harmless: the process exits immediately" assumption was the documented bug for `pkg/attach` embedders) to describe the pump.

### Implementation notes for the reviewer

- **Behavioral note (documented here, not a regression vs. the bug):** the pump reads stdin in a process-scoped goroutine that outlives a single `Run`. For the `sb`/`sbsh` CLIs (process exits after attach) this is invisible. For a library embedder that does sequential `Run`s this is the fix. For an embedder that does one `Run` and then reads `os.Stdin` itself afterward, the pump may have read-ahead one chunk and hold it — this is inherent to any "persistent reader" design (the issue's recommended fix) and is strictly better than the prior byte-theft. Verified the held byte is delivered to the next consumer, not dropped.
- The `withRawFd` poller-preservation machinery (`#364`) is retained unchanged; only the SetReadDeadline-based unblock comment lineage was updated.

## Test plan

- [x] `make test-race` (the AC's named target) — green, all packages including `internal/client/...`, `pkg/...`.
- [x] `make test` — green, including the `e2e` detach/exit suite that exercises the real attach teardown paths (`#364`).
- [x] `go build ./...`, `go vet ./...` — clean.
- [x] `pre-commit run --files <changed>` — all hooks pass (gofmt, golangci-lint, addlicense).
- [x] New `TestStdinPump_SequentialAttachReuse` (clientrunner) — drives two sequential `startConnectionManager` + `restoreParentTerminal` cycles over a non-pollable `os.Pipe` stdin and asserts (a) no `dualcopier` goroutine from session 1 survives teardown, (b) a byte written between sessions is delivered to session 2's socket. This is the AC at the layer the bug lives in (the `pkg/attach` fake-controller harness returns `attachErr` before reaching the copier, so the I/O path isn't reachable there).
- [x] New `TestStdinPump_ByteSurvivesConsumerCancellation` — pump-level invariant: cancel returns promptly without consuming; a byte produced while no consumer is active reaches the next consumer.

## Acceptance criteria

- [x] Two sequential `attach.Run` calls in one process with a non-pollable `Stdin`: no `dualcopier` goroutine from session 1 survives into session 2, and a byte written between the sessions is delivered to session 2 (not lost). — verified by `TestStdinPump_SequentialAttachReuse`.
- [x] `make test-race` stays green.

Closes #399