### PR TITLE
fix: restore parent terminal when signal cancels ctx during attach window

### DIFF
--- a/cmd/sbsh/sbsh.go
+++ b/cmd/sbsh/sbsh.go
@@ -503,8 +503,26 @@ func runClient(
 
 	logger.DebugContext(ctx, "waiting for controller to signal ready")
 	if err := ctrl.WaitReady(); err != nil {
-		logger.DebugContext(ctx, "controller not ready", "error", err)
-		return fmt.Errorf("%w: %w", errdefs.ErrWaitOnReady, err)
+		// A signal that cancels ctx during the attach window makes WaitReady
+		// return ctx.Err() before readiness. By this point the controller's
+		// Attach has already put the parent terminal into raw mode (the IO
+		// copiers are relaying the prompt), so returning straight away strands
+		// the parent shell in raw mode — the failure #392 fixes for the
+		// steady-state path, surfacing here on an earlier window. Drive the
+		// same WaitClose/isCleanSessionEnd teardown the ctx.Done arm below
+		// uses: the controller's Run goroutine runs Close once Attach unblocks
+		// on the cancelled ctx, and Close restores the parent terminal before
+		// closing the channel WaitClose blocks on. A handled signal
+		// (context.Canceled) then exits 0 like the steady-state arm; a genuine
+		// readiness failure still surfaces wrapped in ErrWaitOnReady. See #419.
+		logger.DebugContext(ctx, "controller not ready, draining teardown", "error", err)
+		if errC := ctrl.WaitClose(); errC != nil {
+			err = fmt.Errorf("%w: %w", errdefs.ErrWaitOnClose, errC)
+		}
+		if !isCleanSessionEnd(err) {
+			return fmt.Errorf("%w: %w", errdefs.ErrWaitOnReady, err)
+		}
+		return nil
 	}
 
 	logger.DebugContext(ctx, "controller ready, entering client event loop")

--- a/cmd/sbsh/sbsh_test.go
+++ b/cmd/sbsh/sbsh_test.go
@@ -168,6 +168,80 @@ func TestRunTerminal_ErrWaitOnReady(t *testing.T) {
 	}
 }
 
+// TestRunTerminal_WaitReadyContextCanceledDrivesTeardown covers issue #419:
+// when a signal cancels ctx during the attach window, WaitReady returns
+// context.Canceled before readiness. runClient must drive the WaitClose
+// teardown (which restores the parent terminal) and exit 0 rather than
+// returning the spurious ErrWaitOnReady that left the terminal in raw mode.
+func TestRunTerminal_WaitReadyContextCanceledDrivesTeardown(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	waitCloseCalled := make(chan struct{}, 1)
+	newClientController := func(_ context.Context) api.ClientController {
+		return &client.ControllerTest{
+			RunFunc: func(_ *api.ClientDoc) error {
+				return nil
+			},
+			WaitReadyFunc: func() error {
+				// The real Controller.WaitReady only returns non-nil via its
+				// ctx.Done arm, i.e. context.Canceled on a signal landing in
+				// the attach window.
+				return context.Canceled
+			},
+			WaitCloseFunc: func() error {
+				waitCloseCalled <- struct{}{}
+				return nil
+			},
+			StartFunc: func() error {
+				return nil
+			},
+		}
+	}
+
+	ctrl := newClientController(context.Background())
+
+	t.Cleanup(func() {})
+
+	doc := &api.ClientDoc{
+		APIVersion: api.APIVersionV1Beta1,
+		Kind:       api.KindClient,
+		Metadata: api.ClientMetadata{
+			Name:        naming.RandomName(),
+			Labels:      make(map[string]string),
+			Annotations: make(map[string]string),
+		},
+		Spec: api.ClientSpec{
+			ID:           api.ID(naming.RandomID()),
+			LogFile:      "/tmp/sbsh-logs/s0",
+			RunPath:      viper.GetString(config.SBSH_ROOT_RUN_PATH.ViperKey),
+			TerminalSpec: nil,
+		},
+	}
+	done := make(chan error)
+	defer close(done)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		done <- runClient(ctx, cancel, logger, ctrl, doc)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected nil (clean signal-during-window exit); got: '%v'", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for runClient to return")
+	}
+
+	select {
+	case <-waitCloseCalled:
+		// WaitClose drove the teardown that restores the parent terminal.
+	default:
+		t.Fatal("expected WaitClose to be called on the WaitReady-cancel path")
+	}
+}
+
 func TestRunTerminal_ErrContextDoneWithWaitCloseError(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 


### PR DESCRIPTION
## Summary

- A signal that cancels the client's context **during the attach window** — after the controller's `Attach` has put the parent terminal into raw mode (the IO copiers are already relaying the prompt) but before `runClient`'s `ctrl.WaitReady()` returns — took the `ErrWaitOnReady` early-return path at `cmd/sbsh/sbsh.go` and exited **without** driving the terminal-restore teardown. The parent shell was left stranded in raw mode. This is the attach-window analogue of the steady-state stranding #392 addresses; it is a different, earlier code path and is not fixed by #392.
- `WaitReady` only returns non-nil via `Controller.WaitReady`'s `ctx.Done` arm (`internal/client/controller.go:108-115`), i.e. `context.Canceled` from a signal landing in the window. The early return wrapped it in `ErrWaitOnReady` and returned immediately, never reaching the steady-state `ctx.Done` arm that drives `ctrl.WaitClose()` → controller `Close` → runner `Close` → `restoreParentTerminal`.

## Fix

Route the `WaitReady`-error path through the **same `WaitClose`/`isCleanSessionEnd` teardown the adjacent `ctx.Done` arm already uses** (the issue's first suggested option). When the controller's `Run` goroutine unblocks `Attach` on the cancelled ctx, its `Close` restores the parent terminal *before* closing the channel `WaitClose` blocks on (`controller.go:444` runs `sr.Close` ahead of `close(closedCh)` at `:450`), so on `WaitClose` return the restore is guaranteed complete. A handled signal (`context.Canceled`) then exits 0 like the steady-state arm, matching the clean-session-end contract from #380/#381; a genuine readiness failure still surfaces wrapped in `ErrWaitOnReady`.

No deadlock risk: `Attach`'s only blocking steps are `waitReady` calls that honour `sr.ctx` (bounded by `waitReadyTimeout`), so `Attach` reliably returns on ctx-cancel and `Run` reaches `Close` (via the `Attach`-error path at `controller.go:249` or, on a racing `Attach` success, the loop's `ctx.Done` arm).

### `pkg/attach` audit (the issue asked to audit it)

`pkg/attach.Run` already handles its analogous window correctly: on `WaitReady` error it calls `ctrl.Close(waitErr)` then drains `<-errCh` (`pkg/attach/attach.go:152-164`), and `Close` drives `restoreParentTerminal`. No change needed there. The gap was specific to `cmd/sbsh`, which relies on `Run` to drive `Close` rather than calling it proactively — fixed here by driving `WaitClose` on the early-return path, consistent with `cmd/sbsh`'s own steady-state arm.

## Verification basis

The fix's contract is *"the `WaitReady`-cancel path drives `WaitClose` and exits 0 instead of returning a spurious `ErrWaitOnReady`"*. The new fake-controller unit test observes exactly that contract (it asserts `WaitClose` is invoked and `runClient` returns nil). The actual raw-mode `restoreParentTerminal` it ultimately drives is exercised by the runner's existing terminal-restore tests; this PR wires `cmd/sbsh`'s early-return path into that same teardown.

The issue's repro is a pty-level e2e (signal-on-prompt-detection lands in the window). This repo's `cmd/sbsh` suite has no pty-e2e harness for that path, so the end-to-end raw-mode observation the issue describes is **not** reproduced as an automated test here — the regression is covered at the controller-contract tier instead. Flagged for transparency per the runtime-behavioral-verification bar.

## Test plan

- [x] `make sbsh-sb` — canonical build; binary verified ELF (`7f 45 4c 46`) and runnable (`sbsh version`)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — full suite, `GOTEST-EXIT=0`, zero FAIL lines
- [x] New regression test `TestRunTerminal_WaitReadyContextCanceledDrivesTeardown` passes; existing `TestRunTerminal_ErrWaitOnReady` (non-clean error path) still passes
- [ ] pty-level e2e reproducing the stranded-raw-mode observable — no pty-e2e harness exists for `cmd/sbsh`'s client path; covered at the controller-contract tier instead (see Verification basis)

Closes #419