### PR TITLE
fix: stop clearing terminal on attach/detach by default, add opt-in clear flags

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -115,6 +115,13 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SB_ATTACH_FULL_CAPTURE = DefineKV("SB_ATTACH_FULL_CAPTURE", "sb/attach/fullCapture")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SB_ATTACH_CLEAR_SCREEN = DefineKV("SB_ATTACH_CLEAR_SCREEN", "sb/attach/clearScreen")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SB_ATTACH_CLEAR_SCREEN_ON_DETACH = DefineKV(
+		"SB_ATTACH_CLEAR_SCREEN_ON_DETACH",
+		"sb/attach/clearScreenOnDetach",
+	)
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SB_DETACH_NAME = DefineKV("SB_DETACH_NAME", "sb/detach/name")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SB_DETACH_ID = DefineKV("SB_DETACH_ID", "sb/detach/id")
@@ -196,6 +203,13 @@ var (
 	SBSH_CLIENT_DISABLE_DETACH_KEYSTROKE = DefineKV(
 		"SBSH_CLIENT_DISABLE_DETACH_KEYSTROKE",
 		"sbsh.client.disableDetachKeystroke",
+	)
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SBSH_CLIENT_CLEAR_SCREEN = DefineKV("SBSH_CLIENT_CLEAR_SCREEN", "sbsh.client.clearScreen")
+	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
+	SBSH_CLIENT_CLEAR_SCREEN_ON_DETACH = DefineKV(
+		"SBSH_CLIENT_CLEAR_SCREEN_ON_DETACH",
+		"sbsh.client.clearScreenOnDetach",
 	)
 
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/sb/attach/attach.go
+++ b/cmd/sb/attach/attach.go
@@ -175,6 +175,15 @@ func setupAttachCmdFlags(attachCmd *cobra.Command) {
 	attachCmd.Flags().
 		Bool("full-capture", false, "Replay the entire raw capture buffer on attach instead of repainting the current screen")
 	_ = viper.BindPFlag(config.SB_ATTACH_FULL_CAPTURE.ViperKey, attachCmd.Flags().Lookup("full-capture"))
+	attachCmd.Flags().
+		Bool("clear-screen", false, "Clear the terminal before repainting the session screen on attach (legacy behavior); the default paints below existing content. No effect with --full-capture, whose replay is raw history")
+	_ = viper.BindPFlag(config.SB_ATTACH_CLEAR_SCREEN.ViperKey, attachCmd.Flags().Lookup("clear-screen"))
+	attachCmd.Flags().
+		Bool("clear-screen-on-detach", false, "Erase the screen after detaching (^] twice or sb detach); the default leaves screen content untouched")
+	_ = viper.BindPFlag(
+		config.SB_ATTACH_CLEAR_SCREEN_ON_DETACH.ViperKey,
+		attachCmd.Flags().Lookup("clear-screen-on-detach"),
+	)
 }
 
 func run(
@@ -201,6 +210,8 @@ func run(
 
 	disableDetach := viper.GetBool(config.SB_ATTACH_DISABLE_DETACH_KEYSTROKE.ViperKey)
 	fullCapture := viper.GetBool(config.SB_ATTACH_FULL_CAPTURE.ViperKey)
+	clearScreen := viper.GetBool(config.SB_ATTACH_CLEAR_SCREEN.ViperKey)
+	clearScreenOnDetach := viper.GetBool(config.SB_ATTACH_CLEAR_SCREEN_ON_DETACH.ViperKey)
 
 	logger.DebugContext(
 		ctx,
@@ -211,6 +222,10 @@ func run(
 		disableDetach,
 		"full_capture",
 		fullCapture,
+		"clear_screen",
+		clearScreen,
+		"clear_screen_on_detach",
+		clearScreenOnDetach,
 	)
 
 	runErr := attach.Run(ctx, attach.Options{
@@ -220,6 +235,8 @@ func run(
 		Stderr:                 os.Stderr,
 		DisableDetachKeystroke: disableDetach,
 		FullCapture:            fullCapture,
+		ClearScreen:            clearScreen,
+		ClearScreenOnDetach:    clearScreenOnDetach,
 		Logger:                 logger,
 	})
 	if runErr == nil || errors.Is(runErr, context.Canceled) || errors.Is(runErr, errdefs.ErrContextDone) {

--- a/cmd/sbsh/sbsh.go
+++ b/cmd/sbsh/sbsh.go
@@ -212,6 +212,10 @@ You can also use sbsh with parameters. For example:
 					TerminalSpec:    terminalSpec,
 					DetachKeystroke: !disableDetach, // Invert flag: when disable-detach is true, DetachKeystroke is false
 					ClientMode:      api.RunNewTerminal,
+					ClearScreen:     viper.GetBool(config.SBSH_CLIENT_CLEAR_SCREEN.ViperKey),
+					ClearScreenOnDetach: viper.GetBool(
+						config.SBSH_CLIENT_CLEAR_SCREEN_ON_DETACH.ViperKey,
+					),
 				},
 			}
 
@@ -307,6 +311,21 @@ func setClientFlags(rootCmd *cobra.Command) error {
 
 	rootCmd.Flags().Bool("disable-detach", false, "Disable detach keystroke (^] twice)")
 	if err := viper.BindPFlag(config.SBSH_CLIENT_DISABLE_DETACH_KEYSTROKE.ViperKey, rootCmd.Flags().Lookup("disable-detach")); err != nil {
+		return err
+	}
+
+	rootCmd.Flags().
+		Bool("clear-screen", false, "Clear the terminal before painting the session screen (legacy behavior); the default paints below existing content")
+	if err := viper.BindPFlag(config.SBSH_CLIENT_CLEAR_SCREEN.ViperKey, rootCmd.Flags().Lookup("clear-screen")); err != nil {
+		return err
+	}
+
+	rootCmd.Flags().
+		Bool("clear-screen-on-detach", false, "Erase the screen after detaching (^] twice or sb detach); the default leaves screen content untouched")
+	if err := viper.BindPFlag(
+		config.SBSH_CLIENT_CLEAR_SCREEN_ON_DETACH.ViperKey,
+		rootCmd.Flags().Lookup("clear-screen-on-detach"),
+	); err != nil {
 		return err
 	}
 

--- a/internal/client/clientrunner/io.go
+++ b/internal/client/clientrunner/io.go
@@ -151,10 +151,11 @@ func (sr *Exec) attach() error {
 	var response struct{}
 	sr.metadataMu.RLock()
 	fullCapture := sr.metadata.Spec.FullCapture
+	clearScreen := sr.metadata.Spec.ClearScreen
 	sr.metadataMu.RUnlock()
 	conn, err := sr.terminalClient.Attach(
 		sr.ctx,
-		&api.AttachRequest{ClientID: sr.id, FullCapture: fullCapture},
+		&api.AttachRequest{ClientID: sr.id, FullCapture: fullCapture, ClearScreen: clearScreen},
 		&response,
 	)
 	if err != nil {

--- a/internal/client/clientrunner/io_extra_test.go
+++ b/internal/client/clientrunner/io_extra_test.go
@@ -68,12 +68,13 @@ func TestAttach_Success(t *testing.T) {
 		},
 	}
 	sr.metadata.Spec.FullCapture = true
+	sr.metadata.Spec.ClearScreen = true
 
 	if err := sr.attach(); err != nil {
 		t.Fatalf("attach: %v", err)
 	}
-	if gotReq == nil || gotReq.ClientID != sr.id || !gotReq.FullCapture {
-		t.Fatalf("attach request = %+v; want ClientID=%q FullCapture=true", gotReq, sr.id)
+	if gotReq == nil || gotReq.ClientID != sr.id || !gotReq.FullCapture || !gotReq.ClearScreen {
+		t.Fatalf("attach request = %+v; want ClientID=%q FullCapture=true ClearScreen=true", gotReq, sr.id)
 	}
 	if sr.ioConn != clientConn {
 		t.Fatal("attach did not store the returned connection in ioConn")

--- a/internal/client/clientrunner/lifecycle.go
+++ b/internal/client/clientrunner/lifecycle.go
@@ -196,7 +196,7 @@ func (sr *Exec) Close(_ error) error {
 		}
 	}
 
-	sr.restoreParentTerminal("")
+	sr.restoreParentTerminal("", false)
 	sr.logger.Debug("Close: cleanup complete")
 
 	sr.metadataMu.Lock()
@@ -231,11 +231,20 @@ func (sr *Exec) Detach() error {
 	// the Detach-RPC-failure case from #385 does. See issue #389.
 	ctx, cancel := context.WithTimeout(sr.ctx, detachTimeout)
 	defer cancel()
+
+	// Both user-detach triggers (^]^] keystroke and a remote `sb detach`)
+	// funnel through here, so this is the only place the opt-in detach
+	// clear applies; the Close()/process-exit paths always pass false.
+	sr.metadataMu.RLock()
+	clearScreen := sr.metadata.Spec.ClearScreenOnDetach
+	sr.metadataMu.RUnlock()
+
 	if err := sr.terminalClient.Detach(ctx, &sr.id); err != nil {
 		sr.logger.Warn("Detach RPC failed; restoring parent terminal anyway", "client_id", sr.id, "error", err)
 		// Suppress the "Detached" banner — it would be misleading when the RPC
-		// failed — but the restore still runs. See #383.
-		sr.restoreParentTerminal("")
+		// failed — but the restore still runs. See #383. The opt-in clear still
+		// applies: the user committed to detaching either way.
+		sr.restoreParentTerminal("", clearScreen)
 		return err
 	}
 
@@ -244,7 +253,7 @@ func (sr *Exec) Detach() error {
 	// message so it is written after the inbound copier has drained (no
 	// interleave with mid-flush remote bytes) but while raw mode is still active
 	// so the embedded \r\n behaves. See issues #364 and #383.
-	sr.restoreParentTerminal("\x1b[93m\r\nDetached\x1b[0m\r\n")
+	sr.restoreParentTerminal("\x1b[93m\r\nDetached\x1b[0m\r\n", clearScreen)
 
 	return nil
 }

--- a/internal/client/clientrunner/restore_linux_test.go
+++ b/internal/client/clientrunner/restore_linux_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/eminwux/sbsh/pkg/api"
+	"github.com/hinshun/vt10x"
 	"golang.org/x/sys/unix"
 )
 
@@ -318,6 +319,150 @@ func TestDetach_BannerWrittenBeforeNormalize(t *testing.T) {
 	}
 	if bannerIdx >= 0 && normIdx >= 0 && bannerIdx > normIdx {
 		t.Errorf("banner should precede normalize sequence; banner@%d normalize@%d in %q", bannerIdx, normIdx, out)
+	}
+}
+
+// captureDetachOutput swaps stdout for a pipe, runs Detach, and returns every
+// byte the teardown wrote — the banner plus the restore sequence.
+func captureDetachOutput(t *testing.T, sr *Exec) string {
+	t.Helper()
+	r, w, errPipe := os.Pipe()
+	if errPipe != nil {
+		t.Fatalf("Pipe: %v", errPipe)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+	sr.stdout = w
+
+	if err := sr.Detach(); err != nil {
+		t.Fatalf("Detach: %v", err)
+	}
+	_ = w.Close()
+
+	buf, errRead := io.ReadAll(r)
+	if errRead != nil {
+		t.Fatalf("ReadAll: %v", errRead)
+	}
+	return string(buf)
+}
+
+// TestDetach_CursorStaysAfterBanner asserts the default detach restore leaves
+// the cursor on the line after the "Detached" banner instead of yanking it to
+// row 1, on a session that never entered the alt screen. The bare ?1049l of
+// #365 performed an implicit DECRC with no prior save, which xterm documents
+// as restoring the default (home) cursor; the DECSC prefix pins the restore
+// to the banner position. Verified by feeding the teardown bytes into a vt10x
+// terminal seeded mid-screen — the same parser the repro in #425 used.
+func TestDetach_CursorStaysAfterBanner(t *testing.T) {
+	sr, _ := newAttachedExec(t)
+	sr.terminalClient = &mockTerminalClient{}
+
+	out := captureDetachOutput(t, sr)
+
+	if strings.Contains(out, "\x1b[2J") {
+		t.Errorf("default detach must not erase the screen; got %q", out)
+	}
+
+	// Parent terminal mid-screen: four lines written, prompt on row 3.
+	vt := vt10x.New(vt10x.WithSize(80, 24))
+	_, _ = vt.Write([]byte("$ ls\r\nfile1\r\nfile2\r\n$ "))
+	_, _ = vt.Write([]byte(out))
+
+	// The banner's two \r\n frames put "Detached" on row 4 and the cursor on
+	// row 5 col 0; the restore sequence must keep it there. (vt10x keeps a
+	// single saved-cursor slot and swaps buffers on a normal-buffer ?1049l —
+	// quirks that do not affect the cursor assertion.)
+	cur := vt.Cursor()
+	if cur.Y == 0 {
+		t.Fatalf("detach restored the cursor to row 1 — the #425 jump; output %q", out)
+	}
+	if cur.X != 0 || cur.Y != 5 {
+		t.Errorf("cursor after detach = (%d,%d), want (0,5) — the line after the banner", cur.X, cur.Y)
+	}
+}
+
+// TestDetach_OptInClearScreen asserts --clear-screen-on-detach performs a real
+// screen erase — the \x1b[2J\x1b[H bytes on client stdout after the normalize
+// sequence — not merely a cursor-home.
+func TestDetach_OptInClearScreen(t *testing.T) {
+	sr, _ := newAttachedExec(t)
+	sr.terminalClient = &mockTerminalClient{}
+	sr.metadata.Spec.ClearScreenOnDetach = true
+
+	out := captureDetachOutput(t, sr)
+
+	clearIdx := strings.Index(out, "\x1b[2J\x1b[H")
+	normIdx := strings.Index(out, "\x1b[?1049l")
+	if clearIdx < 0 {
+		t.Fatalf("opt-in detach clear must write \\x1b[2J\\x1b[H to stdout; got %q", out)
+	}
+	if normIdx < 0 || clearIdx < normIdx {
+		t.Errorf("clear must follow the normalize sequence; clear@%d normalize@%d in %q", clearIdx, normIdx, out)
+	}
+
+	vt := vt10x.New(vt10x.WithSize(80, 24))
+	_, _ = vt.Write([]byte("$ ls\r\nfile1\r\nfile2\r\n$ "))
+	_, _ = vt.Write([]byte(out))
+	if cur := vt.Cursor(); cur.X != 0 || cur.Y != 0 {
+		t.Errorf("cursor after opt-in clear = (%d,%d), want home (0,0)", cur.X, cur.Y)
+	}
+}
+
+// TestDetach_OptInClearScreen_RPCFailure asserts the opt-in clear still runs
+// when the Detach RPC fails — the user committed to detaching either way.
+func TestDetach_OptInClearScreen_RPCFailure(t *testing.T) {
+	sr, _ := newAttachedExec(t)
+	sr.terminalClient = &mockTerminalClient{
+		detachFunc: func(_ context.Context, _ *api.ID) error { return errMockDetach },
+	}
+	sr.metadata.Spec.ClearScreenOnDetach = true
+
+	r, w, errPipe := os.Pipe()
+	if errPipe != nil {
+		t.Fatalf("Pipe: %v", errPipe)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+	sr.stdout = w
+
+	if err := sr.Detach(); !errors.Is(err, errMockDetach) {
+		t.Fatalf("Detach: want errMockDetach, got %v", err)
+	}
+	_ = w.Close()
+
+	buf, errRead := io.ReadAll(r)
+	if errRead != nil {
+		t.Fatalf("ReadAll: %v", errRead)
+	}
+	if !strings.Contains(string(buf), "\x1b[2J\x1b[H") {
+		t.Errorf("opt-in clear missing on RPC-failure detach; got %q", string(buf))
+	}
+}
+
+// TestDetach_AltScreenSessionReturnsToNormalBuffer asserts a detach while the
+// parent terminal sits in the alternate screen (a TUI session) still returns
+// to the normal buffer with its content intact — the DECSC prefix must not
+// break the ?1049l buffer switch. The pre-attach cursor restore itself cannot
+// be asserted under vt10x: it keeps a single saved-cursor slot where
+// xterm/VTE keep one per buffer, so the prefix's save lands in the wrong slot
+// only in the emulator. See the escRestoreParentTerm comment.
+func TestDetach_AltScreenSessionReturnsToNormalBuffer(t *testing.T) {
+	sr, _ := newAttachedExec(t)
+	sr.terminalClient = &mockTerminalClient{}
+
+	out := captureDetachOutput(t, sr)
+
+	vt := vt10x.New(vt10x.WithSize(80, 24))
+	_, _ = vt.Write([]byte("before-tui\r\n"))
+	_, _ = vt.Write([]byte("\x1b[?1049h\x1b[2J\x1b[HTUI APP"))
+	_, _ = vt.Write([]byte(out))
+
+	if vt.Mode()&vt10x.ModeAltScreen != 0 {
+		t.Errorf("detach left the terminal in the alt screen; output %q", out)
+	}
+	if !strings.Contains(vt.String(), "before-tui") {
+		t.Errorf("normal-buffer content lost across detach; screen %q", vt.String())
+	}
+	if strings.Contains(vt.String(), "TUI APP") {
+		t.Errorf("alt-screen content leaked into the normal buffer; screen %q", vt.String())
 	}
 }
 

--- a/internal/client/clientrunner/stdin_pump_test.go
+++ b/internal/client/clientrunner/stdin_pump_test.go
@@ -176,7 +176,7 @@ func TestStdinPump_SequentialAttachReuse(t *testing.T) {
 	_ = server1 // session 1 sends nothing; the connection is torn down below.
 
 	// Tear session 1 down. No copier goroutine from it may survive.
-	sr1.restoreParentTerminal("")
+	sr1.restoreParentTerminal("", false)
 	if got := waitCopierGoroutines(baseline, 2*time.Second); got != baseline {
 		t.Fatalf("after session 1 teardown: %d copier goroutines survived; want %d", got, baseline)
 	}
@@ -206,5 +206,5 @@ func TestStdinPump_SequentialAttachReuse(t *testing.T) {
 		t.Fatalf("session 2 received n=%d %q; want the between-sessions byte %q", n, rb[:n], "Z")
 	}
 
-	sr2.restoreParentTerminal("")
+	sr2.restoreParentTerminal("", false)
 }

--- a/internal/client/clientrunner/terminal.go
+++ b/internal/client/clientrunner/terminal.go
@@ -80,9 +80,19 @@ const copierWaitTimeout = 500 * time.Millisecond
 // escHideCursor in internal/terminal/terminalrunner/terminal_screen.go) and
 // with anything a TUI/shell on the remote side wrote through to the parent
 // terminal without a matching reset. Emitted unconditionally per #365 — the
-// client cannot rely on the remote side emitting a matching reset on its own;
-// resetting a mode that wasn't set is a no-op on every terminal.
-const escRestoreParentTerm = "\x1b[?1049l" + // leave the alternate screen buffer
+// client cannot rely on the remote side emitting a matching reset on its own.
+//
+// "Resetting a mode that wasn't set is a no-op" does not hold for ?1049l:
+// xterm documents DECRST 1049 as "Use Normal Screen Buffer and restore cursor
+// as in DECRC", and DECRC with no prior save restores the *default* cursor —
+// home — so a bare ?1049l on a session that never entered the alt screen
+// yanks the prompt to row 1 over stale content. The DECSC (\x1b7) prefix
+// makes the DECRC component restore the just-saved position instead.
+// xterm/VTE keep per-buffer saved cursors, so when a TUI is exiting the alt
+// screen the DECSC lands in the alt buffer's slot and the ?1049l still
+// restores the normal buffer's pre-attach cursor. See issue #425.
+const escRestoreParentTerm = "\x1b7" + // save cursor (DECSC) so ?1049l's DECRC restores it
+	"\x1b[?1049l" + // leave the alternate screen buffer
 	"\x1b[?25h" + // make the cursor visible
 	"\x1b[0 q" + // reset cursor style (DECSCUSR) to terminal default
 	"\x1b[?1000l" + // disable X11 mouse reporting (basic)
@@ -91,6 +101,11 @@ const escRestoreParentTerm = "\x1b[?1049l" + // leave the alternate screen buffe
 	"\x1b[?1006l" + // disable SGR mouse encoding
 	"\x1b[?1015l" + // disable urxvt mouse encoding
 	"\x1b[?2004l" // disable bracketed paste
+
+// escClearScreenHome is the full screen erase + cursor home the opt-in
+// --clear-screen-on-detach flag emits after escRestoreParentTerm — a real
+// erase, not merely a cursor-home. See issue #425.
+const escClearScreenHome = "\x1b[2J\x1b[H"
 
 // restoreParentTerminal performs a single, idempotent "unblock stdin + restore
 // tty" at the session boundary so the parent shell is always handed back a
@@ -104,7 +119,12 @@ const escRestoreParentTerm = "\x1b[?1049l" + // leave the alternate screen buffe
 // "Detached" notice) cannot interleave with mid-flush remote bytes yet raw mode
 // is still active so its embedded \r\n behaves correctly. The Close()/exit
 // paths pass "". See issues #364 and #383.
-func (sr *Exec) restoreParentTerminal(postDrainMsg string) {
+//
+// clearScreen, when true, emits a full screen erase + home immediately after
+// the normalize sequence — the user-detach paths pass the opt-in
+// ClearScreenOnDetach spec value; the Close()/process-exit paths pass false
+// so they keep the screen content untouched. See issue #425.
+func (sr *Exec) restoreParentTerminal(postDrainMsg string, clearScreen bool) {
 	sr.restoreOnce.Do(func() {
 		sr.logger.Debug("restoreParentTerminal: beginning terminal restore")
 
@@ -136,30 +156,11 @@ func (sr *Exec) restoreParentTerminal(postDrainMsg string) {
 			}
 		}
 
-		// Write any teardown-confirmation banner now: the inbound copier has
-		// drained (so this cannot interleave with mid-flush remote bytes) and the
-		// termios restore below has not yet run (so raw mode is still active and
-		// the banner's embedded \r\n behaves). Emitted before the normalize
-		// sequence so it lands while any alt-screen the remote set is still
-		// active, matching the pre-#383 relative ordering. See issue #383.
-		if postDrainMsg != "" && sr.stdout != nil {
-			if _, err := sr.stdout.WriteString(postDrainMsg); err != nil {
-				sr.logger.Debug("restoreParentTerminal: write post-drain message failed", "error", err)
-			}
-		}
-
-		// Normalize the parent terminal's output-side DEC private mode state
-		// (alt-screen, cursor visibility, cursor style) before handing the
-		// terminal back. Runs after the copier wait so we do not race the
-		// socket->stdout copier still draining remote bytes, and before the
-		// termios restore — these are escape bytes interpreted by the parent
-		// terminal emulator, not line-discipline input, so the active termios
-		// mode does not affect them. See issue #365.
-		if sr.stdout != nil {
-			if _, err := sr.stdout.WriteString(escRestoreParentTerm); err != nil {
-				sr.logger.Debug("restoreParentTerminal: write normalize sequence failed", "error", err)
-			}
-		}
+		// The inbound copier has drained (so output cannot interleave with
+		// mid-flush remote bytes) and the termios restore below has not yet
+		// run (so raw mode is still active and embedded \r\n behaves) —
+		// the safe point for the banner + normalize + opt-in clear writes.
+		sr.writeTeardownOutput(postDrainMsg, clearScreen)
 
 		// Restore termios raw->cooked (still via SyscallConn, no .Fd()).
 		_ = sr.toExitShell()
@@ -176,6 +177,34 @@ func (sr *Exec) restoreParentTerminal(postDrainMsg string) {
 
 		sr.logger.Info("restoreParentTerminal: parent terminal restored")
 	})
+}
+
+// writeTeardownOutput writes the teardown byte sequences to the parent
+// terminal in order: the optional post-drain confirmation banner (emitted
+// before the normalize sequence so it lands while any alt-screen the remote
+// set is still active, matching the pre-#383 relative ordering — see issue
+// #383), the output-side normalize sequence (escape bytes interpreted by
+// the parent terminal emulator, not line-discipline input, so the active
+// termios mode does not affect them — see issue #365), and the opt-in
+// detach clear (a real screen erase after the normalize so it applies to
+// the normal buffer the ?1049l just guaranteed is active — see issue #425).
+func (sr *Exec) writeTeardownOutput(postDrainMsg string, clearScreen bool) {
+	if sr.stdout == nil {
+		return
+	}
+	if postDrainMsg != "" {
+		if _, err := sr.stdout.WriteString(postDrainMsg); err != nil {
+			sr.logger.Debug("restoreParentTerminal: write post-drain message failed", "error", err)
+		}
+	}
+	if _, err := sr.stdout.WriteString(escRestoreParentTerm); err != nil {
+		sr.logger.Debug("restoreParentTerminal: write normalize sequence failed", "error", err)
+	}
+	if clearScreen {
+		if _, err := sr.stdout.WriteString(escClearScreenHome); err != nil {
+			sr.logger.Debug("restoreParentTerminal: write clear screen failed", "error", err)
+		}
+	}
 }
 
 func (sr *Exec) initTerminal() error {

--- a/internal/terminal/terminalrunner/connections.go
+++ b/internal/terminal/terminalrunner/connections.go
@@ -208,7 +208,7 @@ func (sr *Exec) initialAttachPaint(client *ioClient) []byte {
 		sr.logger.Warn("no screen model for client attach repaint", "client", client.id)
 		return nil
 	}
-	return screen.repaint()
+	return screen.repaint(client.clearScreen)
 }
 
 func (sr *Exec) addClient(c *ioClient) {

--- a/internal/terminal/terminalrunner/connections_attach_paint_test.go
+++ b/internal/terminal/terminalrunner/connections_attach_paint_test.go
@@ -25,8 +25,9 @@ import (
 	"github.com/eminwux/sbsh/pkg/api"
 )
 
-// Default attach (fullCapture=false) synthesizes a bounded repaint from the
-// live screen model — the current screen, not the raw capture file.
+// Default attach (fullCapture=false, clearScreen=false) synthesizes a
+// bounded repaint from the live screen model — the current screen, not the
+// raw capture file — and never erases the client's terminal.
 func TestInitialAttachPaintRepaintsScreen(t *testing.T) {
 	sr := newScreenExec()
 	screen := newScreenModel()
@@ -38,8 +39,29 @@ func TestInitialAttachPaintRepaintsScreen(t *testing.T) {
 	id := api.ID("c1")
 	got := string(sr.initialAttachPaint(&ioClient{id: &id, fullCapture: false}))
 
+	if strings.Contains(got, escClearScreen) {
+		t.Errorf("default repaint paint must not clear the screen; got %q", got)
+	}
+	if !strings.Contains(got, "current screen state") {
+		t.Errorf("repaint paint should contain the live screen; got %q", got)
+	}
+}
+
+// --clear-screen (clearScreen=true) restores the legacy clear-and-repaint
+// seed paint.
+func TestInitialAttachPaintClearScreen(t *testing.T) {
+	sr := newScreenExec()
+	screen := newScreenModel()
+	feed(screen, "current screen state")
+	sr.ptyPipesMu.Lock()
+	sr.ptyPipes.screen = screen
+	sr.ptyPipesMu.Unlock()
+
+	id := api.ID("c1c")
+	got := string(sr.initialAttachPaint(&ioClient{id: &id, fullCapture: false, clearScreen: true}))
+
 	if !strings.Contains(got, escClearScreen) {
-		t.Errorf("repaint paint should clear the screen; got %q", got)
+		t.Errorf("clear-screen repaint paint should clear the screen; got %q", got)
 	}
 	if !strings.Contains(got, "current screen state") {
 		t.Errorf("repaint paint should contain the live screen; got %q", got)

--- a/internal/terminal/terminalrunner/lifecycle.go
+++ b/internal/terminal/terminalrunner/lifecycle.go
@@ -496,7 +496,7 @@ func (sr *Exec) Attach(req *api.AttachRequest, response *api.ResponseWithFD) err
 		return fmt.Errorf("Attach: terminal not running")
 	}
 
-	cliFD, err := sr.CreateNewClient(&req.ClientID, req.FullCapture)
+	cliFD, err := sr.CreateNewClient(&req.ClientID, req.FullCapture, req.ClearScreen)
 	if err != nil {
 		return err
 	}
@@ -507,7 +507,14 @@ func (sr *Exec) Attach(req *api.AttachRequest, response *api.ResponseWithFD) err
 
 	fds := []int{cliFD}
 
-	sr.logger.Debug("Attach response", "id", req.ClientID, "fullCapture", req.FullCapture, "ok", payload.OK, "fds", fds)
+	sr.logger.Debug(
+		"Attach response",
+		"id", req.ClientID,
+		"fullCapture", req.FullCapture,
+		"clearScreen", req.ClearScreen,
+		"ok", payload.OK,
+		"fds", fds,
+	)
 
 	response.JSON = payload
 	response.FDs = fds

--- a/internal/terminal/terminalrunner/socket_rpc_cluster_test.go
+++ b/internal/terminal/terminalrunner/socket_rpc_cluster_test.go
@@ -247,7 +247,7 @@ func TestCreateNewClient_RegistersAndCleansUp(t *testing.T) {
 	sr := newWiredExec(t)
 
 	id := api.ID("attach-1")
-	cliFD, err := sr.CreateNewClient(&id, false)
+	cliFD, err := sr.CreateNewClient(&id, false, false)
 	if err != nil {
 		t.Fatalf("CreateNewClient: %v", err)
 	}

--- a/internal/terminal/terminalrunner/sockets.go
+++ b/internal/terminal/terminalrunner/sockets.go
@@ -249,7 +249,7 @@ func (sr *Exec) OpenSocketCtrl() error {
 	return nil
 }
 
-func (sr *Exec) CreateNewClient(clientID *api.ID, fullCapture bool) (int, error) {
+func (sr *Exec) CreateNewClient(clientID *api.ID, fullCapture, clearScreen bool) (int, error) {
 	sr.logger.Debug("CreateNewClient: creating socketpair", "id", clientID)
 	sv, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|sockCloexec, 0)
 	if err != nil {
@@ -269,7 +269,7 @@ func (sr *Exec) CreateNewClient(clientID *api.ID, fullCapture bool) (int, error)
 	}
 	_ = f.Close() // release the duplicate, keep using ioConn
 
-	cl := &ioClient{id: clientID, conn: ioConn, fullCapture: fullCapture}
+	cl := &ioClient{id: clientID, conn: ioConn, fullCapture: fullCapture, clearScreen: clearScreen}
 
 	sr.addClient(cl)
 	sr.logger.Info("CreateNewClient: client added", "id", clientID)

--- a/internal/terminal/terminalrunner/terminal_runner_exec.go
+++ b/internal/terminal/terminalrunner/terminal_runner_exec.go
@@ -153,6 +153,12 @@ type ioClient struct {
 	// the full raw capture buffer is replayed, otherwise a bounded repaint
 	// of the current screen is synthesized from the screen model.
 	fullCapture bool
+	// clearScreen opts the repaint into the legacy clear-and-repaint
+	// (erase screen + home + absolute positioning) instead of the default
+	// relative paint that preserves the client's prior terminal content.
+	// Set by the --clear-screen flag; ignored on the fullCapture path,
+	// whose replay is raw history.
+	clearScreen bool
 }
 
 func NewTerminalRunnerExec(ctx context.Context, logger *slog.Logger, spec *api.TerminalSpec) TerminalRunner {

--- a/internal/terminal/terminalrunner/terminal_screen.go
+++ b/internal/terminal/terminalrunner/terminal_screen.go
@@ -34,6 +34,9 @@ const (
 	escCursorTo       = "\x1b[%d;%dH" // move cursor to row, col (1-based)
 	escShowCursor     = "\x1b[?25h"   // make the cursor visible
 	escHideCursor     = "\x1b[?25l"   // hide the cursor
+	escEraseToEOL     = "\x1b[K"      // erase from cursor to end of line
+	escCursorUpN      = "\x1b[%dA"    // move cursor up n rows (CUU)
+	escCursorRightN   = "\x1b[%dC"    // move cursor right n cols (CUF)
 )
 
 // vt10x color encoding boundaries. The 16 ANSI colors occupy [0,16):
@@ -140,17 +143,29 @@ func (m *screenModel) snapshot() *api.ScreenshotResult {
 }
 
 // repaint synthesizes a byte sequence that, written to a freshly attached
-// client's raw-mode terminal, reproduces the current screen: alt-screen
-// mode if active, a cleared grid, every visible cell with its SGR colors at
-// its absolute position, and the cursor's position and visibility. Unlike
-// the raw capture replay it is bounded to the viewport regardless of how
-// long the session has run, which is the whole point of repaint-on-attach.
+// client's raw-mode terminal, reproduces the current screen. Unlike the raw
+// capture replay it is bounded to the viewport regardless of how long the
+// session has run, which is the whole point of repaint-on-attach.
 //
-// Absolute per-row cursor positioning (CSI row;1H) is used instead of
-// newlines so the paint is correct in raw mode, where a bare "\n" is a line
-// feed that does not return the carriage. It is taken under the vt10x state
-// lock so cells, cursor, and mode form one consistent frame.
-func (m *screenModel) repaint() []byte {
+// By default the paint never destroys the client's existing terminal
+// content: rows are framed relatively from the cursor's current line
+// ("\r\n" between rows, since in raw mode a bare "\n" is a line feed that
+// does not return the carriage) so prior content scrolls up intact, and the
+// final cursor lands via relative moves (LF/CUU for rows, CR+CUF for the
+// column — relative because the client's absolute cursor row is unknown to
+// the server). Each painted row ends with an erase-to-EOL so stale client
+// content cannot bleed through shorter rows. An empty screen model paints
+// no rows at all.
+//
+// clearScreen opts back into the legacy clear-and-repaint: erase the whole
+// screen, home, then absolute per-row positioning (CSI row;1H). Alt-screen
+// sessions always take the absolute path inside the alt buffer — entering
+// the alt screen never destroys the client's normal-buffer content, and
+// TUIs need absolute coordinates to render correctly.
+//
+// It is taken under the vt10x state lock so cells, cursor, and mode form
+// one consistent frame.
+func (m *screenModel) repaint(clearScreen bool) []byte {
 	m.vt.Lock()
 	defer m.vt.Unlock()
 
@@ -164,32 +179,76 @@ func (m *screenModel) repaint() []byte {
 	for y := range rows {
 		textLines[y], ansiLines[y] = renderLine(m.vt, cols, y)
 	}
-	// Trailing blank rows need no paint — the screen clear already blanked
-	// them. Stop at the last non-empty row (plain text is the canonical
-	// emptiness signal, mirroring renderGrid).
+	// Trailing blank rows need no paint. Stop at the last non-empty row
+	// (plain text is the canonical emptiness signal, mirroring renderGrid).
 	end := len(textLines)
 	for end > 0 && textLines[end-1] == "" {
 		end--
 	}
 
 	var b strings.Builder
-	if altScreen {
-		b.WriteString(escEnterAltScreen)
+	if altScreen || clearScreen {
+		writeAbsolutePaint(&b, ansiLines[:end], cur, altScreen)
+	} else {
+		writeRelativePaint(&b, ansiLines[:end], cur)
 	}
-	b.WriteString(escClearScreen)
-	b.WriteString(escCursorHome)
-	for y := range end {
-		fmt.Fprintf(&b, escCursorTo, y+1, 1)
-		b.WriteString(ansiLines[y])
-	}
-	// vt10x cursor coordinates are 0-based; CSI row;colH is 1-based.
-	fmt.Fprintf(&b, escCursorTo, cur.Y+1, cur.X+1)
 	if cursorVisible {
 		b.WriteString(escShowCursor)
 	} else {
 		b.WriteString(escHideCursor)
 	}
 	return []byte(b.String())
+}
+
+// writeAbsolutePaint emits the legacy clear-and-repaint: erase the whole
+// screen, home, one absolutely positioned write per row, absolute final
+// cursor. Used for alt-screen sessions (entering the alt buffer first) and
+// for the --clear-screen opt-in on the normal buffer.
+func writeAbsolutePaint(b *strings.Builder, lines []string, cur vt10x.Cursor, altScreen bool) {
+	if altScreen {
+		b.WriteString(escEnterAltScreen)
+	}
+	b.WriteString(escClearScreen)
+	b.WriteString(escCursorHome)
+	for y, line := range lines {
+		fmt.Fprintf(b, escCursorTo, y+1, 1)
+		b.WriteString(line)
+	}
+	// vt10x cursor coordinates are 0-based; CSI row;colH is 1-based.
+	fmt.Fprintf(b, escCursorTo, cur.Y+1, cur.X+1)
+}
+
+// writeRelativePaint emits the default non-destructive paint: rows framed
+// from the client cursor's current line with "\r\n", each erased to EOL so
+// stale client content cannot bleed through, then the final cursor placed
+// with relative moves only.
+func writeRelativePaint(b *strings.Builder, lines []string, cur vt10x.Cursor) {
+	for y, line := range lines {
+		if y == 0 {
+			b.WriteString("\r")
+		} else {
+			b.WriteString("\r\n")
+		}
+		b.WriteString(line)
+		b.WriteString(escEraseToEOL)
+	}
+	// The physical line now under the cursor corresponds to the last
+	// painted screen row (or the starting line when nothing painted).
+	// Walk to the cursor's row relatively: LF scrolls at the bottom
+	// margin where CUD would not, CUU for upward moves.
+	lastRow := 0
+	if len(lines) > 0 {
+		lastRow = len(lines) - 1
+	}
+	if d := cur.Y - lastRow; d > 0 {
+		b.WriteString(strings.Repeat("\n", d))
+	} else if d < 0 {
+		fmt.Fprintf(b, escCursorUpN, -d)
+	}
+	b.WriteString("\r")
+	if cur.X > 0 {
+		fmt.Fprintf(b, escCursorRightN, cur.X)
+	}
 }
 
 // renderGrid walks the grid row by row and produces both the plain-text

--- a/internal/terminal/terminalrunner/terminal_screen_test.go
+++ b/internal/terminal/terminalrunner/terminal_screen_test.go
@@ -212,74 +212,176 @@ func TestScreenModelConcurrentWriteAndSnapshot(t *testing.T) {
 	}
 }
 
-// An empty screen (no output yet, the "empty capture" case) repaints to a
-// bare clear-screen + home, no alt-screen switch, cursor home and visible.
+// An empty screen (no output yet, the brand-new `sbsh` session case) paints
+// nothing destructive by default: no clear, no home, no alt-screen switch —
+// the invoking terminal's content survives. Only carriage/cursor-visibility
+// normalization remains.
 func TestRepaintEmptyScreen(t *testing.T) {
 	m := newScreenModel()
-	got := string(m.repaint())
+	got := string(m.repaint(false))
+
+	if strings.Contains(got, escEnterAltScreen) {
+		t.Errorf("empty primary screen must not enter alt screen; got %q", got)
+	}
+	if strings.Contains(got, escClearScreen) || strings.Contains(got, escCursorHome) {
+		t.Errorf("default repaint must not clear or home; got %q", got)
+	}
+	if !strings.HasSuffix(got, escShowCursor) {
+		t.Errorf("empty repaint should leave the cursor visible; got %q", got)
+	}
+}
+
+// --clear-screen restores the legacy behavior on an empty screen: clear +
+// home, cursor at row 1 col 1, visible.
+func TestRepaintEmptyScreenClearScreen(t *testing.T) {
+	m := newScreenModel()
+	got := string(m.repaint(true))
 
 	if strings.Contains(got, escEnterAltScreen) {
 		t.Errorf("empty primary screen must not enter alt screen; got %q", got)
 	}
 	if !strings.Contains(got, escClearScreen) || !strings.Contains(got, escCursorHome) {
-		t.Errorf("repaint must clear and home; got %q", got)
+		t.Errorf("clear-screen repaint must clear and home; got %q", got)
 	}
-	// Cursor lands at row 1, col 1 and stays visible.
 	if !strings.HasSuffix(got, "\x1b[1;1H"+escShowCursor) {
-		t.Errorf("empty repaint should end at home with a visible cursor; got %q", got)
+		t.Errorf("clear-screen empty repaint should end at home with a visible cursor; got %q", got)
 	}
 }
 
-// A plain line of output repaints by positioning at row 1 and writing the
-// glyphs — no newlines, which would stairstep in raw mode.
+// A plain line of output paints relatively by default: carriage return then
+// the glyphs, no screen erase and no absolute positioning, so the client's
+// prior terminal content is preserved.
 func TestRepaintPlainOutput(t *testing.T) {
 	m := newScreenModel()
 	feed(m, "hello world")
-	got := string(m.repaint())
+	got := string(m.repaint(false))
 
+	if !strings.Contains(got, "\rhello world") {
+		t.Errorf("repaint should carriage-return then write the line; got %q", got)
+	}
+	if strings.Contains(got, escClearScreen) {
+		t.Errorf("default repaint must not erase the screen; got %q", got)
+	}
+	if strings.Contains(got, "\x1b[1;1H") {
+		t.Errorf("default repaint must not position absolutely; got %q", got)
+	}
+}
+
+// --clear-screen restores the legacy paint: clear + home + absolute per-row
+// positioning, no newlines (which would stairstep in raw mode).
+func TestRepaintPlainOutputClearScreen(t *testing.T) {
+	m := newScreenModel()
+	feed(m, "hello world")
+	got := string(m.repaint(true))
+
+	if !strings.Contains(got, escClearScreen) {
+		t.Errorf("clear-screen repaint should erase the screen; got %q", got)
+	}
 	if !strings.Contains(got, "\x1b[1;1Hhello world") {
-		t.Errorf("repaint should position row 1 then write the line; got %q", got)
+		t.Errorf("clear-screen repaint should position row 1 then write the line; got %q", got)
 	}
 	if strings.Contains(got, "\n") {
-		t.Errorf("repaint must not use newlines (raw mode); got %q", got)
+		t.Errorf("clear-screen repaint must not use newlines (raw mode); got %q", got)
+	}
+}
+
+// The default relative paint reproduces the session screen below existing
+// client content instead of erasing it: feeding the paint into a simulated
+// client terminal that already holds two lines leaves those lines intact,
+// paints the session rows after them, and lands the cursor at the session's
+// cursor column on the right row.
+func TestRepaintRelativePreservesClientContent(t *testing.T) {
+	session := newScreenModel()
+	feed(session, "one\r\ntwo\r\nthree")
+
+	// Simulated client terminal with prior content; its cursor sits at
+	// col 0 of row 2, the line attach paints from.
+	client := newScreenModel()
+	feed(client, "prior-a\r\nprior-b\r\n")
+
+	feed(client, string(session.repaint(false)))
+
+	snap := client.snapshot()
+	for i, want := range []string{"prior-a", "prior-b", "one", "two", "three"} {
+		lines := strings.Split(snap.Text, "\n")
+		if i >= len(lines) || lines[i] != want {
+			t.Fatalf("client screen row %d = %q, want %q (screen %q)", i, lines[min(i, len(lines)-1)], want, snap.Text)
+		}
+	}
+	// Session cursor was at the end of "three" (col 5, row 2); painted
+	// from client row 2 it must land at col 5, row 4.
+	if snap.CursorX != 5 || snap.CursorY != 4 {
+		t.Errorf("client cursor = (%d,%d), want (5,4)", snap.CursorX, snap.CursorY)
+	}
+}
+
+// A session cursor above the last painted row (e.g. a TUI-less app that
+// moved the cursor up) is reached with a relative CUU, not an absolute CUP.
+func TestRepaintRelativeCursorAboveLastRow(t *testing.T) {
+	session := newScreenModel()
+	feed(session, "aa\r\nbb\r\ncc", "\x1b[1;2H") // cursor to row 1 col 2 (0-based: 1,0... CUP is 1-based)
+
+	client := newScreenModel()
+	feed(client, string(session.repaint(false)))
+
+	snap := client.snapshot()
+	// Session cursor: CUP 1;2 → row 0, col 1 (0-based). Painted from
+	// client row 0, the cursor must land there too.
+	if snap.CursorX != 1 || snap.CursorY != 0 {
+		t.Errorf("client cursor = (%d,%d), want (1,0)", snap.CursorX, snap.CursorY)
+	}
+	if !strings.Contains(string(session.repaint(false)), "\x1b[2A") {
+		t.Errorf("paint should move up relatively (CUU); got %q", string(session.repaint(false)))
 	}
 }
 
 // Reattaching to an alt-screen app (vim/htop) must re-enter the alternate
-// buffer and paint its current contents, not the primary screen's history.
+// buffer and paint its current contents with absolute positioning — clearing
+// inside the alt buffer never destroys the client's normal-buffer content —
+// regardless of the clear-screen opt-in.
 func TestRepaintAltScreen(t *testing.T) {
-	m := newScreenModel()
-	feed(m, "primary content")
-	feed(m, "\x1b[?1049h", "\x1b[2J\x1b[H", "ALT SCREEN APP")
+	for _, clearScreen := range []bool{false, true} {
+		m := newScreenModel()
+		feed(m, "primary content")
+		feed(m, "\x1b[?1049h", "\x1b[2J\x1b[H", "ALT SCREEN APP")
 
-	got := string(m.repaint())
-	if !strings.HasPrefix(got, escEnterAltScreen) {
-		t.Errorf("alt-screen repaint must switch to the alt buffer first; got %q", got)
-	}
-	if !strings.Contains(got, "ALT SCREEN APP") {
-		t.Errorf("repaint should paint the alt-screen contents; got %q", got)
-	}
-	if strings.Contains(got, "primary content") {
-		t.Errorf("alt-screen repaint must not leak primary content; got %q", got)
+		got := string(m.repaint(clearScreen))
+		if !strings.HasPrefix(got, escEnterAltScreen) {
+			t.Errorf("clearScreen=%v: alt-screen repaint must switch to the alt buffer first; got %q", clearScreen, got)
+		}
+		if !strings.Contains(got, escClearScreen) {
+			t.Errorf("clearScreen=%v: alt-screen repaint clears inside the alt buffer; got %q", clearScreen, got)
+		}
+		if !strings.Contains(got, "ALT SCREEN APP") {
+			t.Errorf("clearScreen=%v: repaint should paint the alt-screen contents; got %q", clearScreen, got)
+		}
+		if strings.Contains(got, "primary content") {
+			t.Errorf("clearScreen=%v: alt-screen repaint must not leak primary content; got %q", clearScreen, got)
+		}
 	}
 }
 
-// The cursor's position and hidden state survive the repaint.
+// The cursor's hidden state survives the repaint in both modes, and the
+// legacy mode restores the absolute position.
 func TestRepaintCursorPositionAndVisibility(t *testing.T) {
 	m := newScreenModel()
 	feed(m, "\x1b[5;10H", "\x1b[?25l") // CUP row 5 col 10, then hide cursor
 
-	got := string(m.repaint())
+	got := string(m.repaint(true))
 	if !strings.Contains(got, "\x1b[5;10H") {
-		t.Errorf("repaint should restore the cursor to row 5 col 10; got %q", got)
+		t.Errorf("clear-screen repaint should restore the cursor to row 5 col 10; got %q", got)
 	}
 	if !strings.HasSuffix(got, escHideCursor) {
 		t.Errorf("repaint should end with the cursor hidden; got %q", got)
 	}
+
+	if rel := string(m.repaint(false)); !strings.HasSuffix(rel, escHideCursor) {
+		t.Errorf("default repaint should end with the cursor hidden; got %q", rel)
+	}
 }
 
-// Repaint is bounded to the viewport regardless of session length: feeding
-// far more lines than the grid has rows still paints at most one positioned
+// Repaint is bounded to the viewport regardless of session length in both
+// modes: feeding far more lines than the grid has rows paints at most one
 // row per grid row, never the whole scrollback history.
 func TestRepaintBoundedToViewport(t *testing.T) {
 	m := newScreenModel()
@@ -287,15 +389,20 @@ func TestRepaintBoundedToViewport(t *testing.T) {
 		feed(m, "line\r\n")
 		_ = i
 	}
-	got := string(m.repaint())
 
+	got := string(m.repaint(true))
 	if n := strings.Count(got, "\x1b[1;1H"); n != 1 {
-		t.Errorf("repaint should home exactly once; got %d in %q", n, got)
+		t.Errorf("clear-screen repaint should home exactly once; got %d in %q", n, got)
 	}
 	// At most rows positioned writes (CSI <row>;1H) — one per grid row.
 	positioned := strings.Count(got, ";1H")
 	if positioned > vt100Rows+1 { // +1 for the final cursor-restore CUP
-		t.Errorf("repaint painted %d positioned rows, exceeds viewport %d", positioned, vt100Rows)
+		t.Errorf("clear-screen repaint painted %d positioned rows, exceeds viewport %d", positioned, vt100Rows)
+	}
+
+	rel := string(m.repaint(false))
+	if rows := strings.Count(rel, "\r\n") + 1; rows > vt100Rows {
+		t.Errorf("default repaint framed %d rows, exceeds viewport %d", rows, vt100Rows)
 	}
 }
 

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -47,6 +47,23 @@ type ClientSpec struct {
 	// Attach RPC; the server owns the replay. Set by the --full-capture flag.
 	FullCapture bool `json:"fullCapture,omitempty"`
 
+	// ClearScreen, when true, makes the attach repaint clear the client's
+	// terminal and paint with absolute positioning (the legacy behavior)
+	// instead of the default relative paint that preserves prior terminal
+	// content. Forwarded to the terminal server via the Attach RPC. Set by
+	// the --clear-screen flag; the full-capture replay is raw history and
+	// is unaffected by it.
+	ClearScreen bool `json:"clearScreen,omitempty"`
+
+	// ClearScreenOnDetach, when true, makes the client erase the whole
+	// screen (\x1b[2J\x1b[H) after the parent-terminal restore sequence on
+	// the user-detach path (^]^] keystroke or `sb detach`). The default
+	// leaves the screen content untouched with the cursor on the line
+	// after the Detached banner. Process-exit teardown paths never clear.
+	// Set by the --clear-screen-on-detach flag; client-local, never sent
+	// to the terminal server.
+	ClearScreenOnDetach bool `json:"clearScreenOnDetach,omitempty"`
+
 	// ClientMode determines whether the client runs a new terminal or attaches to an existing one.
 	ClientMode ClientMode `json:"clientMode,omitempty"`
 }

--- a/pkg/api/terminal.go
+++ b/pkg/api/terminal.go
@@ -307,9 +307,15 @@ type SubscribeRequest struct {
 // capture buffer on attach — the legacy behavior — instead of the default
 // bounded repaint synthesized from the live screen model. It mirrors the
 // CLI's --full-capture flag, which plumbs through ClientSpec.FullCapture.
+// ClearScreen opts the repaint into the legacy clear-and-repaint (erase
+// screen + absolute positioning) instead of the default relative paint
+// that preserves the client's prior terminal content; it mirrors the CLI's
+// --clear-screen flag via ClientSpec.ClearScreen and has no effect on the
+// full-capture replay, which is raw history.
 type AttachRequest struct {
 	ClientID    ID
 	FullCapture bool
+	ClearScreen bool
 }
 
 // ResponseWithFD carries a normal JSON result plus OOB file descriptors.

--- a/pkg/attach/attach.go
+++ b/pkg/attach/attach.go
@@ -62,6 +62,19 @@ type Options struct {
 	// It flows through ClientSpec.FullCapture to the terminal server.
 	FullCapture bool
 
+	// ClearScreen, when true, makes the attach repaint clear the terminal
+	// and paint with absolute positioning (the legacy behavior) instead of
+	// the default relative paint that preserves prior terminal content. It
+	// flows through ClientSpec.ClearScreen to the terminal server. The
+	// full-capture replay is raw history and is unaffected by it.
+	ClearScreen bool
+
+	// ClearScreenOnDetach, when true, erases the whole screen after the
+	// parent-terminal restore on the user-detach path (^]^] or `sb
+	// detach`). The default leaves screen content untouched. It flows
+	// through ClientSpec.ClearScreenOnDetach and stays client-local.
+	ClearScreenOnDetach bool
+
 	// Logger is a structured logger for diagnostics. Defaults to a
 	// discard logger when nil so embedders aren't forced to wire one
 	// in.
@@ -129,12 +142,14 @@ func Run(ctx context.Context, opts Options) error {
 			Annotations: make(map[string]string),
 		},
 		Spec: api.ClientSpec{
-			ID:              api.ID(clientID),
-			RunPath:         runDir,
-			SockerCtrl:      clientCtrlSocket,
-			ClientMode:      api.AttachToTerminal,
-			DetachKeystroke: !opts.DisableDetachKeystroke,
-			FullCapture:     opts.FullCapture,
+			ID:                  api.ID(clientID),
+			RunPath:             runDir,
+			SockerCtrl:          clientCtrlSocket,
+			ClientMode:          api.AttachToTerminal,
+			DetachKeystroke:     !opts.DisableDetachKeystroke,
+			FullCapture:         opts.FullCapture,
+			ClearScreen:         opts.ClearScreen,
+			ClearScreenOnDetach: opts.ClearScreenOnDetach,
 			TerminalSpec: &api.TerminalSpec{
 				SocketFile: opts.SocketPath,
 			},

--- a/pkg/builder/client.go
+++ b/pkg/builder/client.go
@@ -34,15 +34,17 @@ type ClientOption func(*clientConfig)
 // clientConfig accumulates ClientOption values. Nil-able fields
 // distinguish "not set" from zero values (e.g. detachKeystroke).
 type clientConfig struct {
-	id              string
-	name            string
-	logFile         string
-	socketFile      string
-	mode            api.ClientMode
-	modeSet         bool
-	detachKeystroke *bool
-	fullCapture     bool
-	terminalSpec    *api.TerminalSpec
+	id                  string
+	name                string
+	logFile             string
+	socketFile          string
+	mode                api.ClientMode
+	modeSet             bool
+	detachKeystroke     *bool
+	fullCapture         bool
+	clearScreen         bool
+	clearScreenOnDetach bool
+	terminalSpec        *api.TerminalSpec
 }
 
 // WithClientID sets the client ID. Empty means "generate a random
@@ -95,6 +97,23 @@ func WithClientDetachKeystroke(enable bool) ClientOption {
 // default is false (repaint). Mirrors the CLI's --full-capture flag.
 func WithClientFullCapture(enable bool) ClientOption {
 	return func(c *clientConfig) { c.fullCapture = enable }
+}
+
+// WithClientClearScreen opts the attach repaint into clearing the
+// terminal and painting with absolute positioning (the legacy behavior)
+// instead of the default relative paint that preserves prior terminal
+// content. The default is false (no clear). Mirrors the CLI's
+// --clear-screen flag; the full-capture replay is unaffected by it.
+func WithClientClearScreen(enable bool) ClientOption {
+	return func(c *clientConfig) { c.clearScreen = enable }
+}
+
+// WithClientClearScreenOnDetach opts into erasing the whole screen after
+// the parent-terminal restore on the user-detach path (^]^] or `sb
+// detach`). The default is false (screen content untouched). Mirrors the
+// CLI's --clear-screen-on-detach flag.
+func WithClientClearScreenOnDetach(enable bool) ClientOption {
+	return func(c *clientConfig) { c.clearScreenOnDetach = enable }
 }
 
 // WithClientTerminalSpec embeds a pre-built TerminalSpec into the
@@ -168,14 +187,16 @@ func BuildClientDoc(
 			Annotations: map[string]string{},
 		},
 		Spec: api.ClientSpec{
-			ID:              api.ID(cfg.id),
-			RunPath:         runPath,
-			LogFile:         cfg.logFile,
-			SockerCtrl:      cfg.socketFile,
-			TerminalSpec:    cfg.terminalSpec,
-			DetachKeystroke: detach,
-			FullCapture:     cfg.fullCapture,
-			ClientMode:      mode,
+			ID:                  api.ID(cfg.id),
+			RunPath:             runPath,
+			LogFile:             cfg.logFile,
+			SockerCtrl:          cfg.socketFile,
+			TerminalSpec:        cfg.terminalSpec,
+			DetachKeystroke:     detach,
+			FullCapture:         cfg.fullCapture,
+			ClearScreen:         cfg.clearScreen,
+			ClearScreenOnDetach: cfg.clearScreenOnDetach,
+			ClientMode:          mode,
 		},
 	}
 	return doc, nil

--- a/pkg/builder/client_test.go
+++ b/pkg/builder/client_test.go
@@ -67,6 +67,12 @@ func TestBuildClientDoc_Defaults(t *testing.T) {
 	if doc.Spec.FullCapture {
 		t.Fatal("expected FullCapture to default false (repaint)")
 	}
+	if doc.Spec.ClearScreen {
+		t.Fatal("expected ClearScreen to default false (no clear)")
+	}
+	if doc.Spec.ClearScreenOnDetach {
+		t.Fatal("expected ClearScreenOnDetach to default false (no clear)")
+	}
 	if doc.Spec.ClientMode != api.RunNewTerminal {
 		t.Fatalf("mode: want RunNewTerminal, got %v", doc.Spec.ClientMode)
 	}
@@ -89,6 +95,8 @@ func TestBuildClientDoc_Overrides(t *testing.T) {
 		builder.WithClientMode(api.AttachToTerminal),
 		builder.WithClientDetachKeystroke(false),
 		builder.WithClientFullCapture(true),
+		builder.WithClientClearScreen(true),
+		builder.WithClientClearScreenOnDetach(true),
 		builder.WithClientTerminalSpec(embed),
 	)
 	if err != nil {
@@ -114,6 +122,12 @@ func TestBuildClientDoc_Overrides(t *testing.T) {
 	}
 	if !doc.Spec.FullCapture {
 		t.Fatal("expected FullCapture=true after WithClientFullCapture(true)")
+	}
+	if !doc.Spec.ClearScreen {
+		t.Fatal("expected ClearScreen=true after WithClientClearScreen(true)")
+	}
+	if !doc.Spec.ClearScreenOnDetach {
+		t.Fatal("expected ClearScreenOnDetach=true after WithClientClearScreenOnDetach(true)")
 	}
 	if doc.Spec.TerminalSpec != embed {
 		t.Fatal("expected embedded TerminalSpec to be the same pointer")

--- a/pkg/spawn/client.go
+++ b/pkg/spawn/client.go
@@ -155,7 +155,8 @@ func validateClientInputs(doc *api.ClientDoc, opts ClientOptions) error {
 }
 
 // buildClientAttachArgs translates a ClientDoc into the CLI argv for
-// `sb [--run-path X] attach --socket S [--id I | <name>] [--disable-detach]`.
+// `sb [--run-path X] attach --socket S [--id I | <name>] [--disable-detach]
+// [--full-capture] [--clear-screen] [--clear-screen-on-detach]`.
 //
 // The `--socket` flag is documented on `sb attach` as "for the
 // terminal" but at runtime it sets the *client's* control socket
@@ -167,7 +168,9 @@ func validateClientInputs(doc *api.ClientDoc, opts ClientOptions) error {
 // If --id and --name are both set the CLI rejects the combination,
 // so spawn deterministically prefers ID (matches CLI precedence).
 func buildClientAttachArgs(doc *api.ClientDoc, opts ClientOptions) []string {
-	const maxAttachArgs = 9 // --run-path X attach --socket S --id I --disable-detach --full-capture
+	// --run-path X attach --socket S --id I --disable-detach --full-capture
+	// --clear-screen --clear-screen-on-detach
+	const maxAttachArgs = 11
 	args := make([]string, 0, maxAttachArgs+len(opts.ExtraArgs))
 
 	if doc.Spec.RunPath != "" {
@@ -182,6 +185,14 @@ func buildClientAttachArgs(doc *api.ClientDoc, opts ClientOptions) []string {
 
 	if doc.Spec.FullCapture {
 		args = append(args, "--full-capture")
+	}
+
+	if doc.Spec.ClearScreen {
+		args = append(args, "--clear-screen")
+	}
+
+	if doc.Spec.ClearScreenOnDetach {
+		args = append(args, "--clear-screen-on-detach")
 	}
 
 	term := doc.Spec.TerminalSpec

--- a/pkg/spawn/client_test.go
+++ b/pkg/spawn/client_test.go
@@ -185,6 +185,37 @@ func TestBuildClientAttachArgs_FullCapture(t *testing.T) {
 	}
 }
 
+// TestBuildClientAttachArgs_ClearScreenFlags covers the --clear-screen and
+// --clear-screen-on-detach legs: each ClientSpec boolean appends its flag
+// (after --full-capture, before the terminal selector), mirroring the
+// --full-capture precedent.
+func TestBuildClientAttachArgs_ClearScreenFlags(t *testing.T) {
+	t.Parallel()
+	doc := &api.ClientDoc{
+		Spec: api.ClientSpec{
+			RunPath:             "/run/sbsh",
+			SockerCtrl:          "/run/sbsh/clients/c-5/socket",
+			ClientMode:          api.AttachToTerminal,
+			DetachKeystroke:     true, // no --disable-detach
+			ClearScreen:         true,
+			ClearScreenOnDetach: true,
+			TerminalSpec:        &api.TerminalSpec{ID: "t-5"},
+		},
+	}
+	got := buildClientAttachArgs(doc, ClientOptions{})
+	want := []string{
+		"--run-path", "/run/sbsh",
+		"attach",
+		"--socket", "/run/sbsh/clients/c-5/socket",
+		"--clear-screen",
+		"--clear-screen-on-detach",
+		"--id", "t-5",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildClientAttachArgs = %q; want %q", got, want)
+	}
+}
+
 // TestBuildClientAttachArgs_IDWinsOverName locks down the tie-break
 // rule: when a TerminalSpec carries both ID and Name, spawn emits
 // --id only (no positional name arg). This matches `sb attach`, which


### PR DESCRIPTION
## Summary
- **Attach default (no clear):** `repaint()` no longer emits `\x1b[2J\x1b[H` for normal-buffer sessions. It paints the session screen relatively from the client cursor's current line (`\r\n` row framing, per-row erase-to-EOL, final cursor via LF/CUU + CR/CUF), so prior terminal content scrolls up intact. An empty screen model (bare `sbsh`) paints no rows at all. Alt-screen sessions keep `?1049h` + clear + absolute positioning — clearing inside the alt buffer never destroys normal-buffer content, and TUIs need absolute coordinates.
- **Attach opt-in clear:** new `--clear-screen` flag on `sb attach` (env `SB_ATTACH_CLEAR_SCREEN`) and bare `sbsh` (env `SBSH_CLIENT_CLEAR_SCREEN`) restores the legacy clear-and-repaint. Plumbed like `FullCapture`: flag → `ClientSpec.ClearScreen` → `api.AttachRequest.ClearScreen` → `CreateNewClient`/`ioClient` → `initialAttachPaint`/`repaint`. `pkg/builder` gains `WithClientClearScreen`/`WithClientClearScreenOnDetach`; `pkg/spawn`'s arg builder emits both flags and `maxAttachArgs` grew 9→11.
- **Detach default (no row-1 jump):** `escRestoreParentTerm` now prefixes `\x1b[?1049l` with DECSC (`\x1b7`). xterm documents DECRST 1049 as "restore cursor as in DECRC", and DECRC with no prior save restores the *home* cursor — the reported jump on sessions that never entered the alt screen. The DECSC pins the restore to the just-written position (the line after the `Detached` banner). xterm/VTE keep per-buffer saved cursors, so the alt-exit path still restores the pre-attach normal-buffer cursor.
- **Detach opt-in clear:** new `--clear-screen-on-detach` flag on both attaching invocations (`SB_ATTACH_CLEAR_SCREEN_ON_DETACH` / `SBSH_CLIENT_CLEAR_SCREEN_ON_DETACH`). When set, the client writes a real `\x1b[2J\x1b[H` after `escRestoreParentTerm` in `restoreParentTerminal()`. Both user-detach triggers (`^]^]` and `sb detach`) funnel through `clientrunner.Exec.Detach()`, which is the only call site passing the opt-in; the `Close()`/process-exit paths always pass false.

## Implementation calls (reviewer may push back)
- **Opt-in clear also applies on the Detach-RPC-failure branch** — the user committed to detaching either way; the banner stays suppressed per #383 but the clear runs.
- **The opt-in detach clear erases the `Detached` banner** — inherent to a full-screen erase issued after the banner write, and what the issue's spec orders (`clear after escRestoreParentTerm`). The post-clear screen is an empty prompt at home, which is the opted-into UX.
- **DECSC chosen over alt-screen state tracking** (the issue offered either): tracking would require scanning the raw socket→stdout passthrough for `1049h/l` in the copier hot path. The DECSC prefix is a constant change and is correct under xterm/VTE per-buffer saved-cursor semantics. One vt10x caveat documented in the tests: vt10x keeps a *single* saved-cursor slot and swaps buffers on a normal-buffer `?1049l` (`!set || !alt` vs st's XOR), so the TUI-case "pre-attach cursor restored" assertion can't be expressed under vt10x — the alt-screen test asserts buffer return + content integrity instead, and the comment on `escRestoreParentTerm` records the reasoning.
- **DECSC prefix applies to every teardown path** (process exit, ctx cancel), not just detach — the same bare-`?1049l` cursor jump existed there, and the constant is shared.

## Test plan
- [x] `make sbsh-sb` + ELF magic verified
- [x] `go build ./...`, `go vet ./...`
- [x] pre-commit (gofmt, go-mod-tidy, golangci-lint) on changed files — clean
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` — full unit suite
- [x] `go test -tags=integration ./cmd/sb/get/...`
- [x] library-consumer example builds + vets
- [x] `make e2e` — full suite green (incl. the attach-repaint prompt detection in `e2e_lifecycle_test.go`, which still matches under the relative paint)
- [x] New unit coverage: repaint with/without clear on normal + alt-screen models, relative paint fed into a simulated client screen (content preserved, cursor lands relative), detach restore sequence with/without the opt-in (vt10x cursor assertions: stays on the line after the banner, not row 1; opt-in clear verified as `\x1b[2J\x1b[H` bytes on client stdout), RPC-failure clear leg, alt-screen detach returns to normal buffer with content intact

## AC mapping
- Bare `sbsh` no longer clears: empty-model paint emits no `2J`/`H` (TestRepaintEmptyScreen)
- `sb attach` default no clear, paints from current line: TestRepaintRelativePreservesClientContent / TestInitialAttachPaintRepaintsScreen; alt-screen repaint unchanged (TestRepaintAltScreen)
- `--clear-screen` + env vars per `cmd/config/env.go` conventions: TestRepaint*ClearScreen, TestInitialAttachPaintClearScreen
- Detach leaves cursor after banner, no erase: TestDetach_CursorStaysAfterBanner; TUI return to normal buffer: TestDetach_AltScreenSessionReturnsToNormalBuffer (pre-attach cursor restore holds under xterm/VTE per-buffer DECSC slots; not assertable under vt10x's single slot — see test comment)
- Opt-in detach clear is a real erase, verified as stdout bytes: TestDetach_OptInClearScreen
- Unit coverage with vt10x assertions: above
- `--full-capture` interaction: documented in `--clear-screen` flag help ("No effect with --full-capture, whose replay is raw history") and in the `ClientSpec.ClearScreen` godoc

Closes #425