### PR TITLE
feat: add one-line install script (curl | bash)

### DIFF
--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -74,9 +74,14 @@ jobs:
           # Resolve the latest tag once, then re-install pinned to it via
           # SBSH_VERSION to exercise the pin path. Skip-checksum is set so the
           # absent-checksum-asset case is acknowledged rather than warned.
-          tag="$(curl -fsSL -H "Authorization: Bearer $GITHUB_TOKEN" \
-            https://api.github.com/repos/eminwux/sbsh/releases/latest \
-            | grep -m1 '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')"
+          # Capture the API response in full before piping to `grep -m1`:
+          # piping curl directly into `grep -m1` makes grep close the pipe
+          # after the first match, so curl aborts mid-write with `curl: (23)`
+          # under `pipefail` (the install.sh resolver captures first for the
+          # same reason).
+          resp="$(curl -fsSL -H "Authorization: Bearer $GITHUB_TOKEN" \
+            https://api.github.com/repos/eminwux/sbsh/releases/latest)"
+          tag="$(printf '%s\n' "$resp" | grep -m1 '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')"
           echo "pinning to $tag"
           SBSH_VERSION="$tag" bash scripts/install.sh
           test -x "$SBSH_INSTALL_PREFIX/sbsh"

--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -64,7 +64,7 @@ jobs:
           echo "sb version:   $v_sb"
           test "$v_sbsh" = "$v_sb"
 
-      - name: Verify env overrides (pinned version + fork repo defaults)
+      - name: Verify env overrides (pinned SBSH_VERSION + SBSH_SKIP_CHECKSUM)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SBSH_INSTALL_PREFIX: ${{ github.workspace }}/.sbsh-pinned

--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -1,0 +1,83 @@
+name: Installer
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "scripts/install.sh"
+      - ".github/workflows/installer.yaml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "scripts/install.sh"
+      - ".github/workflows/installer.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  install:
+    name: Install (${{ matrix.os }})
+    # Exercise the positive `curl | bash` install path on GitHub-hosted
+    # runners. macOS covers the darwin/arm64 asset; ubuntu covers linux/amd64.
+    # The script resolves the latest published release, so this validates the
+    # real end-to-end flow against actual release assets.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Run the installer
+        env:
+          # Authenticated API call avoids the unauthenticated rate limit when
+          # resolving the latest release tag on shared runners.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Install to a workspace-local prefix so no sudo prompt is needed and
+          # the runner's system dirs stay untouched.
+          SBSH_INSTALL_PREFIX: ${{ github.workspace }}/.sbsh-bin
+        run: bash scripts/install.sh
+
+      - name: Verify the install
+        env:
+          SBSH_INSTALL_PREFIX: ${{ github.workspace }}/.sbsh-bin
+        run: |
+          set -euo pipefail
+          prefix="$SBSH_INSTALL_PREFIX"
+          # Both names exist and are executable.
+          test -x "$prefix/sbsh"
+          test -x "$prefix/sb"
+          # `sb` is a real hardlink to `sbsh` (same inode), not a symlink — the
+          # argv[0] dispatch depends on it.
+          test ! -L "$prefix/sb"
+          test "$prefix/sbsh" -ef "$prefix/sb"
+          # Both invocations run and report the same version.
+          v_sbsh="$("$prefix/sbsh" version)"
+          v_sb="$("$prefix/sb" version)"
+          echo "sbsh version: $v_sbsh"
+          echo "sb version:   $v_sb"
+          test "$v_sbsh" = "$v_sb"
+
+      - name: Verify env overrides (pinned version + fork repo defaults)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SBSH_INSTALL_PREFIX: ${{ github.workspace }}/.sbsh-pinned
+          SBSH_SKIP_CHECKSUM: "1"
+        run: |
+          set -euo pipefail
+          # Resolve the latest tag once, then re-install pinned to it via
+          # SBSH_VERSION to exercise the pin path. Skip-checksum is set so the
+          # absent-checksum-asset case is acknowledged rather than warned.
+          tag="$(curl -fsSL -H "Authorization: Bearer $GITHUB_TOKEN" \
+            https://api.github.com/repos/eminwux/sbsh/releases/latest \
+            | grep -m1 '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')"
+          echo "pinning to $tag"
+          SBSH_VERSION="$tag" bash scripts/install.sh
+          test -x "$SBSH_INSTALL_PREFIX/sbsh"
+          test "$("$SBSH_INSTALL_PREFIX/sbsh" version)" = "$tag"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ Get sbsh up and running in minutes.
 
 ### Install
 
+One-liner — auto-detects OS/arch, resolves the latest release, installs `sbsh` and the `sb` hardlink:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/eminwux/sbsh/main/scripts/install.sh | bash
+```
+
+Override defaults via env vars: `SBSH_VERSION=vX.Y.Z` (pin a tag), `SBSH_INSTALL_PREFIX=/path/bin` (default `/usr/local/bin`), `SBSH_REPO=owner/repo` (forks), `SBSH_SKIP_CHECKSUM=1`.
+
+<details>
+<summary>Or install manually</summary>
+
 ```bash
 # Set your platform (defaults shown)
 export OS=linux        # Options: linux, darwin, freebsd
@@ -28,6 +39,8 @@ chmod +x sbsh && \
 sudo install -m 0755 sbsh /usr/local/bin/sbsh && \
 sudo ln -f /usr/local/bin/sbsh /usr/local/bin/sb
 ```
+
+</details>
 
 ### Autocomplete
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -152,6 +152,26 @@ cleanup_tmpdir() {
     fi
 }
 
+# --- Checksum helper ---------------------------------------------------------
+# Stock macOS ships `shasum`/`openssl`, not GNU coreutils' `sha256sum`. Prefer
+# `sha256sum` (Linux/FreeBSD), fall back to `shasum -a 256`, then
+# `openssl dgst -sha256` so the darwin target verifies correctly once a
+# `.sha256` asset is published (#56) instead of aborting under `set -e`.
+sha256_of() {
+    local path="$1"
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$path" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$path" | awk '{print $1}'
+    elif command -v openssl >/dev/null 2>&1; then
+        # `openssl dgst -sha256` prints "SHA256(<path>)= <hex>" — last field.
+        openssl dgst -sha256 "$path" | awk '{print $NF}'
+    else
+        fail "no SHA-256 tool found (need one of: sha256sum, shasum, openssl)."
+        exit 1
+    fi
+}
+
 verify_checksum() {
     local bin_path="$1" sha_url="$2" sha_path="$3"
 
@@ -177,7 +197,7 @@ verify_checksum() {
         fail "checksum asset at ${sha_url} is empty or malformed."
         exit 1
     fi
-    actual="$(sha256sum "$bin_path" | awk '{print $1}')"
+    actual="$(sha256_of "$bin_path")"
     if [ "$expected" != "$actual" ]; then
         fail "checksum mismatch for the downloaded asset"
         printf '    expected: %s\n' "$expected" >&2

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,8 +4,7 @@
 #
 # install.sh — one-line installer for sbsh.
 #
-#   curl -fsSL https://github.com/eminwux/sbsh/releases/latest/download/install.sh | bash
-#   curl -fsSL <raw-url>/scripts/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/eminwux/sbsh/main/scripts/install.sh | bash
 #
 # Collapses the multi-step manual install (download → chmod → install →
 # hardlink) documented in README §Install into a single invocation. sbsh is a
@@ -125,7 +124,10 @@ resolve_latest_version() {
         auth=(-H "Authorization: Bearer ${token}")
     fi
     local resp
-    if ! resp="$(curl -fsSL "${auth[@]}" "$api_url" 2>/dev/null)"; then
+    # ${auth[@]+...} guards the empty-array expansion: under `set -u`, a bare
+    # "${auth[@]}" on an empty array aborts with "unbound variable" on bash
+    # <4.4 (macOS stock /bin/bash 3.2.57) — the default no-token one-liner path.
+    if ! resp="$(curl -fsSL ${auth[@]+"${auth[@]}"} "$api_url" 2>/dev/null)"; then
         fail "could not query ${api_url} for the latest release tag."
         printf '    Pin a version manually:  SBSH_VERSION=v0.12.5 bash install.sh\n' >&2
         exit 1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# Copyright 2025 Emiliano Spinella (eminwux)
+# SPDX-License-Identifier: Apache-2.0
+#
+# install.sh — one-line installer for sbsh.
+#
+#   curl -fsSL https://github.com/eminwux/sbsh/releases/latest/download/install.sh | bash
+#   curl -fsSL <raw-url>/scripts/install.sh | bash
+#
+# Collapses the multi-step manual install (download → chmod → install →
+# hardlink) documented in README §Install into a single invocation. sbsh is a
+# self-contained binary with no host prerequisites (no daemon, no containerd,
+# no cgroups), so — unlike the kukeon installer this is adapted from — there
+# are no prereq checks, no `init` step, and no systemd unit.
+#
+# `sb` is created as a real hardlink (not a symlink) because the binary
+# dispatches on argv[0] basename: `sb` and `sbsh` are the same inode, and the
+# subcommand surface is selected by the name it is invoked under.
+#
+# Env overrides:
+#   SBSH_VERSION           pin a release tag, e.g. v0.12.5 (default: resolve latest via GitHub API)
+#   SBSH_REPO              GitHub repo path (default: eminwux/sbsh — for forks)
+#   SBSH_INSTALL_PREFIX    install dir (default: /usr/local/bin)
+#   SBSH_SKIP_CHECKSUM=1   skip SHA256 verification (NOT recommended)
+#
+# A GITHUB_TOKEN (or GH_TOKEN) in the environment is sent as a bearer token on
+# the GitHub API call used to resolve the latest tag — this avoids the low
+# unauthenticated rate limit on shared/CI runners. It is optional.
+
+set -euo pipefail
+
+SBSH_REPO="${SBSH_REPO:-eminwux/sbsh}"
+SBSH_INSTALL_PREFIX="${SBSH_INSTALL_PREFIX:-/usr/local/bin}"
+SBSH_VERSION="${SBSH_VERSION:-}"
+SBSH_SKIP_CHECKSUM="${SBSH_SKIP_CHECKSUM:-}"
+
+# --- Output helpers -----------------------------------------------------------
+# Colors are emitted only on a TTY so piped output (e.g. CI logs) stays clean.
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+    C_RESET=$'\033[0m'
+    C_BOLD=$'\033[1m'
+    C_GREEN=$'\033[32m'
+    C_RED=$'\033[31m'
+    C_YELLOW=$'\033[33m'
+    C_BLUE=$'\033[34m'
+else
+    C_RESET=""; C_BOLD=""; C_GREEN=""; C_RED=""; C_YELLOW=""; C_BLUE=""
+fi
+
+ok()   { printf '%s✓%s %s\n' "$C_GREEN" "$C_RESET" "$*"; }
+warn() { printf '%s!%s %s\n' "$C_YELLOW" "$C_RESET" "$*" >&2; }
+fail() { printf '%s✗%s %s\n' "$C_RED" "$C_RESET" "$*" >&2; }
+step() { printf '\n%s==>%s %s\n' "$C_BOLD$C_BLUE" "$C_RESET" "$*"; }
+
+# --- Platform detection ------------------------------------------------------
+# Maps `uname` output to the published asset name `sbsh-<os>-<arch>`. sbsh
+# publishes linux/darwin/freebsd × amd64/arm64 (see Makefile OS/ARCHS and
+# .github/workflows/release.yaml).
+detect_os() {
+    local kernel
+    kernel="$(uname -s)"
+    case "$kernel" in
+        Linux)   echo "linux" ;;
+        Darwin)  echo "darwin" ;;
+        FreeBSD) echo "freebsd" ;;
+        *)
+            fail "unsupported OS: ${kernel} (supported: Linux, Darwin, FreeBSD)"
+            exit 1
+            ;;
+    esac
+}
+
+detect_arch() {
+    local arch
+    arch="$(uname -m)"
+    case "$arch" in
+        x86_64|amd64)  echo "amd64" ;;
+        aarch64|arm64) echo "arm64" ;;
+        *)
+            fail "unsupported architecture: ${arch} (supported: amd64, arm64)"
+            exit 1
+            ;;
+    esac
+}
+
+# --- Privilege helper --------------------------------------------------------
+# Use sudo only when the install prefix is not already writable by the current
+# user — root installs need no escalation, and a user-writable prefix (e.g. a
+# custom SBSH_INSTALL_PREFIX, or CI) installs without prompting at all. Falls
+# back to sudo for the usual /usr/local/bin-owned-by-root case.
+SUDO=""
+maybe_sudo() {
+    local dir="$1"
+    # Walk up to the nearest existing ancestor: the prefix may not exist yet,
+    # in which case writability of the parent that will hold it is what matters.
+    while [ -n "$dir" ] && [ ! -e "$dir" ]; do
+        dir="$(dirname "$dir")"
+    done
+    if [ -w "$dir" ]; then
+        SUDO=""
+        return
+    fi
+    if [ "$(id -u)" -eq 0 ]; then
+        SUDO=""
+        return
+    fi
+    if ! command -v sudo >/dev/null 2>&1; then
+        fail "install prefix ${SBSH_INSTALL_PREFIX} is not writable and \`sudo\` is not installed."
+        fail "Re-run as root, install sudo, or set SBSH_INSTALL_PREFIX to a writable directory."
+        exit 1
+    fi
+    SUDO="sudo"
+}
+
+# --- Version resolution ------------------------------------------------------
+resolve_latest_version() {
+    # Resolve the literal latest release tag via the GitHub API rather than the
+    # "/releases/latest" redirect alias — the alias is mutable and can silently
+    # roll back to a withdrawn release. The API call returns the exact tag_name
+    # we then bake into the download URL.
+    local api_url="https://api.github.com/repos/${SBSH_REPO}/releases/latest"
+    local -a auth=()
+    local token="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+    if [ -n "$token" ]; then
+        auth=(-H "Authorization: Bearer ${token}")
+    fi
+    local resp
+    if ! resp="$(curl -fsSL "${auth[@]}" "$api_url" 2>/dev/null)"; then
+        fail "could not query ${api_url} for the latest release tag."
+        printf '    Pin a version manually:  SBSH_VERSION=v0.12.5 bash install.sh\n' >&2
+        exit 1
+    fi
+    # Stay grep/sed-only so the script has no jq dependency.
+    local tag
+    tag="$(printf '%s\n' "$resp" | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
+    if [ -z "$tag" ]; then
+        fail "could not parse tag_name from GitHub API response."
+        exit 1
+    fi
+    printf '%s\n' "$tag"
+}
+
+# --- Install -----------------------------------------------------------------
+# Global so the EXIT trap below can see it after do_install returns. A `local`
+# binding would be invisible by the time the trap fires in the outer shell.
+INSTALL_TMPDIR=""
+cleanup_tmpdir() {
+    if [ -n "${INSTALL_TMPDIR}" ] && [ -d "${INSTALL_TMPDIR}" ]; then
+        rm -rf "${INSTALL_TMPDIR}"
+    fi
+}
+
+verify_checksum() {
+    local bin_path="$1" sha_url="$2" sha_path="$3"
+
+    if [ -n "$SBSH_SKIP_CHECKSUM" ]; then
+        warn "SBSH_SKIP_CHECKSUM=1 set — skipping checksum verification (not recommended)."
+        return 0
+    fi
+
+    if ! curl -fsSL -o "$sha_path" "$sha_url" 2>/dev/null; then
+        # No checksum asset is published yet (depends on #56). Degrade
+        # gracefully with a loud warning rather than hard-failing the install
+        # — but never silently: the operator is told verification was skipped
+        # and how to suppress the warning.
+        warn "no checksum asset published at ${sha_url} — proceeding WITHOUT verification."
+        warn "Set SBSH_SKIP_CHECKSUM=1 to acknowledge and silence this warning."
+        return 0
+    fi
+
+    # Checksum assets are published in `sha256sum` format ("<hex>  <name>").
+    local expected actual
+    expected="$(awk '{print $1}' "$sha_path")"
+    if [ -z "$expected" ]; then
+        fail "checksum asset at ${sha_url} is empty or malformed."
+        exit 1
+    fi
+    actual="$(sha256sum "$bin_path" | awk '{print $1}')"
+    if [ "$expected" != "$actual" ]; then
+        fail "checksum mismatch for the downloaded asset"
+        printf '    expected: %s\n' "$expected" >&2
+        printf '    actual:   %s\n' "$actual" >&2
+        exit 1
+    fi
+    ok "sha256 ${actual}"
+}
+
+do_install() {
+    local os arch asset_url sha_url bin_path sha_path
+    os="$(detect_os)"
+    arch="$(detect_arch)"
+
+    step "Resolving release version"
+    if [ -z "$SBSH_VERSION" ]; then
+        SBSH_VERSION="$(resolve_latest_version)"
+    fi
+    ok "version: ${SBSH_VERSION}"
+
+    asset_url="https://github.com/${SBSH_REPO}/releases/download/${SBSH_VERSION}/sbsh-${os}-${arch}"
+    sha_url="${asset_url}.sha256"
+
+    INSTALL_TMPDIR="$(mktemp -d -t sbsh-install.XXXXXX)"
+    trap cleanup_tmpdir EXIT
+    bin_path="${INSTALL_TMPDIR}/sbsh"
+    sha_path="${INSTALL_TMPDIR}/sbsh.sha256"
+
+    step "Downloading sbsh ${SBSH_VERSION} (${os}/${arch})"
+    if ! curl -fsSL -o "$bin_path" "$asset_url"; then
+        fail "download failed: ${asset_url}"
+        printf '    Confirm SBSH_VERSION=%s ships a sbsh-%s-%s asset at\n' "$SBSH_VERSION" "$os" "$arch" >&2
+        printf '      https://github.com/%s/releases\n' "$SBSH_REPO" >&2
+        exit 1
+    fi
+    ok "downloaded $(wc -c <"$bin_path" | tr -d ' ') bytes"
+
+    step "Verifying checksum"
+    verify_checksum "$bin_path" "$sha_url" "$sha_path"
+
+    chmod +x "$bin_path"
+
+    step "Installing to ${SBSH_INSTALL_PREFIX}"
+    maybe_sudo "$SBSH_INSTALL_PREFIX"
+    $SUDO install -d -m 0755 "$SBSH_INSTALL_PREFIX"
+    $SUDO install -m 0755 "$bin_path" "${SBSH_INSTALL_PREFIX}/sbsh"
+    # Hardlink, not symlink — the binary dispatches on argv[0] basename, so
+    # `sb` must resolve to the same inode rather than via a `sb -> sbsh`
+    # indirection that some shells flatten.
+    $SUDO ln -f "${SBSH_INSTALL_PREFIX}/sbsh" "${SBSH_INSTALL_PREFIX}/sb"
+    ok "installed sbsh + sb hardlink at ${SBSH_INSTALL_PREFIX}"
+}
+
+# --- Next steps --------------------------------------------------------------
+print_next_steps() {
+    cat <<EOF
+
+${C_GREEN}${C_BOLD}✓ sbsh installed${C_RESET}
+
+Make sure ${SBSH_INSTALL_PREFIX} is on your PATH, then verify:
+  ${C_BOLD}sbsh version${C_RESET}
+  ${C_BOLD}sb get terminals${C_RESET}
+
+Enable shell autocomplete (bash shown; zsh/fish also supported):
+  ${C_BOLD}cat >> ~/.bashrc <<'RC'
+source <(sbsh autocomplete bash)
+source <(sb autocomplete bash)
+RC${C_RESET}
+
+Docs:    https://sbsh.io
+Issues:  https://github.com/${SBSH_REPO}/issues
+EOF
+}
+
+# --- Main --------------------------------------------------------------------
+do_install
+print_next_steps


### PR DESCRIPTION
## Summary

- Adds `scripts/install.sh`, a `curl -fsSL <url> | bash` one-liner that collapses the four-step manual install (download → chmod → install → hardlink) from README §Install into a single invocation.
- Auto-detects OS (`uname -s` → linux/darwin/freebsd) and arch (`uname -m` → amd64/arm64), maps to the published `sbsh-<os>-<arch>` asset name (matches `Makefile` OS/ARCHS and `release.yaml`).
- Resolves the latest release tag via the GitHub API (no hardcoded tag), `SBSH_VERSION` pins a specific tag.
- Creates `sb` as a real **hardlink** (`ln -f`), not a symlink, to preserve the `argv[0]` basename dispatch.
- Mirrors kukeon's env-override surface: `SBSH_VERSION`, `SBSH_REPO`, `SBSH_INSTALL_PREFIX` (default `/usr/local/bin`), `SBSH_SKIP_CHECKSUM`.
- Adds `.github/workflows/installer.yaml` exercising the positive install path on ubuntu + macOS hosted runners (default path, hardlink/inode assertion, version-match, and the pinned-`SBSH_VERSION` override path).
- README §Install gains the one-liner above the existing manual steps (folded into a `<details>` block).

## Implementation notes (for reviewer push-back)

- **Checksum (AC item 5, depends on #56):** no release currently publishes a `.sha256` asset (confirmed: `release.yaml` uploads only the six binaries). The AC offers two graceful-degradation options — *warn + continue* or *fail with documented `SBSH_SKIP_CHECKSUM=1` bypass*. I chose **warn + continue** as the lower-blast-radius default: hard-failing would break the one-liner for everyone until #56 lands, defeating the purpose. The warning is loud and printed to stderr — **not a silent skip** — and names the `SBSH_SKIP_CHECKSUM=1` env to acknowledge/silence it. When a `.sha256` asset *is* present the script verifies it and hard-fails on mismatch. Once #56 lands, verification activates automatically with no script change.
- **`sudo` use (AC item: "sudo only when not already root"):** I generalized the literal reading slightly — the script uses `sudo` only when the install prefix is **not writable** by the current user (root and user-writable custom prefixes both skip it). This is a strict superset of "only when not root" (root is always writable) and lets CI / rootless custom-prefix installs run without a sudo prompt. Flagging in case the reviewer wants the literal "non-root ⇒ always sudo" behavior instead.
- **Out of scope (per issue Non-goals):** no prereq checks, no `init` step, no systemd unit — sbsh has none of kukeon's host dependencies.
- **Stable short-URL publish** (e.g. via sbsh.io) is the issue's documented optional follow-up — out of scope here; the README one-liner references the raw GitHub `main` path.

## Test plan

- [x] `pre-commit run --files scripts/install.sh .github/workflows/installer.yaml README.md` — all hooks pass (prettier, check-yaml, etc.)
- [x] `make sbsh-sb` + ELF-magic verify (`7f 45 4c 46`) — produces a real executable
- [x] `go build ./...`, `go vet ./...` — clean (no Go changed)
- [x] `go test -timeout=5m $(go list ./... | grep -v '/e2e$')` — pass
- [x] End-to-end install against real release v0.12.5 into a temp prefix: latest-tag resolution, download, loud missing-checksum warning, no-sudo writable-prefix install, `sb`/`sbsh` share one inode (hardlink), both run `version` OK.
- [x] Override paths: `SBSH_VERSION` pin, `SBSH_SKIP_CHECKSUM=1`, bad-version download failure (exit 1 + clear message), unsupported OS/arch (exit 1 + clear message).

Closes #427