### PR TITLE
fix: treat os.ErrProcessDone from SIGKILL as stopped, not failed

### DIFF
--- a/cmd/sb/stop/terminals.go
+++ b/cmd/sb/stop/terminals.go
@@ -396,13 +396,25 @@ func sendSignal(pid int, pidStart uint64, sig syscall.Signal) error {
 		return fmt.Errorf("%w: %w", errdefs.ErrSignalProcess, err)
 	}
 	if err := proc.Signal(sig); err != nil {
-		if errors.Is(err, syscall.ESRCH) {
+		if isProcessGoneErr(err) {
 			// Process is already gone — not an error for our purposes.
 			return nil
 		}
 		return fmt.Errorf("%w: %w", errdefs.ErrSignalProcess, err)
 	}
 	return nil
+}
+
+// isProcessGoneErr reports whether err from a signal delivery means the target
+// process has already exited. The raw syscall path (syscall.Kill) surfaces this
+// as ESRCH; the pidfd-backed os.Process.Signal path (Go 1.23+) surfaces it as
+// os.ErrProcessDone ("os: process already finished"). Either way the process is
+// gone, which is exactly the goal of a stop — so callers escalating to SIGKILL
+// must classify it as success, not failure. Without the os.ErrProcessDone arm a
+// child that exits on its own in the window between the grace deadline and the
+// SIGKILL syscall is misreported as resultFailed (a TOCTOU race).
+func isProcessGoneErr(err error) bool {
+	return errors.Is(err, syscall.ESRCH) || errors.Is(err, os.ErrProcessDone)
 }
 
 // processIsOurs reports whether pid is alive AND matches the recorded

--- a/cmd/sb/stop/terminals_test.go
+++ b/cmd/sb/stop/terminals_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net"
@@ -392,5 +393,34 @@ func Test_SendPgroupKill_GoneGroupIsNoOp(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	if err := sendPgroupKill(pgid); err != nil {
 		t.Fatalf("sendPgroupKill(drained pgid=%d) = %v; want nil (ESRCH suppressed)", pgid, err)
+	}
+}
+
+// Test_IsProcessGoneErr covers the error classification at the heart of #411:
+// a SIGKILL escalation that races a process exiting on its own must treat the
+// "already gone" signals as success. ESRCH comes from the raw syscall path;
+// os.ErrProcessDone ("os: process already finished") comes from the pidfd-backed
+// os.Process.Signal path (Go 1.23+) — the latter is what regressed, since the
+// pre-fix check only matched ESRCH.
+func Test_IsProcessGoneErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"esrch", syscall.ESRCH, true},
+		{"esrch wrapped", fmt.Errorf("kill: %w", syscall.ESRCH), true},
+		{"process done", os.ErrProcessDone, true},
+		{"process done wrapped", fmt.Errorf("signal: %w", os.ErrProcessDone), true},
+		{"nil", nil, false},
+		{"unrelated", syscall.EPERM, false},
+		{"unrelated wrapped", fmt.Errorf("signal: %w", syscall.EPERM), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isProcessGoneErr(tc.err); got != tc.want {
+				t.Fatalf("isProcessGoneErr(%v) = %v; want %v", tc.err, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- `sb stop --kill-after` misreported a stop as `resultFailed` when the child exited on its own in the TOCTOU window between the SIGTERM grace deadline (`waitForExit` at `terminals.go:298`) and the escalation SIGKILL (`terminals.go:316`). Surfaced as a flaky `Test_StopOneTerminal_KillAfterEscalates` failure under parallel-suite CPU contention.
- Root cause was error *classification*, not the 200ms grace: `sendSignal` (`terminals.go:398`) swallowed `syscall.ESRCH` from `proc.Signal`, but the pidfd-backed `os.Process.Signal` path (Go 1.23+; this repo builds on go1.24) returns `os.ErrProcessDone` ("os: process already finished") for an already-exited process — exactly the observed stderr — which the ESRCH-only check missed, so the error propagated and the escalation branch returned `resultFailed`.
- Fix extracts the "process is gone" classification into `isProcessGoneErr`, matching both `syscall.ESRCH` and `os.ErrProcessDone`, and uses it in `sendSignal`. Because all SIGKILL callers (graceful SIGTERM fallback, `--force`, `--kill-after` escalation) route through `sendSignal`, fixing it at the source covers every path. A SIGKILL that finds the process already gone is success — the goal of the stop.
- The companion pgroup kill (`sendPgroupKill`, `terminals.go:367`) was already covered: it calls `syscall.Kill` directly, which returns raw `ESRCH` (not `os.ErrProcessDone`) and already suppresses it. No change needed there; confirmed by reading the function.

## Notes on test choice
The bug is an inherently racy TOCTOU window, so the regression guard is a deterministic table test on the extracted `isProcessGoneErr` classifier (the exact fix point) rather than an attempt to reproduce the race. An end-to-end `sendSignal`-on-a-reaped-process test was considered and dropped: it would pass via the earlier `pidutil.Match` → `os.ErrNotExist` short-circuit (`terminals.go:384`), not the `proc.Signal` → `os.ErrProcessDone` branch being fixed, so it would be a misleading guard.

## Test plan
- [x] `make sbsh-sb` (ELF verified — magic `7f 45 4c 46`, `file` not installed on host)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./cmd/sb/stop/...` (incl. new `Test_IsProcessGoneErr`, and `Test_StopOneTerminal_KillAfterEscalates`)
- [x] Full unit suite: `go test -timeout=5m $(go list ./... | grep -v '/e2e$')`
- [x] Integration: `go test -tags=integration ./cmd/sb/get/...`
- [x] E2E: `E2E_BIN_DIR=$(pwd) go test ./e2e`
- [x] `pre-commit run --files` on the changed files (golangci-lint, go fmt, addlicense — all pass)

Closes #411