### PR TITLE
fix: trap SIGHUP/SIGQUIT in attached client so parent terminal modes are restored

### DIFF
--- a/cmd/sb/attach/attach.go
+++ b/cmd/sb/attach/attach.go
@@ -186,9 +186,12 @@ func run(
 		return errdefs.ErrLoggerNotFound
 	}
 
-	// Top-level context also reacts to SIGINT/SIGTERM (nice UX). pkg/attach
-	// deliberately does not trap signals itself; the CLI owns that policy.
-	ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+	// Top-level context also reacts to SIGINT/SIGTERM/SIGHUP/SIGQUIT (nice UX).
+	// pkg/attach deliberately does not trap signals itself; the CLI owns that
+	// policy. Trapping HUP/QUIT drives the same ctx-cancel → restoreParentTerminal
+	// path as INT/TERM, so a HUP/QUIT whose tty survives doesn't leave the parent
+	// shell in raw mode with DEC private modes still active.
+	ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT)
 	defer cancel()
 
 	socketPath, err := resolveTerminalSocket(cmd, logger, args)

--- a/cmd/sbsh/sbsh.go
+++ b/cmd/sbsh/sbsh.go
@@ -230,7 +230,10 @@ You can also use sbsh with parameters. For example:
 				}
 			}
 
-			ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+			// Trap HUP/QUIT alongside INT/TERM so they drive the same ctx-cancel →
+			// restoreParentTerminal path; otherwise a HUP/QUIT whose tty survives
+			// leaves the parent shell in raw mode with DEC private modes active.
+			ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT)
 			ctrl := client.NewClientController(ctx, logger)
 
 			return runClient(ctx, cancel, logger, ctrl, doc)

--- a/e2e/e2e_sbsh_signal_test.go
+++ b/e2e/e2e_sbsh_signal_test.go
@@ -1,0 +1,191 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// ptyTermios reads the line-discipline state of the pty referred to by fd.
+// Reading from the pty master reflects the termios the attached client set on
+// the slave, so the test can observe raw->cooked transitions from the parent
+// side. (The precondition assertions below confirm the master view tracks the
+// slave: it reports raw while attached and canonical after restore.)
+func ptyTermios(t *testing.T, fd uintptr) *unix.Termios {
+	t.Helper()
+	tio, err := unix.IoctlGetTermios(int(fd), unix.TCGETS)
+	if err != nil {
+		t.Fatalf("IoctlGetTermios: %v", err)
+	}
+	return tio
+}
+
+// isCanonical reports whether the terminal is in cooked mode with echo — the
+// "stty -a shows canonical mode with echo" state the issue's AC names.
+func isCanonical(tio *unix.Termios) bool {
+	return tio.Lflag&unix.ICANON != 0 && tio.Lflag&unix.ECHO != 0
+}
+
+// waitClientReady blocks until the attached client logs that it has finished
+// attaching and entered its steady-state event loop, or the deadline elapses.
+//
+// The signal must land in that event loop, not during the earlier WaitReady
+// phase: the IO copiers begin relaying bytes while Attach is still in progress
+// (so a visible prompt or even a command round-trip is *not* proof of
+// readiness), and a signal caught mid-WaitReady takes an early-return path that
+// legitimately skips restore and is out of scope here. The controller writes
+// "controller ready, entering main event loop" at info level to its per-client
+// log under <run_path>/clients/<id>/log exactly when WaitReady unblocks, which
+// is the precise, race-free gate.
+func waitClientReady(t *testing.T, runPath string, timeout time.Duration) {
+	t.Helper()
+	const marker = "controller ready, entering main event loop"
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		logs, _ := filepath.Glob(filepath.Join(runPath, "clients", "*", "log"))
+		for _, lf := range logs {
+			if b, err := os.ReadFile(lf); err == nil && strings.Contains(string(b), marker) {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("client did not reach steady-state event loop within %v", timeout)
+}
+
+// spawnSbshOnPty starts sbsh attached to pts and returns the process handle so
+// the caller can deliver a signal directly to the client. It mirrors
+// runPersistentBinaryPty but hands back *os.Process instead of swallowing it.
+func spawnSbshOnPty(t *testing.T, pts *os.File, env []string) *os.Process {
+	t.Helper()
+
+	bin := resolveBinary(t, sbsh)
+
+	env = append(env,
+		`PS1="__P__ "`,
+		"TERM=xterm",
+		"LANG=C",
+		"COLUMNS=120",
+		"LINES=40",
+	)
+	files := []*os.File{pts, pts, pts}
+	procAttr := &os.ProcAttr{
+		Env:   env,
+		Files: files,
+		Sys: &syscall.SysProcAttr{
+			Setsid:  true,
+			Setctty: true,
+			Ctty:    0,
+		},
+	}
+
+	p, err := os.StartProcess(bin, []string{bin}, procAttr)
+	if err != nil {
+		t.Fatalf("StartProcess: %v", err)
+	}
+	return p
+}
+
+// TestSbsh_SignalRestoresTerminal asserts that a SIGHUP or SIGQUIT delivered to
+// an attached client (tty surviving) drives the ctx-cancel -> restore path so
+// the controlling terminal is left in canonical mode with echo, rather than
+// stranded in raw mode with DEC private modes still active. Regression test for
+// the client trapping only INT/TERM: with HUP/QUIT untrapped they took the
+// default terminate disposition and skipped restore entirely.
+func TestSbsh_SignalRestoresTerminal(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		sig  syscall.Signal
+	}{
+		{"SIGHUP", syscall.SIGHUP},
+		{"SIGQUIT", syscall.SIGQUIT},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			requireBinaries(t, sb, sbsh)
+			runPath := newRunPath(t)
+
+			t.Cleanup(func() {
+				runPathEnv := buildSbRunPathEnv(t, runPath)
+				runReturningBinary(t, []string{runPathEnv}, sb, "prune", "terminals", "--verbose", "--log-level", "debug")
+				runReturningBinary(t, []string{runPathEnv}, sb, "prune", "clients", "--verbose", "--log-level", "debug")
+			})
+
+			ptmx, pts := setupPty(t)
+			defer func() { _ = ptmx.Close() }()
+
+			// Drain the pty master so the client never blocks writing output.
+			go func() {
+				buf := make([]byte, 4096)
+				for {
+					if _, err := ptmx.Read(buf); err != nil {
+						return
+					}
+				}
+			}()
+
+			env := append([]string{}, getRandomSbshRunPath(t, runPath))
+			proc := spawnSbshOnPty(t, pts, env)
+			// pts belongs to the child now; drop our copy so the child and the
+			// kernel line discipline are the only holders.
+			_ = pts.Close()
+
+			waitCh := make(chan error, 1)
+			go func() { _, werr := proc.Wait(); waitCh <- werr }()
+
+			// Gate on the client reaching its steady-state event loop before the
+			// signal — see waitClientReady for why a prompt/round-trip won't do.
+			waitClientReady(t, runPath, 8*time.Second)
+
+			// Precondition: attached client put the terminal into raw mode.
+			if isCanonical(ptyTermios(t, ptmx.Fd())) {
+				t.Fatalf("expected raw mode while attached, but terminal is canonical")
+			}
+
+			// Deliver the signal directly to the client process.
+			if err := proc.Signal(tc.sig); err != nil {
+				t.Fatalf("signalling %v: %v", tc.sig, err)
+			}
+
+			select {
+			case <-waitCh:
+			case <-time.After(5 * time.Second):
+				_ = proc.Kill()
+				t.Fatalf("timeout waiting for client to exit after %v", tc.sig)
+			}
+
+			// Restore runs during ctx-cancel teardown before the process exits;
+			// poll briefly to absorb teardown latency.
+			deadline := time.Now().Add(2 * time.Second)
+			for {
+				if isCanonical(ptyTermios(t, ptmx.Fd())) {
+					break
+				}
+				if !time.Now().Before(deadline) {
+					t.Fatalf("terminal not restored to canonical mode after %v", tc.sig)
+				}
+				time.Sleep(20 * time.Millisecond)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- The attached client (`sb attach` and `sbsh`) trapped only `os.Interrupt` and `SIGTERM` via `signal.NotifyContext`, so a `SIGHUP` or `SIGQUIT` took the default terminate disposition: the process died without ctx cancellation, `restoreParentTerminal` never ran, and whenever the controlling terminal survived the signal the parent shell was left in raw mode with mouse-tracking/bracketed-paste/alt-screen still active.
- Fix: add `syscall.SIGHUP` and `syscall.SIGQUIT` to the client's `signal.NotifyContext` set at both sites (`cmd/sb/attach/attach.go:191`, `cmd/sbsh/sbsh.go:233`), so HUP/QUIT drive the same ctx-cancel → `restoreParentTerminal` path as INT/TERM. This matches the server-side parity set in `internal/terminal/terminalrunner/signals_linux.go` (`SIGTERM, SIGINT, SIGHUP, SIGQUIT`).

## Verification — instrumented e2e regression test

Added `e2e/e2e_sbsh_signal_test.go` (`TestSbsh_SignalRestoresTerminal`, subtests SIGHUP and SIGQUIT). It spawns `sbsh` on a real pty, asserts the terminal is in **raw** mode while attached, delivers the signal directly to the client, and asserts the pty returns to **canonical mode with echo** (the `stty -a` observable the AC names) — read via `IoctlGetTermios(TCGETS)` on the pty master.

Per `agents/dev/CLAUDE.md` §Verifying behavioral runtime fixes, this is a real instrumented test of the runtime path (not a static trace). I confirmed it has teeth: reverting the fix and rebuilding makes both subtests **fail** (`terminal not restored to canonical mode`); with the fix they pass.

Notes on the test design (documented so the reviewer can audit the non-obvious parts):
- The signal must land in the controller's steady-state event loop, **not** during the earlier `WaitReady` phase. The IO copiers begin relaying while `Attach` is still in progress, so a visible prompt — or even a full command round-trip — is *not* proof of readiness (a signal caught mid-`WaitReady` takes an early-return path that legitimately skips restore and is out of scope for this issue). The test gates on the controller's `"controller ready, entering main event loop"` log line (written to `<run_path>/clients/<id>/log` exactly when `WaitReady` unblocks) — a race-free readiness signal rather than a blind sleep.

## Scope note

The e2e test exercises the `sbsh` client path. The `sb attach` path (`cmd/sb/attach/attach.go`) receives the line-identical edit and funnels through the same `pkg/attach` → client-runner `restoreParentTerminal` teardown driven by the same `signal.NotifyContext` ctx, so the mechanism the test verifies is shared. A dedicated `sb attach` e2e (start a server terminal, then attach) was not added to keep this PR focused; flagging it so the reviewer can request one if desired.

## Test plan

- [x] `make sbsh-sb` (canonical build; ELF verified via magic bytes — `file` not installed on host)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite, includes the new e2e test)
- [x] Regression test fails without the fix, passes with it (verified by reverting both sites, rebuilding, re-running)

## Acceptance criteria

- [x] `kill -HUP` / `kill -QUIT` on an attached client restores the parent terminal modes before exit when the tty survives — verified by `TestSbsh_SignalRestoresTerminal`.
- [x] `stty -a` after the signal shows the terminal back in canonical mode with echo — the test asserts exactly `ICANON` + `ECHO` re-set on the pty.

Closes #392