### PR TITLE
fix: reap orphan terminal dirs in prune and warn about them in get

### DIFF
--- a/cmd/sb/get/terminals.go
+++ b/cmd/sb/get/terminals.go
@@ -94,10 +94,11 @@ func listTerminals(cmd *cobra.Command, _ []string) error {
 		"args", cmd.Flags().Args(),
 	)
 
+	runPath := viper.GetString(config.SB_ROOT_RUN_PATH.ViperKey)
 	err := discovery.ScanAndPrintTerminals(
 		cmd.Context(),
 		logger,
-		viper.GetString(config.SB_ROOT_RUN_PATH.ViperKey),
+		runPath,
 		os.Stdout,
 		viper.GetBool(listAllInput),
 		format,
@@ -106,6 +107,12 @@ func listTerminals(cmd *cobra.Command, _ []string) error {
 		logger.Debug("error scanning and printing terminals", "error", err)
 		fmt.Fprintln(os.Stderr, "Could not scan terminals")
 		return err
+	}
+	// Orphan dirs (missing/corrupt metadata.json) are invisible to the scan
+	// above; warn on stderr so the leak is observable without --verbose and
+	// without disturbing parseable stdout output. See #391.
+	if _, errOrphans := discovery.ReportOrphanTerminalDirs(cmd.Context(), logger, runPath, os.Stderr); errOrphans != nil {
+		logger.Debug("error reporting orphan terminal directories", "error", errOrphans)
 	}
 	logger.Debug("terminals list completed successfully")
 	return nil

--- a/internal/discovery/orphans.go
+++ b/internal/discovery/orphans.go
@@ -1,0 +1,126 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	pkgdiscovery "github.com/eminwux/sbsh/pkg/discovery"
+)
+
+// liveSocketProbeTimeout bounds the dial used to decide whether an orphan
+// terminal directory still hosts a live control socket. Mirrors the probe
+// in terminalrunner.OpenSocketCtrl: a successful dial means a live peer is
+// serving the path; ENOENT/ECONNREFUSED/timeout means nobody is accepting.
+const liveSocketProbeTimeout = 100 * time.Millisecond
+
+// pruneOrphanTerminalDirs removes terminal directories whose metadata.json
+// is missing or unparseable. ScanTerminals can never return such
+// directories, so the metadata-driven prune in ScanAndPruneTerminals never
+// reaps them and they leak on disk indefinitely (see #391). A directory
+// hosting a live unix socket is never removed: corrupt metadata does not
+// prove the terminal process is gone, and a live socket proves it is not.
+func pruneOrphanTerminalDirs(ctx context.Context, logger *slog.Logger, runPath string, w io.Writer) error {
+	orphans, err := pkgdiscovery.OrphanTerminalDirs(ctx, logger, runPath)
+	if err != nil {
+		return err
+	}
+	for _, dir := range orphans {
+		if hasLiveSocket(ctx, dir) {
+			logger.WarnContext(
+				ctx,
+				"pruneOrphanTerminalDirs: skipping orphan dir with live socket",
+				"dir", dir,
+			)
+			if w != nil {
+				fmt.Fprintf(w, "Skipped orphan terminal directory %s (live socket)\n", dir)
+			}
+			continue
+		}
+		if errRemove := os.RemoveAll(dir); errRemove != nil {
+			logger.ErrorContext(
+				ctx,
+				"pruneOrphanTerminalDirs: failed to remove orphan dir",
+				"dir", dir,
+				"error", errRemove,
+			)
+			return fmt.Errorf("prune orphan terminal dir %s: %w", dir, errRemove)
+		}
+		logger.InfoContext(ctx, "pruneOrphanTerminalDirs: orphan terminal dir removed", "dir", dir)
+		if w != nil {
+			fmt.Fprintf(w, "Pruned orphan terminal directory %s (missing or corrupt metadata.json)\n", dir)
+		}
+	}
+	return nil
+}
+
+// hasLiveSocket reports whether any unix socket directly inside dir accepts
+// a connection. Best-effort: a terminal whose control socket was placed
+// outside its run dir (custom Spec.SocketFile) is not detected, but the
+// default layout (runPath/terminals/<id>/socket) is covered.
+func hasLiveSocket(ctx context.Context, dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	dialer := net.Dialer{Timeout: liveSocketProbeTimeout}
+	for _, e := range entries {
+		if e.Type()&fs.ModeSocket == 0 {
+			continue
+		}
+		conn, errDial := dialer.DialContext(ctx, "unix", filepath.Join(dir, e.Name()))
+		if errDial == nil {
+			_ = conn.Close()
+			return true
+		}
+	}
+	return false
+}
+
+// ReportOrphanTerminalDirs writes a one-line warning to w when directories
+// with missing or unparseable metadata.json exist under runPath/terminals,
+// and returns the orphan count. It gives `sb get terminals` a non-verbose
+// signal that invisible directories need cleanup — without it the only
+// trace is a Warn-level log hidden behind --verbose. Best-effort: callers
+// surface the count, not the listing; `sb prune terminals` does the reaping.
+func ReportOrphanTerminalDirs(ctx context.Context, logger *slog.Logger, runPath string, w io.Writer) (int, error) {
+	orphans, err := pkgdiscovery.OrphanTerminalDirs(ctx, logger, runPath)
+	if err != nil {
+		return 0, err
+	}
+	if len(orphans) == 0 {
+		return 0, nil
+	}
+	plural := "y"
+	if len(orphans) > 1 {
+		plural = "ies"
+	}
+	fmt.Fprintf(
+		w,
+		"warning: %d terminal director%s with missing or corrupt metadata.json; run 'sb prune terminals' to clean up\n",
+		len(orphans), plural,
+	)
+	return len(orphans), nil
+}

--- a/internal/discovery/orphans_test.go
+++ b/internal/discovery/orphans_test.go
@@ -1,0 +1,200 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package discovery_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/internal/discovery"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// backdateDir pushes a directory's mtime past the orphan grace period so
+// prune exercises the steady-state (not freshly-created) classification.
+func backdateDir(t *testing.T, dir string) {
+	t.Helper()
+	old := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(dir, old, old); err != nil {
+		t.Fatalf("chtimes %s: %v", dir, err)
+	}
+}
+
+// truncateMetadata halves metadata.json in place, reproducing the
+// corrupt-file shape from #391's repro.
+func truncateMetadata(t *testing.T, dir string) {
+	t.Helper()
+	path := filepath.Join(dir, "metadata.json")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, b[:len(b)/2], 0o644); err != nil {
+		t.Fatalf("truncate %s: %v", path, err)
+	}
+}
+
+// TestScanAndPruneTerminals_ReapsCorruptMetadataDir asserts a directory
+// whose metadata.json is truncated mid-write is removed by prune even
+// though ScanTerminals can never return it.
+func TestScanAndPruneTerminals_ReapsCorruptMetadataDir(t *testing.T) {
+	runPath := t.TempDir()
+	writeTerminalDoc(t, runPath, "id-corrupt", "alpha", api.Exited, deadPid)
+	termDir := filepath.Join(runPath, defaults.TerminalsRunPath, "id-corrupt")
+	truncateMetadata(t, termDir)
+	backdateDir(t, termDir)
+
+	if err := discovery.ScanAndPruneTerminals(context.Background(), discardLogger(), runPath, io.Discard); err != nil {
+		t.Fatalf("ScanAndPruneTerminals: unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(termDir); !os.IsNotExist(err) {
+		t.Fatalf("expected corrupt-metadata terminal dir to be pruned, stat err=%v", err)
+	}
+}
+
+// TestScanAndPruneTerminals_ReapsMissingMetadataDir asserts a directory with
+// no metadata.json at all (terminal killed before the first write — the
+// #374 window) is removed by prune.
+func TestScanAndPruneTerminals_ReapsMissingMetadataDir(t *testing.T) {
+	runPath := t.TempDir()
+	termDir := filepath.Join(runPath, defaults.TerminalsRunPath, "id-missing")
+	if err := os.MkdirAll(termDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(termDir, "log"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	backdateDir(t, termDir)
+
+	var out bytes.Buffer
+	if err := discovery.ScanAndPruneTerminals(context.Background(), discardLogger(), runPath, &out); err != nil {
+		t.Fatalf("ScanAndPruneTerminals: unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(termDir); !os.IsNotExist(err) {
+		t.Fatalf("expected missing-metadata terminal dir to be pruned, stat err=%v", err)
+	}
+	if !strings.Contains(out.String(), termDir) {
+		t.Fatalf("expected prune output to name the reaped dir, got %q", out.String())
+	}
+}
+
+// TestScanAndPruneTerminals_SkipsOrphanWithLiveSocket asserts an orphan
+// directory hosting a unix socket with a live listener is never removed —
+// corrupt metadata does not prove the terminal process is gone.
+func TestScanAndPruneTerminals_SkipsOrphanWithLiveSocket(t *testing.T) {
+	runPath := t.TempDir()
+	termDir := filepath.Join(runPath, defaults.TerminalsRunPath, "id-live-sock")
+	if err := os.MkdirAll(termDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	ln, err := net.Listen("unix", filepath.Join(termDir, "socket"))
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			conn, errAccept := ln.Accept()
+			if errAccept != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	backdateDir(t, termDir)
+
+	if err := discovery.ScanAndPruneTerminals(context.Background(), discardLogger(), runPath, io.Discard); err != nil {
+		t.Fatalf("ScanAndPruneTerminals: unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(termDir); err != nil {
+		t.Fatalf("expected orphan dir with live socket to survive prune, stat err=%v", err)
+	}
+}
+
+// TestScanAndPruneTerminals_ShieldsFreshOrphanDir asserts a just-created
+// metadata-less directory survives prune: the runner MkdirAlls the dir
+// before the first metadata.json write lands, so reaping inside the grace
+// window would race terminal startup.
+func TestScanAndPruneTerminals_ShieldsFreshOrphanDir(t *testing.T) {
+	runPath := t.TempDir()
+	termDir := filepath.Join(runPath, defaults.TerminalsRunPath, "id-fresh")
+	if err := os.MkdirAll(termDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	if err := discovery.ScanAndPruneTerminals(context.Background(), discardLogger(), runPath, io.Discard); err != nil {
+		t.Fatalf("ScanAndPruneTerminals: unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(termDir); err != nil {
+		t.Fatalf("expected fresh dir to survive prune, stat err=%v", err)
+	}
+}
+
+// TestReportOrphanTerminalDirs asserts the `sb get` warning channel: a
+// one-line, non-verbose signal when orphans exist, silence when none do.
+func TestReportOrphanTerminalDirs(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("warns when orphans exist", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeTerminalDoc(t, runPath, "id-corrupt", "alpha", api.Exited, deadPid)
+		termDir := filepath.Join(runPath, defaults.TerminalsRunPath, "id-corrupt")
+		truncateMetadata(t, termDir)
+		backdateDir(t, termDir)
+
+		var out bytes.Buffer
+		n, err := discovery.ReportOrphanTerminalDirs(ctx, discardLogger(), runPath, &out)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if n != 1 {
+			t.Fatalf("expected 1 orphan, got %d", n)
+		}
+		if !strings.Contains(out.String(), "sb prune terminals") {
+			t.Fatalf("expected warning to name the cleanup command, got %q", out.String())
+		}
+	})
+
+	t.Run("silent when no orphans", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeTerminalDoc(t, runPath, "id-ok", "alpha", api.Ready, os.Getpid())
+
+		var out bytes.Buffer
+		n, err := discovery.ReportOrphanTerminalDirs(ctx, discardLogger(), runPath, &out)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if n != 0 {
+			t.Fatalf("expected 0 orphans, got %d", n)
+		}
+		if out.Len() != 0 {
+			t.Fatalf("expected no output, got %q", out.String())
+		}
+	})
+}

--- a/internal/discovery/terminals.go
+++ b/internal/discovery/terminals.go
@@ -100,7 +100,13 @@ func ScanAndPruneTerminals(ctx context.Context, logger *slog.Logger, runPath str
 		pkgdiscovery.TerminalID,
 		pkgdiscovery.TerminalName,
 	)
-	return err
+	if err != nil {
+		return err
+	}
+	// Metadata-driven pruning above can only reap directories ScanTerminals
+	// returns; directories whose metadata.json is missing or corrupt never
+	// appear there and would leak forever without this pass. See #391.
+	return pruneOrphanTerminalDirs(ctx, logger, runPath, w)
 }
 
 func PruneTerminal(logger *slog.Logger, metadata *api.TerminalDoc) error {

--- a/pkg/discovery/orphans.go
+++ b/pkg/discovery/orphans.go
@@ -1,0 +1,102 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/pkg/api"
+)
+
+// orphanGracePeriod shields a just-created terminal directory from being
+// classified as orphaned. The terminal runner MkdirAlls the directory
+// before the first atomic metadata.json write lands, so a scan racing that
+// window would otherwise see a metadata-less directory that is about to
+// become a live terminal and let prune remove it mid-startup.
+const orphanGracePeriod = 30 * time.Second
+
+// OrphanTerminalDirs returns the directories under runPath/terminals whose
+// metadata.json is missing or unparseable. Such directories are invisible
+// to ScanTerminals — the metadata glob never matches a missing file, and
+// per-file decode failures are skipped by design (see scanMetadataFiles) —
+// so without this enumeration they can never be listed or reaped and leak
+// on disk indefinitely.
+//
+// A metadata.json that exists but cannot be read (e.g. permission denied)
+// does not classify the directory as orphaned: an unreadable file cannot
+// prove the terminal is gone, and the caller likely lacks the rights to
+// remove the directory anyway. Directories modified within the last
+// orphanGracePeriod are also skipped — see the constant's doc.
+func OrphanTerminalDirs(ctx context.Context, logger *slog.Logger, runPath string) ([]string, error) {
+	root := filepath.Join(runPath, defaults.TerminalsRunPath)
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		logger.ErrorContext(ctx, "OrphanTerminalDirs: failed to read terminals root", "dir", root, "error", err)
+		return nil, fmt.Errorf("read dir %q: %w", root, err)
+	}
+
+	var orphans []string
+	for _, e := range entries {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(root, e.Name())
+		b, errRead := os.ReadFile(filepath.Join(dir, "metadata.json"))
+		if errRead == nil {
+			var doc api.TerminalDoc
+			if json.Unmarshal(b, &doc) == nil {
+				continue
+			}
+		} else if !errors.Is(errRead, fs.ErrNotExist) {
+			logger.WarnContext(
+				ctx,
+				"OrphanTerminalDirs: metadata.json unreadable, not classifying as orphan",
+				"dir", dir,
+				"error", errRead,
+			)
+			continue
+		}
+		if info, errInfo := e.Info(); errInfo == nil && time.Since(info.ModTime()) < orphanGracePeriod {
+			logger.DebugContext(ctx, "OrphanTerminalDirs: skipping recently modified dir", "dir", dir)
+			continue
+		}
+		logger.WarnContext(
+			ctx,
+			"OrphanTerminalDirs: terminal dir has missing or unparseable metadata.json",
+			"dir", dir,
+		)
+		orphans = append(orphans, dir)
+	}
+	return orphans, nil
+}

--- a/pkg/discovery/orphans_test.go
+++ b/pkg/discovery/orphans_test.go
@@ -1,0 +1,135 @@
+// Copyright 2025 Emiliano Spinella (eminwux)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package discovery_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/eminwux/sbsh/internal/defaults"
+	"github.com/eminwux/sbsh/pkg/discovery"
+)
+
+// backdateDir pushes a directory's mtime past the orphan grace period so
+// tests exercise the steady-state (not freshly-created) classification.
+func backdateDir(t *testing.T, dir string) {
+	t.Helper()
+	old := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(dir, old, old); err != nil {
+		t.Fatalf("chtimes %s: %v", dir, err)
+	}
+}
+
+func TestOrphanTerminalDirs(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+
+	t.Run("missing terminals root yields no orphans", func(t *testing.T) {
+		got, err := discovery.OrphanTerminalDirs(ctx, logger, t.TempDir())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("expected no orphans, got %v", got)
+		}
+	})
+
+	t.Run("healthy dirs are not orphans", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeTerminalDoc(t, runPath, "id-ok", "alpha")
+		backdateDir(t, filepath.Join(runPath, defaults.TerminalsRunPath, "id-ok"))
+
+		got, err := discovery.OrphanTerminalDirs(ctx, logger, runPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("expected no orphans, got %v", got)
+		}
+	})
+
+	t.Run("missing and corrupt metadata classify as orphans", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeTerminalDoc(t, runPath, "id-ok", "alpha")
+		writeInvalidTerminalJSON(t, runPath, "id-corrupt")
+		missingDir := filepath.Join(runPath, defaults.TerminalsRunPath, "id-missing")
+		if err := os.MkdirAll(missingDir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(missingDir, "log"), []byte("x"), 0o644); err != nil {
+			t.Fatalf("write log: %v", err)
+		}
+		for _, id := range []string{"id-ok", "id-corrupt", "id-missing"} {
+			backdateDir(t, filepath.Join(runPath, defaults.TerminalsRunPath, id))
+		}
+
+		got, err := discovery.OrphanTerminalDirs(ctx, logger, runPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := map[string]bool{
+			filepath.Join(runPath, defaults.TerminalsRunPath, "id-corrupt"): true,
+			filepath.Join(runPath, defaults.TerminalsRunPath, "id-missing"): true,
+		}
+		if len(got) != len(want) {
+			t.Fatalf("expected %d orphans, got %v", len(want), got)
+		}
+		for _, dir := range got {
+			if !want[dir] {
+				t.Fatalf("unexpected orphan %s (got %v)", dir, got)
+			}
+		}
+	})
+
+	t.Run("recently modified dirs are shielded by the grace period", func(t *testing.T) {
+		runPath := t.TempDir()
+		freshDir := filepath.Join(runPath, defaults.TerminalsRunPath, "id-fresh")
+		if err := os.MkdirAll(freshDir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+
+		got, err := discovery.OrphanTerminalDirs(ctx, logger, runPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("expected fresh dir to be shielded, got %v", got)
+		}
+	})
+
+	t.Run("stray files under terminals root are ignored", func(t *testing.T) {
+		runPath := t.TempDir()
+		root := filepath.Join(runPath, defaults.TerminalsRunPath)
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "stray"), []byte("x"), 0o644); err != nil {
+			t.Fatalf("write stray: %v", err)
+		}
+
+		got, err := discovery.OrphanTerminalDirs(ctx, logger, runPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("expected stray file to be ignored, got %v", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Terminal run directories whose `metadata.json` is missing (killed in the #374 window) or corrupt are invisible to `ScanTerminals` by design (#258 skips decode failures; the glob never matches a missing file), so the metadata-driven `sb prune terminals` could never reap them — a permanent disk leak under `~/.sbsh/run/terminals/`.
- New `pkg/discovery.OrphanTerminalDirs` enumerates `terminals/*` directories whose `metadata.json` is missing or unparseable. `ScanAndPruneTerminals` now runs a directory-driven pass after the metadata-driven one and removes those orphans.
- **Live-socket guard:** an orphan dir hosting a unix socket that accepts a connection (same 100ms dial-probe pattern as `terminalrunner.OpenSocketCtrl`) is never removed — corrupt metadata doesn't prove the process is gone. Prune prints a `Skipped … (live socket)` line instead.
- **Startup-race guard:** directories modified within the last 30s are shielded. The runner `MkdirAll`s the dir before the first atomic metadata write lands, so reaping inside that window would race a starting terminal. (Design call documented below.)
- `sb get terminals` now prints a one-line warning to **stderr** when orphan dirs exist (`warning: N terminal directories with missing or corrupt metadata.json; run 'sb prune terminals' to clean up`) — visible without `--verbose`, and on stderr so parseable stdout (table/json/yaml) is undisturbed.

## Design calls for review
- Orphan classification is deliberately narrow: a `metadata.json` that exists but is *unreadable* (e.g. EACCES, foreign uid) is **not** an orphan — an unreadable file can't prove the terminal is gone, and the caller likely can't remove the dir anyway. Only ENOENT or read-ok-but-unparseable qualifies, matching the issue's "missing or unparseable".
- The same leak exists for `clients/*` directories (`ScanAndPruneClients` is metadata-driven too); the issue scopes terminals only, so clients parity is left to a follow-up issue (filed separately, referenced on this PR).
- The grace window lives in `pkg/discovery.OrphanTerminalDirs` so prune and the `sb get` warning stay consistent (no warning for a just-created dir either).

## Acceptance criteria
- [x] `sb prune terminals` removes terminal directories with missing or unparseable `metadata.json` (and never removes one with a live socket) — covered by `TestScanAndPruneTerminals_ReapsCorruptMetadataDir`, `_ReapsMissingMetadataDir`, `_SkipsOrphanWithLiveSocket`, plus a real-binary smoke of the issue's repro (both orphan classes reaped, dir empty after prune).
- [x] Operators have a non-`--verbose` signal that corrupt/orphan directories exist — `sb get terminals` stderr warning, covered by `TestReportOrphanTerminalDirs` and the smoke run.
- [x] A test covers both the truncated-metadata and missing-metadata directory cases through prune — `internal/discovery/orphans_test.go` (truncation helper halves the file, matching the repro).

## Test plan
- [x] `make sbsh-sb` (ELF verified)
- [x] `go build ./...` && `go vet ./...`
- [x] `make test` (full suite incl. integration + e2e) — green
- [x] Real-binary smoke: orphan-missing + orphan-corrupt dirs under a scratch `SB_RUN_PATH` → `sb get terminals -a` warns on stderr, `sb prune terminals` reaps both, `terminals/` left empty

Closes #391