### PR TITLE
fix: reap orphan client dirs in prune and warn about them in get

### DIFF
--- a/cmd/sb/get/clients.go
+++ b/cmd/sb/get/clients.go
@@ -87,10 +87,11 @@ func listClients(cmd *cobra.Command, _ []string) error {
 		"args", cmd.Flags().Args(),
 	)
 
+	runPath := viper.GetString(config.SB_ROOT_RUN_PATH.ViperKey)
 	err := discovery.ScanAndPrintClients(
 		cmd.Context(),
 		logger,
-		viper.GetString(config.SB_ROOT_RUN_PATH.ViperKey),
+		runPath,
 		os.Stdout,
 		viper.GetBool(config.SB_GET_CLIENTS_ALL.ViperKey),
 		format,
@@ -99,6 +100,12 @@ func listClients(cmd *cobra.Command, _ []string) error {
 		logger.Debug("error scanning and printing clients", "error", err)
 		fmt.Fprintln(os.Stderr, "Could not scan clients")
 		return err
+	}
+	// Orphan dirs (missing/corrupt metadata.json) are invisible to the scan
+	// above; warn on stderr so the leak is observable without --verbose and
+	// without disturbing parseable stdout output. See #422.
+	if _, errOrphans := discovery.ReportOrphanClientDirs(cmd.Context(), logger, runPath, os.Stderr); errOrphans != nil {
+		logger.Debug("error reporting orphan client directories", "error", errOrphans)
 	}
 	logger.Debug("clients list completed successfully")
 	return nil

--- a/internal/discovery/clients.go
+++ b/internal/discovery/clients.go
@@ -94,7 +94,13 @@ func ScanAndPruneClients(ctx context.Context, logger *slog.Logger, runPath strin
 		pkgdiscovery.ClientID,
 		pkgdiscovery.ClientName,
 	)
-	return err
+	if err != nil {
+		return err
+	}
+	// Metadata-driven pruning above can only reap directories ScanClients
+	// returns; directories whose metadata.json is missing or corrupt never
+	// appear there and would leak forever without this pass. See #422.
+	return pruneOrphanClientDirs(ctx, logger, runPath, w)
 }
 
 // ScanClients is a thin wrapper around [pkgdiscovery.ScanClients].

--- a/internal/discovery/orphans.go
+++ b/internal/discovery/orphans.go
@@ -31,9 +31,10 @@ import (
 )
 
 // liveSocketProbeTimeout bounds the dial used to decide whether an orphan
-// terminal directory still hosts a live control socket. Mirrors the probe
-// in terminalrunner.OpenSocketCtrl: a successful dial means a live peer is
-// serving the path; ENOENT/ECONNREFUSED/timeout means nobody is accepting.
+// terminal or client directory still hosts a live control socket. Mirrors
+// the probe in terminalrunner.OpenSocketCtrl: a successful dial means a live
+// peer is serving the path; ENOENT/ECONNREFUSED/timeout means nobody is
+// accepting.
 const liveSocketProbeTimeout = 100 * time.Millisecond
 
 // pruneOrphanTerminalDirs removes terminal directories whose metadata.json
@@ -47,30 +48,51 @@ func pruneOrphanTerminalDirs(ctx context.Context, logger *slog.Logger, runPath s
 	if err != nil {
 		return err
 	}
+	return pruneOrphanDirs(ctx, logger, w, orphans, "terminal")
+}
+
+// pruneOrphanClientDirs removes client directories whose metadata.json is
+// missing or unparseable — the clients-side counterpart of
+// pruneOrphanTerminalDirs (see #422). The live-socket guard covers the
+// client control socket (clients/<id>/client.sock — see pkg/attach).
+func pruneOrphanClientDirs(ctx context.Context, logger *slog.Logger, runPath string, w io.Writer) error {
+	orphans, err := pkgdiscovery.OrphanClientDirs(ctx, logger, runPath)
+	if err != nil {
+		return err
+	}
+	return pruneOrphanDirs(ctx, logger, w, orphans, "client")
+}
+
+// pruneOrphanDirs removes the given orphan directories, skipping any that
+// still host a live unix socket. noun ("terminal", "client") labels logs and
+// the per-directory lines written to w.
+func pruneOrphanDirs(ctx context.Context, logger *slog.Logger, w io.Writer, orphans []string, noun string) error {
 	for _, dir := range orphans {
 		if hasLiveSocket(ctx, dir) {
 			logger.WarnContext(
 				ctx,
-				"pruneOrphanTerminalDirs: skipping orphan dir with live socket",
+				"pruneOrphanDirs: skipping orphan dir with live socket",
+				"kind", noun,
 				"dir", dir,
 			)
 			if w != nil {
-				fmt.Fprintf(w, "Skipped orphan terminal directory %s (live socket)\n", dir)
+				fmt.Fprintf(w, "Skipped orphan %s directory %s (live socket)\n", noun, dir)
 			}
 			continue
 		}
 		if errRemove := os.RemoveAll(dir); errRemove != nil {
 			logger.ErrorContext(
 				ctx,
-				"pruneOrphanTerminalDirs: failed to remove orphan dir",
+				"pruneOrphanDirs: failed to remove orphan dir",
+				"kind", noun,
 				"dir", dir,
 				"error", errRemove,
 			)
-			return fmt.Errorf("prune orphan terminal dir %s: %w", dir, errRemove)
+			return fmt.Errorf("prune orphan %s dir %s: %w", noun, dir, errRemove)
 		}
-		logger.InfoContext(ctx, "pruneOrphanTerminalDirs: orphan terminal dir removed", "dir", dir)
+		logger.InfoContext(ctx, "pruneOrphanDirs: orphan dir removed", "kind", noun, "dir", dir)
 		if w != nil {
-			fmt.Fprintf(w, "Pruned orphan terminal directory %s (missing or corrupt metadata.json)\n", dir)
+			fmt.Fprintf(w, "Pruned orphan %s directory %s (missing or corrupt metadata.json)\n", noun, dir)
 		}
 	}
 	return nil
@@ -79,7 +101,8 @@ func pruneOrphanTerminalDirs(ctx context.Context, logger *slog.Logger, runPath s
 // hasLiveSocket reports whether any unix socket directly inside dir accepts
 // a connection. Best-effort: a terminal whose control socket was placed
 // outside its run dir (custom Spec.SocketFile) is not detected, but the
-// default layout (runPath/terminals/<id>/socket) is covered.
+// default layouts (runPath/terminals/<id>/socket,
+// runPath/clients/<id>/client.sock) are covered.
 func hasLiveSocket(ctx context.Context, dir string) bool {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -110,8 +133,25 @@ func ReportOrphanTerminalDirs(ctx context.Context, logger *slog.Logger, runPath 
 	if err != nil {
 		return 0, err
 	}
+	return reportOrphanDirs(w, orphans, "terminal", "sb prune terminals"), nil
+}
+
+// ReportOrphanClientDirs is the clients-side counterpart of
+// ReportOrphanTerminalDirs: a one-line warning channel for `sb get clients`
+// when orphan client directories exist; `sb prune clients` does the reaping.
+func ReportOrphanClientDirs(ctx context.Context, logger *slog.Logger, runPath string, w io.Writer) (int, error) {
+	orphans, err := pkgdiscovery.OrphanClientDirs(ctx, logger, runPath)
+	if err != nil {
+		return 0, err
+	}
+	return reportOrphanDirs(w, orphans, "client", "sb prune clients"), nil
+}
+
+// reportOrphanDirs writes the one-line orphan warning to w and returns the
+// orphan count. Silent when there are no orphans.
+func reportOrphanDirs(w io.Writer, orphans []string, noun, pruneCmd string) int {
 	if len(orphans) == 0 {
-		return 0, nil
+		return 0
 	}
 	plural := "y"
 	if len(orphans) > 1 {
@@ -119,8 +159,8 @@ func ReportOrphanTerminalDirs(ctx context.Context, logger *slog.Logger, runPath 
 	}
 	fmt.Fprintf(
 		w,
-		"warning: %d terminal director%s with missing or corrupt metadata.json; run 'sb prune terminals' to clean up\n",
-		len(orphans), plural,
+		"warning: %d %s director%s with missing or corrupt metadata.json; run '%s' to clean up\n",
+		len(orphans), noun, plural, pruneCmd,
 	)
-	return len(orphans), nil
+	return len(orphans)
 }

--- a/internal/discovery/orphans_test.go
+++ b/internal/discovery/orphans_test.go
@@ -156,6 +156,150 @@ func TestScanAndPruneTerminals_ShieldsFreshOrphanDir(t *testing.T) {
 	}
 }
 
+// TestScanAndPruneClients_ReapsCorruptMetadataDir asserts a client directory
+// whose metadata.json is truncated mid-write is removed by prune even though
+// ScanClients can never return it. See #422.
+func TestScanAndPruneClients_ReapsCorruptMetadataDir(t *testing.T) {
+	runPath := t.TempDir()
+	writeClientDoc(t, runPath, "id-corrupt", api.ClientExited, deadPid)
+	clientDir := filepath.Join(runPath, defaults.ClientsRunPath, "id-corrupt")
+	truncateMetadata(t, clientDir)
+	backdateDir(t, clientDir)
+
+	if err := discovery.ScanAndPruneClients(context.Background(), discardLogger(), runPath, io.Discard); err != nil {
+		t.Fatalf("ScanAndPruneClients: unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(clientDir); !os.IsNotExist(err) {
+		t.Fatalf("expected corrupt-metadata client dir to be pruned, stat err=%v", err)
+	}
+}
+
+// TestScanAndPruneClients_ReapsMissingMetadataDir asserts a client directory
+// with no metadata.json at all (client killed before the first write) is
+// removed by prune.
+func TestScanAndPruneClients_ReapsMissingMetadataDir(t *testing.T) {
+	runPath := t.TempDir()
+	clientDir := filepath.Join(runPath, defaults.ClientsRunPath, "id-missing")
+	if err := os.MkdirAll(clientDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(clientDir, "log"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+	backdateDir(t, clientDir)
+
+	var out bytes.Buffer
+	if err := discovery.ScanAndPruneClients(context.Background(), discardLogger(), runPath, &out); err != nil {
+		t.Fatalf("ScanAndPruneClients: unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(clientDir); !os.IsNotExist(err) {
+		t.Fatalf("expected missing-metadata client dir to be pruned, stat err=%v", err)
+	}
+	if !strings.Contains(out.String(), clientDir) {
+		t.Fatalf("expected prune output to name the reaped dir, got %q", out.String())
+	}
+}
+
+// TestScanAndPruneClients_SkipsOrphanWithLiveSocket asserts an orphan client
+// directory hosting a unix socket with a live listener is never removed —
+// corrupt metadata does not prove the client process is gone.
+func TestScanAndPruneClients_SkipsOrphanWithLiveSocket(t *testing.T) {
+	runPath := t.TempDir()
+	clientDir := filepath.Join(runPath, defaults.ClientsRunPath, "id-live-sock")
+	if err := os.MkdirAll(clientDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	ln, err := net.Listen("unix", filepath.Join(clientDir, "client.sock"))
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			conn, errAccept := ln.Accept()
+			if errAccept != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	backdateDir(t, clientDir)
+
+	if err := discovery.ScanAndPruneClients(context.Background(), discardLogger(), runPath, io.Discard); err != nil {
+		t.Fatalf("ScanAndPruneClients: unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(clientDir); err != nil {
+		t.Fatalf("expected orphan dir with live socket to survive prune, stat err=%v", err)
+	}
+}
+
+// TestScanAndPruneClients_ShieldsFreshOrphanDir asserts a just-created
+// metadata-less client directory survives prune: the client MkdirAlls the
+// dir before the first metadata.json write lands, so reaping inside the
+// grace window would race client startup.
+func TestScanAndPruneClients_ShieldsFreshOrphanDir(t *testing.T) {
+	runPath := t.TempDir()
+	clientDir := filepath.Join(runPath, defaults.ClientsRunPath, "id-fresh")
+	if err := os.MkdirAll(clientDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	if err := discovery.ScanAndPruneClients(context.Background(), discardLogger(), runPath, io.Discard); err != nil {
+		t.Fatalf("ScanAndPruneClients: unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(clientDir); err != nil {
+		t.Fatalf("expected fresh dir to survive prune, stat err=%v", err)
+	}
+}
+
+// TestReportOrphanClientDirs asserts the `sb get clients` warning channel: a
+// one-line, non-verbose signal when orphan client dirs exist, silence when
+// none do.
+func TestReportOrphanClientDirs(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("warns when orphans exist", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeClientDoc(t, runPath, "id-corrupt", api.ClientExited, deadPid)
+		clientDir := filepath.Join(runPath, defaults.ClientsRunPath, "id-corrupt")
+		truncateMetadata(t, clientDir)
+		backdateDir(t, clientDir)
+
+		var out bytes.Buffer
+		n, err := discovery.ReportOrphanClientDirs(ctx, discardLogger(), runPath, &out)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if n != 1 {
+			t.Fatalf("expected 1 orphan, got %d", n)
+		}
+		if !strings.Contains(out.String(), "sb prune clients") {
+			t.Fatalf("expected warning to name the cleanup command, got %q", out.String())
+		}
+	})
+
+	t.Run("silent when no orphans", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeClientDoc(t, runPath, "id-ok", api.ClientReady, os.Getpid())
+
+		var out bytes.Buffer
+		n, err := discovery.ReportOrphanClientDirs(ctx, discardLogger(), runPath, &out)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if n != 0 {
+			t.Fatalf("expected 0 orphans, got %d", n)
+		}
+		if out.Len() != 0 {
+			t.Fatalf("expected no output, got %q", out.String())
+		}
+	})
+}
+
 // TestReportOrphanTerminalDirs asserts the `sb get` warning channel: a
 // one-line, non-verbose signal when orphans exist, silence when none do.
 func TestReportOrphanTerminalDirs(t *testing.T) {

--- a/pkg/discovery/orphans.go
+++ b/pkg/discovery/orphans.go
@@ -31,11 +31,11 @@ import (
 	"github.com/eminwux/sbsh/pkg/api"
 )
 
-// orphanGracePeriod shields a just-created terminal directory from being
-// classified as orphaned. The terminal runner MkdirAlls the directory
-// before the first atomic metadata.json write lands, so a scan racing that
-// window would otherwise see a metadata-less directory that is about to
-// become a live terminal and let prune remove it mid-startup.
+// orphanGracePeriod shields a just-created terminal or client directory from
+// being classified as orphaned. The runner MkdirAlls the directory before
+// the first atomic metadata.json write lands, so a scan racing that window
+// would otherwise see a metadata-less directory that is about to become a
+// live entity and let prune remove it mid-startup.
 const orphanGracePeriod = 30 * time.Second
 
 // OrphanTerminalDirs returns the directories under runPath/terminals whose
@@ -51,13 +51,37 @@ const orphanGracePeriod = 30 * time.Second
 // remove the directory anyway. Directories modified within the last
 // orphanGracePeriod are also skipped — see the constant's doc.
 func OrphanTerminalDirs(ctx context.Context, logger *slog.Logger, runPath string) ([]string, error) {
-	root := filepath.Join(runPath, defaults.TerminalsRunPath)
+	return orphanDirs[api.TerminalDoc](ctx, logger, runPath, defaults.TerminalsRunPath, "OrphanTerminalDirs", "terminal")
+}
+
+// OrphanClientDirs returns the directories under runPath/clients whose
+// metadata.json is missing or unparseable. The same leak exists for clients
+// as for terminals: ScanClients shares the metadata glob and the
+// skip-on-decode-failure design, so such directories can never be listed or
+// reaped without this enumeration. Classification rules (unreadable files,
+// grace window) match OrphanTerminalDirs.
+func OrphanClientDirs(ctx context.Context, logger *slog.Logger, runPath string) ([]string, error) {
+	return orphanDirs[api.ClientDoc](ctx, logger, runPath, defaults.ClientsRunPath, "OrphanClientDirs", "client")
+}
+
+// orphanDirs enumerates the directories under runPath/subDir whose
+// metadata.json is missing or does not decode into T. See the exported
+// wrappers for the classification contract.
+func orphanDirs[T any](
+	ctx context.Context,
+	logger *slog.Logger,
+	runPath string,
+	subDir string,
+	logPrefix string,
+	noun string,
+) ([]string, error) {
+	root := filepath.Join(runPath, subDir)
 	entries, err := os.ReadDir(root)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return nil, nil
 		}
-		logger.ErrorContext(ctx, "OrphanTerminalDirs: failed to read terminals root", "dir", root, "error", err)
+		logger.ErrorContext(ctx, fmt.Sprintf("%s: failed to read %ss root", logPrefix, noun), "dir", root, "error", err)
 		return nil, fmt.Errorf("read dir %q: %w", root, err)
 	}
 
@@ -74,26 +98,26 @@ func OrphanTerminalDirs(ctx context.Context, logger *slog.Logger, runPath string
 		dir := filepath.Join(root, e.Name())
 		b, errRead := os.ReadFile(filepath.Join(dir, "metadata.json"))
 		if errRead == nil {
-			var doc api.TerminalDoc
+			var doc T
 			if json.Unmarshal(b, &doc) == nil {
 				continue
 			}
 		} else if !errors.Is(errRead, fs.ErrNotExist) {
 			logger.WarnContext(
 				ctx,
-				"OrphanTerminalDirs: metadata.json unreadable, not classifying as orphan",
+				fmt.Sprintf("%s: metadata.json unreadable, not classifying as orphan", logPrefix),
 				"dir", dir,
 				"error", errRead,
 			)
 			continue
 		}
 		if info, errInfo := e.Info(); errInfo == nil && time.Since(info.ModTime()) < orphanGracePeriod {
-			logger.DebugContext(ctx, "OrphanTerminalDirs: skipping recently modified dir", "dir", dir)
+			logger.DebugContext(ctx, fmt.Sprintf("%s: skipping recently modified dir", logPrefix), "dir", dir)
 			continue
 		}
 		logger.WarnContext(
 			ctx,
-			"OrphanTerminalDirs: terminal dir has missing or unparseable metadata.json",
+			fmt.Sprintf("%s: %s dir has missing or unparseable metadata.json", logPrefix, noun),
 			"dir", dir,
 		)
 		orphans = append(orphans, dir)

--- a/pkg/discovery/orphans_test.go
+++ b/pkg/discovery/orphans_test.go
@@ -133,3 +133,100 @@ func TestOrphanTerminalDirs(t *testing.T) {
 		}
 	})
 }
+
+func TestOrphanClientDirs(t *testing.T) {
+	ctx := context.Background()
+	logger := testLogger()
+
+	t.Run("missing clients root yields no orphans", func(t *testing.T) {
+		got, err := discovery.OrphanClientDirs(ctx, logger, t.TempDir())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("expected no orphans, got %v", got)
+		}
+	})
+
+	t.Run("healthy dirs are not orphans", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeClientDoc(t, runPath, "id-ok", "alpha")
+		backdateDir(t, filepath.Join(runPath, defaults.ClientsRunPath, "id-ok"))
+
+		got, err := discovery.OrphanClientDirs(ctx, logger, runPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("expected no orphans, got %v", got)
+		}
+	})
+
+	t.Run("missing and corrupt metadata classify as orphans", func(t *testing.T) {
+		runPath := t.TempDir()
+		writeClientDoc(t, runPath, "id-ok", "alpha")
+		writeInvalidClientJSON(t, runPath, "id-corrupt")
+		missingDir := filepath.Join(runPath, defaults.ClientsRunPath, "id-missing")
+		if err := os.MkdirAll(missingDir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(missingDir, "log"), []byte("x"), 0o644); err != nil {
+			t.Fatalf("write log: %v", err)
+		}
+		for _, id := range []string{"id-ok", "id-corrupt", "id-missing"} {
+			backdateDir(t, filepath.Join(runPath, defaults.ClientsRunPath, id))
+		}
+
+		got, err := discovery.OrphanClientDirs(ctx, logger, runPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := map[string]bool{
+			filepath.Join(runPath, defaults.ClientsRunPath, "id-corrupt"): true,
+			filepath.Join(runPath, defaults.ClientsRunPath, "id-missing"): true,
+		}
+		if len(got) != len(want) {
+			t.Fatalf("expected %d orphans, got %v", len(want), got)
+		}
+		for _, dir := range got {
+			if !want[dir] {
+				t.Fatalf("unexpected orphan %s (got %v)", dir, got)
+			}
+		}
+	})
+
+	t.Run("recently modified dirs are shielded by the grace period", func(t *testing.T) {
+		runPath := t.TempDir()
+		freshDir := filepath.Join(runPath, defaults.ClientsRunPath, "id-fresh")
+		if err := os.MkdirAll(freshDir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+
+		got, err := discovery.OrphanClientDirs(ctx, logger, runPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("expected fresh dir to be shielded, got %v", got)
+		}
+	})
+
+	t.Run("stray files under clients root are ignored", func(t *testing.T) {
+		runPath := t.TempDir()
+		root := filepath.Join(runPath, defaults.ClientsRunPath)
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "stray"), []byte("x"), 0o644); err != nil {
+			t.Fatalf("write stray: %v", err)
+		}
+
+		got, err := discovery.OrphanClientDirs(ctx, logger, runPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("expected stray file to be ignored, got %v", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- `clients/<id>/` directories whose `metadata.json` is missing or unparseable were invisible to `ScanClients` (decode failures skipped by design; the glob never matches a missing file), so the metadata-driven prune in `ScanAndPruneClients` could never reap them — the clients-side twin of the terminals leak fixed in #421.
- Mirrors the #421 mechanics: `pkg/discovery.OrphanClientDirs` enumerates orphan dirs (same ENOENT-or-unparseable-only classification, same 30s startup grace window), `ScanAndPruneClients` runs a directory-driven pass after the metadata-driven one with the live-socket guard (covers `clients/<id>/client.sock`), and `sb get clients` prints a one-line stderr warning when orphan dirs exist.
- Rather than copy-pasting #421's code, the shared mechanics are factored into generic helpers — `orphanDirs[T]` in `pkg/discovery/orphans.go`, `pruneOrphanDirs`/`reportOrphanDirs` in `internal/discovery/orphans.go` — with the existing terminal functions becoming thin wrappers, matching the repo's existing `scanMetadataFiles[T]`/`scanAndPruneMetadata` dedup pattern. Terminal-side behavior, output lines, and warning text are unchanged (existing #421 tests pass unmodified).

## Test plan
- [x] `make sbsh-sb` (ELF magic verified; `file` binary unavailable on this host, checked via `od`)
- [x] `go build ./...` and `go vet ./...`
- [x] `go test ./pkg/discovery/... ./internal/discovery/... ./cmd/sb/get/...`
- [x] Full CI-equivalent suite: `go test $(go list ./... | grep -v '/e2e$')`, `go test -tags=integration ./cmd/sb/get/...`, `E2E_BIN_DIR=$(pwd) go test ./e2e` — exit 0
- [x] New tests: truncated-metadata and missing-metadata client dirs reaped through `ScanAndPruneClients`; live-socket orphan survives; fresh dir shielded by grace window; `ReportOrphanClientDirs` warns/stays silent

## Acceptance criteria
- [x] `sb prune clients` removes client directories with missing or unparseable `metadata.json` (and never removes one with a live socket)
- [x] `sb get clients` surfaces a non-`--verbose` signal when orphan client directories exist
- [x] Tests cover both the truncated-metadata and missing-metadata directory cases through prune

Closes #422