### PR TITLE
fix: give waitOnTerminal a ctx escape so a dropped closeReqCh send can't leak it

### DIFF
--- a/internal/terminal/terminalrunner/lifecycle.go
+++ b/internal/terminal/terminalrunner/lifecycle.go
@@ -118,7 +118,23 @@ func (sr *Exec) applyLogFilePerms() error {
 }
 
 func (sr *Exec) waitOnTerminal() {
-	err := <-sr.closeReqCh
+	// Mirror the ctx escape watchChildExit's send select already has
+	// (lifecycle.go's closeReqCh send below). closeReqCh is unbuffered and
+	// watchChildExit is its sole sender; on an externally-driven Close that
+	// escalates to SIGKILL, ctxCancel can already be done when the sender
+	// selects, so the sender takes its ctx.Done() arm and drops the value.
+	// Without a symmetric escape here this sole receiver parks on the bare
+	// receive forever, leaking one goroutine (plus its Exec) per affected
+	// Close. The receive and the ctx guard race like the send does; on a
+	// clean exit the value arrives and we publish EvCmdExited as before. See
+	// #397.
+	var err error
+	select {
+	case err = <-sr.closeReqCh:
+	case <-sr.ctx.Done():
+		sr.logger.Debug("waitOnTerminal: ctx cancelled before close request; exiting", "id", sr.id)
+		return
+	}
 	sr.logger.Info("terminal close requested", "id", sr.id, "err", err)
 	sr.logger.Debug("sending EvCmdExited event", "id", sr.id)
 	trySendEvent(sr.logger, sr.evCh, Event{ID: sr.id, Type: EvCmdExited, Err: err, When: time.Now()})

--- a/internal/terminal/terminalrunner/lifecycle_wait_on_terminal_test.go
+++ b/internal/terminal/terminalrunner/lifecycle_wait_on_terminal_test.go
@@ -1,0 +1,112 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package terminalrunner
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+// newWaitOnTerminalTestExec builds a minimal Exec for exercising
+// waitOnTerminal's receive in isolation. closeReqCh is UNBUFFERED to match the
+// production wiring (terminal_runner_exec.go:209) — the leak only manifests on
+// an unbuffered channel where a dropped sender send leaves the receiver with
+// nothing to take.
+func newWaitOnTerminalTestExec(t *testing.T, evCh chan Event) *Exec {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	return &Exec{
+		ctx:        ctx,
+		ctxCancel:  cancel,
+		logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		id:         "test",
+		closeReqCh: make(chan error), // unbuffered, as in production
+		evCh:       evCh,
+	}
+}
+
+// TestWaitOnTerminal_CtxCancel_NoLeak reproduces #397: on an externally-driven
+// Close that escalates to SIGKILL, watchChildExit's send select can take its
+// ctx.Done() arm and drop the exit error before waitOnTerminal — the sole
+// receiver — ever receives it. With a bare `<-closeReqCh` the receiver parked
+// forever, leaking one goroutine per affected Close. waitOnTerminal must now
+// take the symmetric ctx.Done() escape and return.
+func TestWaitOnTerminal_CtxCancel_NoLeak(t *testing.T) {
+	sr := newWaitOnTerminalTestExec(t, make(chan Event, 1))
+
+	done := make(chan struct{})
+	go func() {
+		sr.waitOnTerminal()
+		close(done)
+	}()
+
+	// Simulate the dropped-send race: cancel ctx (as Close's ctxCancel does)
+	// without ever sending on closeReqCh (as watchChildExit does when it picks
+	// its own ctx.Done() arm).
+	sr.ctxCancel()
+
+	select {
+	case <-done:
+		// waitOnTerminal escaped via ctx.Done() — no leak.
+	case <-time.After(5 * time.Second):
+		t.Fatalf("waitOnTerminal did not return after ctx cancel; goroutine leaked (#397)")
+	}
+}
+
+// TestWaitOnTerminal_NormalExit_PublishesEvent asserts the clean path is
+// unchanged: when watchChildExit delivers the exit error on closeReqCh,
+// waitOnTerminal receives it and publishes EvCmdExited carrying that error.
+func TestWaitOnTerminal_NormalExit_PublishesEvent(t *testing.T) {
+	evCh := make(chan Event, 1)
+	sr := newWaitOnTerminalTestExec(t, evCh)
+
+	done := make(chan struct{})
+	go func() {
+		sr.waitOnTerminal()
+		close(done)
+	}()
+
+	wantErr := errors.New("shell process exited: code=0")
+	select {
+	case sr.closeReqCh <- wantErr:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("waitOnTerminal never received on closeReqCh")
+	}
+
+	select {
+	case ev := <-evCh:
+		if ev.Type != EvCmdExited {
+			t.Fatalf("event Type=%v; want EvCmdExited", ev.Type)
+		}
+		if !errors.Is(ev.Err, wantErr) {
+			t.Fatalf("event Err=%v; want %v", ev.Err, wantErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("waitOnTerminal did not publish EvCmdExited")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("waitOnTerminal did not return after publishing event")
+	}
+}


### PR DESCRIPTION
## Summary

- `waitOnTerminal` (the sole receiver on `closeReqCh`) did a bare `<-sr.closeReqCh` with no ctx escape, while its sole sender `watchChildExit` already had a ctx-guarded send select. On an externally-driven `Close` that escalates to SIGKILL, `ctxCancel` is already done by the time the sender selects, so ~50% of the time the sender takes its `ctx.Done()` arm and **drops** the exit value. With the channel unbuffered (`terminal_runner_exec.go:209`), the receiver then parks on the bare receive forever — leaking one `waitOnTerminal` goroutine (plus its `Exec`, never GC-able) per affected `Close`. The issue measured 19/30 New→Start→Close cycles leaking.
- Fix per the issue's first (smallest, most symmetric) suggestion: give `waitOnTerminal` the same `select { case <-closeReqCh / case <-ctx.Done() }` escape the sender has. On a clean exit the value arrives and `EvCmdExited` is published exactly as before; on the dropped-send race the receiver escapes via `ctx.Done()` and returns instead of leaking.

## Note on issue premise (line numbers)

The issue cites `lifecycle.go:109-114,157-160,225`, but #398 (the reaper-zombie fix, now on `main`) shifted those: `waitOnTerminal`'s receive is now at `lifecycle.go:121`, the sender's send select at `185-187`, and `ctxCancel` at `295`. The structure the bug depends on is unchanged — bare receiver vs. ctx-guarded sender on an unbuffered channel — so the diagnosis and fix hold verbatim against current `main`.

## Test plan

- [x] New deterministic regression test `lifecycle_wait_on_terminal_test.go`:
  - `TestWaitOnTerminal_CtxCancel_NoLeak` — unbuffered `closeReqCh` (matching production), cancel ctx without ever sending (the dropped-send race), assert `waitOnTerminal` returns rather than parking. Fails (5s timeout) against the pre-fix bare receive.
  - `TestWaitOnTerminal_NormalExit_PublishesEvent` — clean path unchanged: value delivered → `EvCmdExited` carrying the error published.
- [x] `go build ./...`, `go vet ./internal/terminal/terminalrunner/...`
- [x] `make sbsh-sb` (ELF verified, `sb` hardlinked)
- [x] `make test` (full CI suite incl. e2e) — green
- [x] `make test-race` — green (AC item 2)

## Acceptance criteria

- [x] Repeated New→Start→Close cycles (including the SIGKILL-escalation path with a SIGTERM-ignoring child) leave zero goroutines parked in `waitOnTerminal` — the receiver now has a ctx escape, so a dropped sender send can no longer strand it. Verified deterministically by `TestWaitOnTerminal_CtxCancel_NoLeak` (which reproduces the dropped-send race directly rather than relying on the coin-flip full-cycle repro).
- [x] `make test-race` stays green.

Closes #397