### PR TITLE
docs: add install one-liner to docs-site install pages

### DIFF
--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -8,6 +8,17 @@ sbsh is available for Linux, macOS, and FreeBSD. See the [Installation](install/
 
 ### Quick Install
 
+One-liner — auto-detects OS/arch, resolves the latest release, installs `sbsh` and the `sb` hardlink:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/eminwux/sbsh/main/scripts/install.sh | bash
+```
+
+Override defaults via env vars: `SBSH_VERSION=vX.Y.Z` (pin a tag), `SBSH_INSTALL_PREFIX=/path/bin` (default `/usr/local/bin`), `SBSH_REPO=owner/repo` (forks), `SBSH_SKIP_CHECKSUM=1`.
+
+<details>
+<summary>Or install manually</summary>
+
 ```bash
 # Set your platform (defaults shown)
 export OS=linux        # Options: linux, darwin, freebsd
@@ -19,6 +30,8 @@ chmod +x sbsh && \
 sudo install -m 0755 sbsh /usr/local/bin/sbsh && \
 sudo ln -f /usr/local/bin/sbsh /usr/local/bin/sb
 ```
+
+</details>
 
 ### Autocomplete Setup
 

--- a/docs/site/install/install-linux.md
+++ b/docs/site/install/install-linux.md
@@ -4,6 +4,17 @@ Install sbsh on Linux systems (Ubuntu, Debian, RHEL, CentOS, etc.).
 
 ## Quick Install
 
+One-liner — auto-detects arch, resolves the latest release, installs `sbsh` and the `sb` hardlink:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/eminwux/sbsh/main/scripts/install.sh | bash
+```
+
+Override defaults via env vars: `SBSH_VERSION=vX.Y.Z` (pin a tag), `SBSH_INSTALL_PREFIX=/path/bin` (default `/usr/local/bin`), `SBSH_REPO=owner/repo` (forks), `SBSH_SKIP_CHECKSUM=1`.
+
+<details>
+<summary>Or install manually</summary>
+
 ```bash
 # Set your architecture (default shown)
 export ARCH=amd64      # Options: amd64, arm64
@@ -14,6 +25,8 @@ chmod +x sbsh && \
 sudo install -m 0755 sbsh /usr/local/bin/sbsh && \
 sudo ln -f /usr/local/bin/sbsh /usr/local/bin/sb
 ```
+
+</details>
 
 ## Verify Installation
 

--- a/docs/site/install/install-macos.md
+++ b/docs/site/install/install-macos.md
@@ -4,6 +4,17 @@ Install sbsh on macOS systems.
 
 ## Quick Install
 
+One-liner — auto-detects arch, resolves the latest release, installs `sbsh` and the `sb` hardlink:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/eminwux/sbsh/main/scripts/install.sh | bash
+```
+
+Override defaults via env vars: `SBSH_VERSION=vX.Y.Z` (pin a tag), `SBSH_INSTALL_PREFIX=/path/bin` (default `/usr/local/bin`), `SBSH_REPO=owner/repo` (forks), `SBSH_SKIP_CHECKSUM=1`.
+
+<details>
+<summary>Or install manually</summary>
+
 ```bash
 # Set your architecture (Apple Silicon uses arm64, Intel uses amd64)
 export ARCH=arm64      # For Apple Silicon (M1/M2/M3)
@@ -15,6 +26,8 @@ chmod +x sbsh && \
 sudo install -m 0755 sbsh /usr/local/bin/sbsh && \
 sudo ln -f /usr/local/bin/sbsh /usr/local/bin/sb
 ```
+
+</details>
 
 ## Verify Installation
 


### PR DESCRIPTION
## Summary
Verbatim documentation update applied from issue #431.
Mode: verbatim.

## Spec from issue
- File: `docs/site/getting-started.md` — Section: `### Quick Install`
- File: `docs/site/install/install-linux.md` — Section: `## Quick Install`
- File: `docs/site/install/install-macos.md` — Section: `## Quick Install`
- Each page now leads with the `curl -fsSL https://raw.githubusercontent.com/eminwux/sbsh/main/scripts/install.sh | bash` one-liner + env-var note, with the existing platform-specific manual snippet retained in a `<details>` "Or install manually" block.

## Diff vs spec
- [x] Each applied hunk matches the issue's "After" wording character-for-character.
- [x] Only the three named files were touched; manual snippets keep their per-page platform specialization (`${OS}-${ARCH}`, `linux-${ARCH}`, `darwin-${ARCH}`).

Closes #431