### PR TITLE
fix: replace cobra placeholder help text for sb attach

### DIFF
--- a/cmd/sb/attach/attach.go
+++ b/cmd/sb/attach/attach.go
@@ -47,13 +47,13 @@ func NewAttachCmd() *cobra.Command {
 	attachCmd := &cobra.Command{
 		Use:     Command,
 		Aliases: []string{CommandAlias},
-		Short:   "A brief description of your command",
-		Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
+		Short:   "Attach to a running terminal",
+		Long: `Attach to a running terminal by its ID or name.
 
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+Identify the target with --id or --name (the two are mutually exclusive).
+Once attached, your terminal is connected to the remote session; press the
+detach keystroke (^] twice) to detach and leave it running, or use
+--disable-detach to turn the keystroke off.`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logger, ok := cmd.Context().Value(types.CtxLogger).(*slog.Logger)


### PR DESCRIPTION
## Summary
- `sb attach` shipped the unedited `cobra init` placeholder for its `Short`/`Long` help, so `sb attach --help` and the `sb --help` command list showed boilerplate ("A brief description of your command" / the "Cobra is a CLI library" paragraph) instead of a real description.
- Replaced `Short`/`Long` in `cmd/sb/attach/attach.go` with a real description — attach to a running terminal by `--id` or `--name` (mutually exclusive), detach with the `^]^]` keystroke or disable it via `--disable-detach` — matching the multi-line style of the sibling `detach` command's help.

## Test plan
- [x] `make sbsh-sb` — canonical build succeeds (binary built, `sb` hardlink created)
- [x] `go build ./...`
- [x] `go vet ./cmd/sb/attach/...`
- [x] `go test ./cmd/sb/attach/...` — passes
- [x] `sb --help` attach row now reads `Attach to a running terminal`
- [x] `sb attach --help` long text describes the actual command
- [x] `git grep` confirms no remaining "A brief description of your command" / "Cobra is a CLI library" / "A longer description that spans multiple lines" placeholders in `cmd/`

## Acceptance criteria
- [x] `sb attach --help` describes the actual command.
- [x] The `sb --help` command list shows a real one-line summary for `attach`.
- [x] No remaining "A brief description of your command" / "Cobra is a CLI library" placeholders in `cmd/`.

Closes #393