### PR TITLE
test: de-flake trap.sh ETXTBSY by writing it once in TestMain

### DIFF
--- a/pkg/spawn/lifecycle_test.go
+++ b/pkg/spawn/lifecycle_test.go
@@ -44,15 +44,30 @@ import (
 // goroutines races on the kernel's writer-FD check and surfaces as ETXTBSY.
 var sharedSleeperPath string
 
+// sharedTrapPath is the package-shared path to a trap.sh script that traps and
+// ignores SIGTERM (so gracefulShutdown must escalate to SIGKILL). Written once
+// in TestMain before any test runs for the same reason as sharedSleeperPath
+// (see #377): a per-test os.WriteFile of an executable then fork+exec from
+// sibling parallel goroutines races on the kernel's writer-FD check and
+// surfaces as ETXTBSY. The script body is static, so a single shared copy
+// suffices.
+var sharedTrapPath string
+
 func TestMain(m *testing.M) {
-	dir, err := os.MkdirTemp("", "spawn-test-sleeper-")
+	dir, err := os.MkdirTemp("", "spawn-test-scripts-")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "spawn tests: create sleeper tempdir: %v\n", err)
+		fmt.Fprintf(os.Stderr, "spawn tests: create script tempdir: %v\n", err)
 		os.Exit(1)
 	}
 	sharedSleeperPath = filepath.Join(dir, "sleeper.sh")
 	if err := os.WriteFile(sharedSleeperPath, []byte("#!/bin/sh\nexec sleep 30\n"), 0o755); err != nil {
 		fmt.Fprintf(os.Stderr, "spawn tests: write sleeper: %v\n", err)
+		_ = os.RemoveAll(dir)
+		os.Exit(1)
+	}
+	sharedTrapPath = filepath.Join(dir, "trap.sh")
+	if err := os.WriteFile(sharedTrapPath, []byte("#!/bin/sh\ntrap '' TERM\nwhile true; do sleep 1; done\n"), 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "spawn tests: write trap script: %v\n", err)
 		_ = os.RemoveAll(dir)
 		os.Exit(1)
 	}
@@ -66,6 +81,13 @@ func TestMain(m *testing.M) {
 func sleeperBinary(t *testing.T) string {
 	t.Helper()
 	return sharedSleeperPath
+}
+
+// trapBinary returns the package-shared trap.sh path written once in TestMain.
+// See sharedTrapPath's docstring for the rationale.
+func trapBinary(t *testing.T) string {
+	t.Helper()
+	return sharedTrapPath
 }
 
 // TestClientHandle_Close_NoSocketEscalates spawns a long-lived child whose
@@ -267,13 +289,10 @@ func TestResolveStdio_ExplicitStreamsNotRedirected(t *testing.T) {
 // SIGKILL to reap it.
 func TestGracefulShutdown_SIGKILLEscalation(t *testing.T) {
 	t.Parallel()
-	path := filepath.Join(t.TempDir(), "trap.sh")
-	// Trap SIGTERM so the SIGTERM step times out and SIGKILL is required.
-	script := "#!/bin/sh\ntrap '' TERM\nwhile true; do sleep 1; done\n"
-	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
-		t.Fatalf("write trap script: %v", err)
-	}
-	cmd := exec.Command(path)
+	// trap.sh traps SIGTERM so the SIGTERM step times out and SIGKILL is
+	// required. Written once in TestMain (not per-test) to avoid the ETXTBSY
+	// fork/exec race under t.Parallel(); see sharedTrapPath.
+	cmd := exec.Command(trapBinary(t))
 	proc, err := startProcess(cmd, nil)
 	if err != nil {
 		t.Fatalf("startProcess: %v", err)


### PR DESCRIPTION
## Summary

- `TestGracefulShutdown_SIGKILLEscalation` wrote an executable `trap.sh` per-test via `os.WriteFile` then immediately `fork`/`exec`'d it. Under `t.Parallel()` (and `-count`), a sibling test's `fork` could inherit the still-open write fd, so `execve` returned `ETXTBSY` ("text file busy"). This is the same race #376/#377 eliminated for `sleeper.sh` — but #377 only migrated the shared sleeper into `TestMain`; the per-test `trap.sh` was left behind.
- Applies the #377 remedy: `trap.sh` is now written once in `TestMain` (before any parallel test runs) to a package-shared path, exposed via a `trapBinary(t)` helper mirroring `sleeperBinary(t)`. The script body is static so a single shared copy suffices. The `TestMain` tempdir is renamed `spawn-test-scripts-` since it now holds both scripts.
- Audited `pkg/spawn` per AC item 2: `git grep WriteFile pkg/spawn/` confirms the only remaining `os.WriteFile(…0o755)` calls are the two TestMain writes (sleeper + trap); no per-test write-then-exec of an executable remains.

## Test plan

- [x] `go test -count=5 ./pkg/spawn/...` — passes, no `text file busy`
- [x] `go test -race -count=5 ./pkg/spawn/...` — passes, no `text file busy`
- [x] `make test` — all packages pass
- [x] `make test-race` (covers `./pkg/...`) — all packages pass
- [x] `make sbsh-sb` — builds `sbsh` + `sb` (ELF verified)

Closes #394