### PR TITLE
refactor: rename --clear-screen flags to symmetric --clear-on-attach/--clear-on-detach

### DIFF
--- a/cmd/config/env.go
+++ b/cmd/config/env.go
@@ -115,11 +115,11 @@ var (
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SB_ATTACH_FULL_CAPTURE = DefineKV("SB_ATTACH_FULL_CAPTURE", "sb/attach/fullCapture")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
-	SB_ATTACH_CLEAR_SCREEN = DefineKV("SB_ATTACH_CLEAR_SCREEN", "sb/attach/clearScreen")
+	SB_ATTACH_CLEAR_ON_ATTACH = DefineKV("SB_ATTACH_CLEAR_ON_ATTACH", "sb/attach/clearOnAttach")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
-	SB_ATTACH_CLEAR_SCREEN_ON_DETACH = DefineKV(
-		"SB_ATTACH_CLEAR_SCREEN_ON_DETACH",
-		"sb/attach/clearScreenOnDetach",
+	SB_ATTACH_CLEAR_ON_DETACH = DefineKV(
+		"SB_ATTACH_CLEAR_ON_DETACH",
+		"sb/attach/clearOnDetach",
 	)
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
 	SB_DETACH_NAME = DefineKV("SB_DETACH_NAME", "sb/detach/name")
@@ -205,11 +205,11 @@ var (
 		"sbsh.client.disableDetachKeystroke",
 	)
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
-	SBSH_CLIENT_CLEAR_SCREEN = DefineKV("SBSH_CLIENT_CLEAR_SCREEN", "sbsh.client.clearScreen")
+	SBSH_CLIENT_CLEAR_ON_ATTACH = DefineKV("SBSH_CLIENT_CLEAR_ON_ATTACH", "sbsh.client.clearOnAttach")
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable
-	SBSH_CLIENT_CLEAR_SCREEN_ON_DETACH = DefineKV(
-		"SBSH_CLIENT_CLEAR_SCREEN_ON_DETACH",
-		"sbsh.client.clearScreenOnDetach",
+	SBSH_CLIENT_CLEAR_ON_DETACH = DefineKV(
+		"SBSH_CLIENT_CLEAR_ON_DETACH",
+		"sbsh.client.clearOnDetach",
 	)
 
 	//nolint:revive,gochecknoglobals,staticcheck // ignore linter warning about this variable

--- a/cmd/sb/attach/attach.go
+++ b/cmd/sb/attach/attach.go
@@ -176,13 +176,13 @@ func setupAttachCmdFlags(attachCmd *cobra.Command) {
 		Bool("full-capture", false, "Replay the entire raw capture buffer on attach instead of repainting the current screen")
 	_ = viper.BindPFlag(config.SB_ATTACH_FULL_CAPTURE.ViperKey, attachCmd.Flags().Lookup("full-capture"))
 	attachCmd.Flags().
-		Bool("clear-screen", false, "Clear the terminal before repainting the session screen on attach (legacy behavior); the default paints below existing content. No effect with --full-capture, whose replay is raw history")
-	_ = viper.BindPFlag(config.SB_ATTACH_CLEAR_SCREEN.ViperKey, attachCmd.Flags().Lookup("clear-screen"))
+		Bool("clear-on-attach", false, "Clear the terminal before repainting the session screen on attach (legacy behavior); the default paints below existing content. No effect with --full-capture, whose replay is raw history")
+	_ = viper.BindPFlag(config.SB_ATTACH_CLEAR_ON_ATTACH.ViperKey, attachCmd.Flags().Lookup("clear-on-attach"))
 	attachCmd.Flags().
-		Bool("clear-screen-on-detach", false, "Erase the screen after detaching (^] twice or sb detach); the default leaves screen content untouched")
+		Bool("clear-on-detach", false, "Erase the screen after detaching (^] twice or sb detach); the default leaves screen content untouched")
 	_ = viper.BindPFlag(
-		config.SB_ATTACH_CLEAR_SCREEN_ON_DETACH.ViperKey,
-		attachCmd.Flags().Lookup("clear-screen-on-detach"),
+		config.SB_ATTACH_CLEAR_ON_DETACH.ViperKey,
+		attachCmd.Flags().Lookup("clear-on-detach"),
 	)
 }
 
@@ -210,8 +210,8 @@ func run(
 
 	disableDetach := viper.GetBool(config.SB_ATTACH_DISABLE_DETACH_KEYSTROKE.ViperKey)
 	fullCapture := viper.GetBool(config.SB_ATTACH_FULL_CAPTURE.ViperKey)
-	clearScreen := viper.GetBool(config.SB_ATTACH_CLEAR_SCREEN.ViperKey)
-	clearScreenOnDetach := viper.GetBool(config.SB_ATTACH_CLEAR_SCREEN_ON_DETACH.ViperKey)
+	clearOnAttach := viper.GetBool(config.SB_ATTACH_CLEAR_ON_ATTACH.ViperKey)
+	clearOnDetach := viper.GetBool(config.SB_ATTACH_CLEAR_ON_DETACH.ViperKey)
 
 	logger.DebugContext(
 		ctx,
@@ -222,10 +222,10 @@ func run(
 		disableDetach,
 		"full_capture",
 		fullCapture,
-		"clear_screen",
-		clearScreen,
-		"clear_screen_on_detach",
-		clearScreenOnDetach,
+		"clear_on_attach",
+		clearOnAttach,
+		"clear_on_detach",
+		clearOnDetach,
 	)
 
 	runErr := attach.Run(ctx, attach.Options{
@@ -235,8 +235,8 @@ func run(
 		Stderr:                 os.Stderr,
 		DisableDetachKeystroke: disableDetach,
 		FullCapture:            fullCapture,
-		ClearScreen:            clearScreen,
-		ClearScreenOnDetach:    clearScreenOnDetach,
+		ClearOnAttach:          clearOnAttach,
+		ClearOnDetach:          clearOnDetach,
 		Logger:                 logger,
 	})
 	if runErr == nil || errors.Is(runErr, context.Canceled) || errors.Is(runErr, errdefs.ErrContextDone) {

--- a/cmd/sbsh/sbsh.go
+++ b/cmd/sbsh/sbsh.go
@@ -212,9 +212,9 @@ You can also use sbsh with parameters. For example:
 					TerminalSpec:    terminalSpec,
 					DetachKeystroke: !disableDetach, // Invert flag: when disable-detach is true, DetachKeystroke is false
 					ClientMode:      api.RunNewTerminal,
-					ClearScreen:     viper.GetBool(config.SBSH_CLIENT_CLEAR_SCREEN.ViperKey),
-					ClearScreenOnDetach: viper.GetBool(
-						config.SBSH_CLIENT_CLEAR_SCREEN_ON_DETACH.ViperKey,
+					ClearOnAttach:   viper.GetBool(config.SBSH_CLIENT_CLEAR_ON_ATTACH.ViperKey),
+					ClearOnDetach: viper.GetBool(
+						config.SBSH_CLIENT_CLEAR_ON_DETACH.ViperKey,
 					),
 				},
 			}
@@ -315,16 +315,16 @@ func setClientFlags(rootCmd *cobra.Command) error {
 	}
 
 	rootCmd.Flags().
-		Bool("clear-screen", false, "Clear the terminal before painting the session screen (legacy behavior); the default paints below existing content")
-	if err := viper.BindPFlag(config.SBSH_CLIENT_CLEAR_SCREEN.ViperKey, rootCmd.Flags().Lookup("clear-screen")); err != nil {
+		Bool("clear-on-attach", false, "Clear the terminal before painting the session screen (legacy behavior); the default paints below existing content")
+	if err := viper.BindPFlag(config.SBSH_CLIENT_CLEAR_ON_ATTACH.ViperKey, rootCmd.Flags().Lookup("clear-on-attach")); err != nil {
 		return err
 	}
 
 	rootCmd.Flags().
-		Bool("clear-screen-on-detach", false, "Erase the screen after detaching (^] twice or sb detach); the default leaves screen content untouched")
+		Bool("clear-on-detach", false, "Erase the screen after detaching (^] twice or sb detach); the default leaves screen content untouched")
 	if err := viper.BindPFlag(
-		config.SBSH_CLIENT_CLEAR_SCREEN_ON_DETACH.ViperKey,
-		rootCmd.Flags().Lookup("clear-screen-on-detach"),
+		config.SBSH_CLIENT_CLEAR_ON_DETACH.ViperKey,
+		rootCmd.Flags().Lookup("clear-on-detach"),
 	); err != nil {
 		return err
 	}

--- a/internal/client/clientrunner/io.go
+++ b/internal/client/clientrunner/io.go
@@ -151,11 +151,11 @@ func (sr *Exec) attach() error {
 	var response struct{}
 	sr.metadataMu.RLock()
 	fullCapture := sr.metadata.Spec.FullCapture
-	clearScreen := sr.metadata.Spec.ClearScreen
+	clearOnAttach := sr.metadata.Spec.ClearOnAttach
 	sr.metadataMu.RUnlock()
 	conn, err := sr.terminalClient.Attach(
 		sr.ctx,
-		&api.AttachRequest{ClientID: sr.id, FullCapture: fullCapture, ClearScreen: clearScreen},
+		&api.AttachRequest{ClientID: sr.id, FullCapture: fullCapture, ClearOnAttach: clearOnAttach},
 		&response,
 	)
 	if err != nil {

--- a/internal/client/clientrunner/io_extra_test.go
+++ b/internal/client/clientrunner/io_extra_test.go
@@ -68,13 +68,13 @@ func TestAttach_Success(t *testing.T) {
 		},
 	}
 	sr.metadata.Spec.FullCapture = true
-	sr.metadata.Spec.ClearScreen = true
+	sr.metadata.Spec.ClearOnAttach = true
 
 	if err := sr.attach(); err != nil {
 		t.Fatalf("attach: %v", err)
 	}
-	if gotReq == nil || gotReq.ClientID != sr.id || !gotReq.FullCapture || !gotReq.ClearScreen {
-		t.Fatalf("attach request = %+v; want ClientID=%q FullCapture=true ClearScreen=true", gotReq, sr.id)
+	if gotReq == nil || gotReq.ClientID != sr.id || !gotReq.FullCapture || !gotReq.ClearOnAttach {
+		t.Fatalf("attach request = %+v; want ClientID=%q FullCapture=true ClearOnAttach=true", gotReq, sr.id)
 	}
 	if sr.ioConn != clientConn {
 		t.Fatal("attach did not store the returned connection in ioConn")

--- a/internal/client/clientrunner/lifecycle.go
+++ b/internal/client/clientrunner/lifecycle.go
@@ -236,7 +236,7 @@ func (sr *Exec) Detach() error {
 	// funnel through here, so this is the only place the opt-in detach
 	// clear applies; the Close()/process-exit paths always pass false.
 	sr.metadataMu.RLock()
-	clearScreen := sr.metadata.Spec.ClearScreenOnDetach
+	clearOnDetach := sr.metadata.Spec.ClearOnDetach
 	sr.metadataMu.RUnlock()
 
 	if err := sr.terminalClient.Detach(ctx, &sr.id); err != nil {
@@ -244,7 +244,7 @@ func (sr *Exec) Detach() error {
 		// Suppress the "Detached" banner — it would be misleading when the RPC
 		// failed — but the restore still runs. See #383. The opt-in clear still
 		// applies: the user committed to detaching either way.
-		sr.restoreParentTerminal("", clearScreen)
+		sr.restoreParentTerminal("", clearOnDetach)
 		return err
 	}
 
@@ -253,7 +253,7 @@ func (sr *Exec) Detach() error {
 	// message so it is written after the inbound copier has drained (no
 	// interleave with mid-flush remote bytes) but while raw mode is still active
 	// so the embedded \r\n behaves. See issues #364 and #383.
-	sr.restoreParentTerminal("\x1b[93m\r\nDetached\x1b[0m\r\n", clearScreen)
+	sr.restoreParentTerminal("\x1b[93m\r\nDetached\x1b[0m\r\n", clearOnDetach)
 
 	return nil
 }

--- a/internal/client/clientrunner/restore_linux_test.go
+++ b/internal/client/clientrunner/restore_linux_test.go
@@ -380,13 +380,13 @@ func TestDetach_CursorStaysAfterBanner(t *testing.T) {
 	}
 }
 
-// TestDetach_OptInClearScreen asserts --clear-screen-on-detach performs a real
+// TestDetach_OptInClearScreen asserts --clear-on-detach performs a real
 // screen erase — the \x1b[2J\x1b[H bytes on client stdout after the normalize
 // sequence — not merely a cursor-home.
 func TestDetach_OptInClearScreen(t *testing.T) {
 	sr, _ := newAttachedExec(t)
 	sr.terminalClient = &mockTerminalClient{}
-	sr.metadata.Spec.ClearScreenOnDetach = true
+	sr.metadata.Spec.ClearOnDetach = true
 
 	out := captureDetachOutput(t, sr)
 
@@ -414,7 +414,7 @@ func TestDetach_OptInClearScreen_RPCFailure(t *testing.T) {
 	sr.terminalClient = &mockTerminalClient{
 		detachFunc: func(_ context.Context, _ *api.ID) error { return errMockDetach },
 	}
-	sr.metadata.Spec.ClearScreenOnDetach = true
+	sr.metadata.Spec.ClearOnDetach = true
 
 	r, w, errPipe := os.Pipe()
 	if errPipe != nil {

--- a/internal/client/clientrunner/terminal.go
+++ b/internal/client/clientrunner/terminal.go
@@ -103,7 +103,7 @@ const escRestoreParentTerm = "\x1b7" + // save cursor (DECSC) so ?1049l's DECRC 
 	"\x1b[?2004l" // disable bracketed paste
 
 // escClearScreenHome is the full screen erase + cursor home the opt-in
-// --clear-screen-on-detach flag emits after escRestoreParentTerm — a real
+// --clear-on-detach flag emits after escRestoreParentTerm — a real
 // erase, not merely a cursor-home. See issue #425.
 const escClearScreenHome = "\x1b[2J\x1b[H"
 
@@ -122,7 +122,7 @@ const escClearScreenHome = "\x1b[2J\x1b[H"
 //
 // clearScreen, when true, emits a full screen erase + home immediately after
 // the normalize sequence — the user-detach paths pass the opt-in
-// ClearScreenOnDetach spec value; the Close()/process-exit paths pass false
+// ClearOnDetach spec value; the Close()/process-exit paths pass false
 // so they keep the screen content untouched. See issue #425.
 func (sr *Exec) restoreParentTerminal(postDrainMsg string, clearScreen bool) {
 	sr.restoreOnce.Do(func() {

--- a/internal/terminal/terminalrunner/connections_attach_paint_test.go
+++ b/internal/terminal/terminalrunner/connections_attach_paint_test.go
@@ -47,7 +47,7 @@ func TestInitialAttachPaintRepaintsScreen(t *testing.T) {
 	}
 }
 
-// --clear-screen (clearScreen=true) restores the legacy clear-and-repaint
+// --clear-on-attach (clearScreen=true) restores the legacy clear-and-repaint
 // seed paint.
 func TestInitialAttachPaintClearScreen(t *testing.T) {
 	sr := newScreenExec()

--- a/internal/terminal/terminalrunner/lifecycle.go
+++ b/internal/terminal/terminalrunner/lifecycle.go
@@ -496,7 +496,7 @@ func (sr *Exec) Attach(req *api.AttachRequest, response *api.ResponseWithFD) err
 		return fmt.Errorf("Attach: terminal not running")
 	}
 
-	cliFD, err := sr.CreateNewClient(&req.ClientID, req.FullCapture, req.ClearScreen)
+	cliFD, err := sr.CreateNewClient(&req.ClientID, req.FullCapture, req.ClearOnAttach)
 	if err != nil {
 		return err
 	}
@@ -511,7 +511,7 @@ func (sr *Exec) Attach(req *api.AttachRequest, response *api.ResponseWithFD) err
 		"Attach response",
 		"id", req.ClientID,
 		"fullCapture", req.FullCapture,
-		"clearScreen", req.ClearScreen,
+		"clearOnAttach", req.ClearOnAttach,
 		"ok", payload.OK,
 		"fds", fds,
 	)

--- a/internal/terminal/terminalrunner/terminal_runner_exec.go
+++ b/internal/terminal/terminalrunner/terminal_runner_exec.go
@@ -156,7 +156,7 @@ type ioClient struct {
 	// clearScreen opts the repaint into the legacy clear-and-repaint
 	// (erase screen + home + absolute positioning) instead of the default
 	// relative paint that preserves the client's prior terminal content.
-	// Set by the --clear-screen flag; ignored on the fullCapture path,
+	// Set by the --clear-on-attach flag; ignored on the fullCapture path,
 	// whose replay is raw history.
 	clearScreen bool
 }

--- a/internal/terminal/terminalrunner/terminal_screen.go
+++ b/internal/terminal/terminalrunner/terminal_screen.go
@@ -203,7 +203,7 @@ func (m *screenModel) repaint(clearScreen bool) []byte {
 // writeAbsolutePaint emits the legacy clear-and-repaint: erase the whole
 // screen, home, one absolutely positioned write per row, absolute final
 // cursor. Used for alt-screen sessions (entering the alt buffer first) and
-// for the --clear-screen opt-in on the normal buffer.
+// for the --clear-on-attach opt-in on the normal buffer.
 func writeAbsolutePaint(b *strings.Builder, lines []string, cur vt10x.Cursor, altScreen bool) {
 	if altScreen {
 		b.WriteString(escEnterAltScreen)

--- a/internal/terminal/terminalrunner/terminal_screen_test.go
+++ b/internal/terminal/terminalrunner/terminal_screen_test.go
@@ -231,7 +231,7 @@ func TestRepaintEmptyScreen(t *testing.T) {
 	}
 }
 
-// --clear-screen restores the legacy behavior on an empty screen: clear +
+// --clear-on-attach restores the legacy behavior on an empty screen: clear +
 // home, cursor at row 1 col 1, visible.
 func TestRepaintEmptyScreenClearScreen(t *testing.T) {
 	m := newScreenModel()
@@ -267,7 +267,7 @@ func TestRepaintPlainOutput(t *testing.T) {
 	}
 }
 
-// --clear-screen restores the legacy paint: clear + home + absolute per-row
+// --clear-on-attach restores the legacy paint: clear + home + absolute per-row
 // positioning, no newlines (which would stairstep in raw mode).
 func TestRepaintPlainOutputClearScreen(t *testing.T) {
 	m := newScreenModel()

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -47,22 +47,22 @@ type ClientSpec struct {
 	// Attach RPC; the server owns the replay. Set by the --full-capture flag.
 	FullCapture bool `json:"fullCapture,omitempty"`
 
-	// ClearScreen, when true, makes the attach repaint clear the client's
+	// ClearOnAttach, when true, makes the attach repaint clear the client's
 	// terminal and paint with absolute positioning (the legacy behavior)
 	// instead of the default relative paint that preserves prior terminal
 	// content. Forwarded to the terminal server via the Attach RPC. Set by
-	// the --clear-screen flag; the full-capture replay is raw history and
+	// the --clear-on-attach flag; the full-capture replay is raw history and
 	// is unaffected by it.
-	ClearScreen bool `json:"clearScreen,omitempty"`
+	ClearOnAttach bool `json:"clearOnAttach,omitempty"`
 
-	// ClearScreenOnDetach, when true, makes the client erase the whole
+	// ClearOnDetach, when true, makes the client erase the whole
 	// screen (\x1b[2J\x1b[H) after the parent-terminal restore sequence on
 	// the user-detach path (^]^] keystroke or `sb detach`). The default
 	// leaves the screen content untouched with the cursor on the line
 	// after the Detached banner. Process-exit teardown paths never clear.
-	// Set by the --clear-screen-on-detach flag; client-local, never sent
+	// Set by the --clear-on-detach flag; client-local, never sent
 	// to the terminal server.
-	ClearScreenOnDetach bool `json:"clearScreenOnDetach,omitempty"`
+	ClearOnDetach bool `json:"clearOnDetach,omitempty"`
 
 	// ClientMode determines whether the client runs a new terminal or attaches to an existing one.
 	ClientMode ClientMode `json:"clientMode,omitempty"`

--- a/pkg/api/terminal.go
+++ b/pkg/api/terminal.go
@@ -307,15 +307,15 @@ type SubscribeRequest struct {
 // capture buffer on attach — the legacy behavior — instead of the default
 // bounded repaint synthesized from the live screen model. It mirrors the
 // CLI's --full-capture flag, which plumbs through ClientSpec.FullCapture.
-// ClearScreen opts the repaint into the legacy clear-and-repaint (erase
+// ClearOnAttach opts the repaint into the legacy clear-and-repaint (erase
 // screen + absolute positioning) instead of the default relative paint
 // that preserves the client's prior terminal content; it mirrors the CLI's
-// --clear-screen flag via ClientSpec.ClearScreen and has no effect on the
+// --clear-on-attach flag via ClientSpec.ClearOnAttach and has no effect on the
 // full-capture replay, which is raw history.
 type AttachRequest struct {
-	ClientID    ID
-	FullCapture bool
-	ClearScreen bool
+	ClientID      ID
+	FullCapture   bool
+	ClearOnAttach bool
 }
 
 // ResponseWithFD carries a normal JSON result plus OOB file descriptors.

--- a/pkg/attach/attach.go
+++ b/pkg/attach/attach.go
@@ -62,18 +62,18 @@ type Options struct {
 	// It flows through ClientSpec.FullCapture to the terminal server.
 	FullCapture bool
 
-	// ClearScreen, when true, makes the attach repaint clear the terminal
+	// ClearOnAttach, when true, makes the attach repaint clear the terminal
 	// and paint with absolute positioning (the legacy behavior) instead of
 	// the default relative paint that preserves prior terminal content. It
-	// flows through ClientSpec.ClearScreen to the terminal server. The
+	// flows through ClientSpec.ClearOnAttach to the terminal server. The
 	// full-capture replay is raw history and is unaffected by it.
-	ClearScreen bool
+	ClearOnAttach bool
 
-	// ClearScreenOnDetach, when true, erases the whole screen after the
+	// ClearOnDetach, when true, erases the whole screen after the
 	// parent-terminal restore on the user-detach path (^]^] or `sb
 	// detach`). The default leaves screen content untouched. It flows
-	// through ClientSpec.ClearScreenOnDetach and stays client-local.
-	ClearScreenOnDetach bool
+	// through ClientSpec.ClearOnDetach and stays client-local.
+	ClearOnDetach bool
 
 	// Logger is a structured logger for diagnostics. Defaults to a
 	// discard logger when nil so embedders aren't forced to wire one
@@ -142,14 +142,14 @@ func Run(ctx context.Context, opts Options) error {
 			Annotations: make(map[string]string),
 		},
 		Spec: api.ClientSpec{
-			ID:                  api.ID(clientID),
-			RunPath:             runDir,
-			SockerCtrl:          clientCtrlSocket,
-			ClientMode:          api.AttachToTerminal,
-			DetachKeystroke:     !opts.DisableDetachKeystroke,
-			FullCapture:         opts.FullCapture,
-			ClearScreen:         opts.ClearScreen,
-			ClearScreenOnDetach: opts.ClearScreenOnDetach,
+			ID:              api.ID(clientID),
+			RunPath:         runDir,
+			SockerCtrl:      clientCtrlSocket,
+			ClientMode:      api.AttachToTerminal,
+			DetachKeystroke: !opts.DisableDetachKeystroke,
+			FullCapture:     opts.FullCapture,
+			ClearOnAttach:   opts.ClearOnAttach,
+			ClearOnDetach:   opts.ClearOnDetach,
 			TerminalSpec: &api.TerminalSpec{
 				SocketFile: opts.SocketPath,
 			},

--- a/pkg/builder/client.go
+++ b/pkg/builder/client.go
@@ -34,17 +34,17 @@ type ClientOption func(*clientConfig)
 // clientConfig accumulates ClientOption values. Nil-able fields
 // distinguish "not set" from zero values (e.g. detachKeystroke).
 type clientConfig struct {
-	id                  string
-	name                string
-	logFile             string
-	socketFile          string
-	mode                api.ClientMode
-	modeSet             bool
-	detachKeystroke     *bool
-	fullCapture         bool
-	clearScreen         bool
-	clearScreenOnDetach bool
-	terminalSpec        *api.TerminalSpec
+	id              string
+	name            string
+	logFile         string
+	socketFile      string
+	mode            api.ClientMode
+	modeSet         bool
+	detachKeystroke *bool
+	fullCapture     bool
+	clearOnAttach   bool
+	clearOnDetach   bool
+	terminalSpec    *api.TerminalSpec
 }
 
 // WithClientID sets the client ID. Empty means "generate a random
@@ -99,21 +99,21 @@ func WithClientFullCapture(enable bool) ClientOption {
 	return func(c *clientConfig) { c.fullCapture = enable }
 }
 
-// WithClientClearScreen opts the attach repaint into clearing the
+// WithClientClearOnAttach opts the attach repaint into clearing the
 // terminal and painting with absolute positioning (the legacy behavior)
 // instead of the default relative paint that preserves prior terminal
 // content. The default is false (no clear). Mirrors the CLI's
-// --clear-screen flag; the full-capture replay is unaffected by it.
-func WithClientClearScreen(enable bool) ClientOption {
-	return func(c *clientConfig) { c.clearScreen = enable }
+// --clear-on-attach flag; the full-capture replay is unaffected by it.
+func WithClientClearOnAttach(enable bool) ClientOption {
+	return func(c *clientConfig) { c.clearOnAttach = enable }
 }
 
-// WithClientClearScreenOnDetach opts into erasing the whole screen after
+// WithClientClearOnDetach opts into erasing the whole screen after
 // the parent-terminal restore on the user-detach path (^]^] or `sb
 // detach`). The default is false (screen content untouched). Mirrors the
-// CLI's --clear-screen-on-detach flag.
-func WithClientClearScreenOnDetach(enable bool) ClientOption {
-	return func(c *clientConfig) { c.clearScreenOnDetach = enable }
+// CLI's --clear-on-detach flag.
+func WithClientClearOnDetach(enable bool) ClientOption {
+	return func(c *clientConfig) { c.clearOnDetach = enable }
 }
 
 // WithClientTerminalSpec embeds a pre-built TerminalSpec into the
@@ -187,16 +187,16 @@ func BuildClientDoc(
 			Annotations: map[string]string{},
 		},
 		Spec: api.ClientSpec{
-			ID:                  api.ID(cfg.id),
-			RunPath:             runPath,
-			LogFile:             cfg.logFile,
-			SockerCtrl:          cfg.socketFile,
-			TerminalSpec:        cfg.terminalSpec,
-			DetachKeystroke:     detach,
-			FullCapture:         cfg.fullCapture,
-			ClearScreen:         cfg.clearScreen,
-			ClearScreenOnDetach: cfg.clearScreenOnDetach,
-			ClientMode:          mode,
+			ID:              api.ID(cfg.id),
+			RunPath:         runPath,
+			LogFile:         cfg.logFile,
+			SockerCtrl:      cfg.socketFile,
+			TerminalSpec:    cfg.terminalSpec,
+			DetachKeystroke: detach,
+			FullCapture:     cfg.fullCapture,
+			ClearOnAttach:   cfg.clearOnAttach,
+			ClearOnDetach:   cfg.clearOnDetach,
+			ClientMode:      mode,
 		},
 	}
 	return doc, nil

--- a/pkg/builder/client_test.go
+++ b/pkg/builder/client_test.go
@@ -67,11 +67,11 @@ func TestBuildClientDoc_Defaults(t *testing.T) {
 	if doc.Spec.FullCapture {
 		t.Fatal("expected FullCapture to default false (repaint)")
 	}
-	if doc.Spec.ClearScreen {
-		t.Fatal("expected ClearScreen to default false (no clear)")
+	if doc.Spec.ClearOnAttach {
+		t.Fatal("expected ClearOnAttach to default false (no clear)")
 	}
-	if doc.Spec.ClearScreenOnDetach {
-		t.Fatal("expected ClearScreenOnDetach to default false (no clear)")
+	if doc.Spec.ClearOnDetach {
+		t.Fatal("expected ClearOnDetach to default false (no clear)")
 	}
 	if doc.Spec.ClientMode != api.RunNewTerminal {
 		t.Fatalf("mode: want RunNewTerminal, got %v", doc.Spec.ClientMode)
@@ -95,8 +95,8 @@ func TestBuildClientDoc_Overrides(t *testing.T) {
 		builder.WithClientMode(api.AttachToTerminal),
 		builder.WithClientDetachKeystroke(false),
 		builder.WithClientFullCapture(true),
-		builder.WithClientClearScreen(true),
-		builder.WithClientClearScreenOnDetach(true),
+		builder.WithClientClearOnAttach(true),
+		builder.WithClientClearOnDetach(true),
 		builder.WithClientTerminalSpec(embed),
 	)
 	if err != nil {
@@ -123,11 +123,11 @@ func TestBuildClientDoc_Overrides(t *testing.T) {
 	if !doc.Spec.FullCapture {
 		t.Fatal("expected FullCapture=true after WithClientFullCapture(true)")
 	}
-	if !doc.Spec.ClearScreen {
-		t.Fatal("expected ClearScreen=true after WithClientClearScreen(true)")
+	if !doc.Spec.ClearOnAttach {
+		t.Fatal("expected ClearOnAttach=true after WithClientClearOnAttach(true)")
 	}
-	if !doc.Spec.ClearScreenOnDetach {
-		t.Fatal("expected ClearScreenOnDetach=true after WithClientClearScreenOnDetach(true)")
+	if !doc.Spec.ClearOnDetach {
+		t.Fatal("expected ClearOnDetach=true after WithClientClearOnDetach(true)")
 	}
 	if doc.Spec.TerminalSpec != embed {
 		t.Fatal("expected embedded TerminalSpec to be the same pointer")

--- a/pkg/spawn/client.go
+++ b/pkg/spawn/client.go
@@ -156,7 +156,7 @@ func validateClientInputs(doc *api.ClientDoc, opts ClientOptions) error {
 
 // buildClientAttachArgs translates a ClientDoc into the CLI argv for
 // `sb [--run-path X] attach --socket S [--id I | <name>] [--disable-detach]
-// [--full-capture] [--clear-screen] [--clear-screen-on-detach]`.
+// [--full-capture] [--clear-on-attach] [--clear-on-detach]`.
 //
 // The `--socket` flag is documented on `sb attach` as "for the
 // terminal" but at runtime it sets the *client's* control socket
@@ -169,7 +169,7 @@ func validateClientInputs(doc *api.ClientDoc, opts ClientOptions) error {
 // so spawn deterministically prefers ID (matches CLI precedence).
 func buildClientAttachArgs(doc *api.ClientDoc, opts ClientOptions) []string {
 	// --run-path X attach --socket S --id I --disable-detach --full-capture
-	// --clear-screen --clear-screen-on-detach
+	// --clear-on-attach --clear-on-detach
 	const maxAttachArgs = 11
 	args := make([]string, 0, maxAttachArgs+len(opts.ExtraArgs))
 
@@ -187,12 +187,12 @@ func buildClientAttachArgs(doc *api.ClientDoc, opts ClientOptions) []string {
 		args = append(args, "--full-capture")
 	}
 
-	if doc.Spec.ClearScreen {
-		args = append(args, "--clear-screen")
+	if doc.Spec.ClearOnAttach {
+		args = append(args, "--clear-on-attach")
 	}
 
-	if doc.Spec.ClearScreenOnDetach {
-		args = append(args, "--clear-screen-on-detach")
+	if doc.Spec.ClearOnDetach {
+		args = append(args, "--clear-on-detach")
 	}
 
 	term := doc.Spec.TerminalSpec

--- a/pkg/spawn/client_test.go
+++ b/pkg/spawn/client_test.go
@@ -185,21 +185,21 @@ func TestBuildClientAttachArgs_FullCapture(t *testing.T) {
 	}
 }
 
-// TestBuildClientAttachArgs_ClearScreenFlags covers the --clear-screen and
-// --clear-screen-on-detach legs: each ClientSpec boolean appends its flag
+// TestBuildClientAttachArgs_ClearFlags covers the --clear-on-attach and
+// --clear-on-detach legs: each ClientSpec boolean appends its flag
 // (after --full-capture, before the terminal selector), mirroring the
 // --full-capture precedent.
-func TestBuildClientAttachArgs_ClearScreenFlags(t *testing.T) {
+func TestBuildClientAttachArgs_ClearFlags(t *testing.T) {
 	t.Parallel()
 	doc := &api.ClientDoc{
 		Spec: api.ClientSpec{
-			RunPath:             "/run/sbsh",
-			SockerCtrl:          "/run/sbsh/clients/c-5/socket",
-			ClientMode:          api.AttachToTerminal,
-			DetachKeystroke:     true, // no --disable-detach
-			ClearScreen:         true,
-			ClearScreenOnDetach: true,
-			TerminalSpec:        &api.TerminalSpec{ID: "t-5"},
+			RunPath:         "/run/sbsh",
+			SockerCtrl:      "/run/sbsh/clients/c-5/socket",
+			ClientMode:      api.AttachToTerminal,
+			DetachKeystroke: true, // no --disable-detach
+			ClearOnAttach:   true,
+			ClearOnDetach:   true,
+			TerminalSpec:    &api.TerminalSpec{ID: "t-5"},
 		},
 	}
 	got := buildClientAttachArgs(doc, ClientOptions{})
@@ -207,8 +207,8 @@ func TestBuildClientAttachArgs_ClearScreenFlags(t *testing.T) {
 		"--run-path", "/run/sbsh",
 		"attach",
 		"--socket", "/run/sbsh/clients/c-5/socket",
-		"--clear-screen",
-		"--clear-screen-on-detach",
+		"--clear-on-attach",
+		"--clear-on-detach",
 		"--id", "t-5",
 	}
 	if !reflect.DeepEqual(got, want) {


### PR DESCRIPTION
## Summary

- Renames the asymmetric `--clear-screen` / `--clear-screen-on-detach` pair (introduced days ago in #426) to the symmetric, lifecycle-explicit `--clear-on-attach` / `--clear-on-detach`. "screen" is dropped — at the attach/detach boundary there is nothing else to clear, so the pair now reads as an obvious matched set.
- Hard rename, **no backward-compat aliases** — confirmed #426's commit `0a171ff` is in **no tagged release** (`git tag --contains 0a171ff` is empty; it lands after `v0.12.5`), so AC #4's hard-rename branch applies.
- All layers from the issue's table renamed consistently: CLI flags (on both `sb attach` and the `sbsh` client root), `SB_ATTACH_*` / `SBSH_CLIENT_*` env vars + viper keys, `ClientSpec` / `pkg/attach.Options` / `api.AttachRequest` struct fields, and the JSON wire tags (`clearScreen`→`clearOnAttach`, `clearScreenOnDetach`→`clearOnDetach`).

## Scope notes (calls the reviewer can push back on)

- **Beyond the issue's table:** the table didn't enumerate the public builder surface, but it's the programmatic mirror of the flags and had to move for consistency: `pkg/builder.WithClientClearScreen`→`WithClientClearOnAttach`, `WithClientClearScreenOnDetach`→`WithClientClearOnDetach` (+ their internal `clientConfig` fields), and `pkg/attach.Options.ClearScreen/ClearScreenOnDetach`→`ClearOnAttach/ClearOnDetach`. `pkg/spawn.buildClientAttachArgs` (the producer of the `sb attach` argv) was updated in lockstep with the renamed flag strings. Leaving these on the old names would have re-created the exact asymmetry the issue removes. All are #426-era, pre-entrenchment surfaces.
- **Left as-is (issue explicitly permits):** the internal lowercase `clearScreen` params/vars/struct fields in `internal/terminal/terminalrunner/*` and `internal/client/clientrunner/terminal.go`, plus the `escClearScreen`/`escClearScreenHome` consts (which literally name the `\x1b[2J` ANSI sequence, not the flag). Doc-comment / test-error references to the removed `--clear-screen` flag literal *were* updated to `--clear-on-attach` for accuracy.

## AC #3 — on-disk metadata / migration (dev to confirm whether on-disk metadata is affected)

**No migration path needed.** Findings:
- The JSON tags `clearScreen`/`clearScreenOnDetach` live **only** on the ephemeral `api.ClientSpec` (`pkg/api/client.go`). The persistent server-side `api.TerminalSpec` carries **no** such field, so persisted terminal metadata is unaffected.
- The clear settings are supplied fresh from flags on **every** `sb attach`; the live session's behavior is driven by the in-memory `Spec` value (`io.go`, `lifecycle.go`), never read back from a persisted client doc to drive the clear. The on-disk client doc is written for live-client discovery only. A pre-rename client doc belongs to a still-running pre-rename client whose behavior is already in memory — so a hard tag rename cannot make an existing session "silently lose the setting." Clients are short-lived (one per interactive attach).

## AC #6 — docs/README references

`git grep` over the whole tree for the old flag/env/viper literals on non-`.go` files returns **none**, so no `documentation` follow-up issue is warranted.

## Test plan

- [x] `make sbsh-sb` — canonical build; binary is ELF (`7f 45 4c 46`), `sb`/`sbsh` hardlinked.
- [x] `./sb attach --help` and `./sbsh --help` show `--clear-on-attach` / `--clear-on-detach`; `--clear-screen*` no longer present.
- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `make test` (full CI target, incl. e2e) — all green.
- [x] `go test ./pkg/...` — all green (builder/spawn/attach/api tests updated for the new names).
- [x] Tree-wide `git grep` confirms no remaining `--clear-screen` / `CLEAR_SCREEN` / old viper-key / exported `ClearScreen*` identifiers (only the permitted internal lowercase locals + ANSI-escape consts remain).

Closes #430
