### PR TITLE
fix: wire make install-sh-check into installer CI to catch mirror drift

### DIFF
--- a/.github/workflows/installer.yaml
+++ b/.github/workflows/installer.yaml
@@ -6,12 +6,14 @@ on:
       - main
     paths:
       - "scripts/install.sh"
+      - "docs/site/install.sh"
       - ".github/workflows/installer.yaml"
   pull_request:
     branches:
       - main
     paths:
       - "scripts/install.sh"
+      - "docs/site/install.sh"
       - ".github/workflows/installer.yaml"
   workflow_dispatch:
 
@@ -33,6 +35,13 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
+
+      # Fail fast if the published mirror (docs/site/install.sh) has drifted
+      # from the canonical scripts/install.sh — an edit to either without
+      # running `make install-sh-sync` would otherwise serve a stale installer
+      # at sbsh.io/install.sh.
+      - name: Check installer mirror is in sync
+        run: make install-sh-check
 
       - name: Run the installer
         env:


### PR DESCRIPTION
## Summary
- The `install-sh-check` drift guard added in #433 was never run in CI, and the `installer.yaml` `paths:` filters watched only `scripts/install.sh` — so a direct edit to the published mirror `docs/site/install.sh`, or an edit to `scripts/install.sh` without `make install-sh-sync`, could silently serve a stale installer at `sbsh.io/install.sh`.
- Adds a `make install-sh-check` step to the `install` job (placed right after checkout so it fails fast, before the heavy network install) that `cmp`s the two files.
- Adds `docs/site/install.sh` to both the `push` and `pull_request` `paths:` filters so a direct edit to the mirror also triggers the workflow and trips the check.

## Implementation note
- The AC said "add an `install-sh-check` *step* to installer.yaml (the job already triggers on `scripts/install.sh` changes)" — I followed that literal, lower-blast-radius reading and added it as a step in the existing `install` job rather than introducing a separate job. It does run once per matrix OS (ubuntu + macos), which is mildly redundant for a pure source-tree `cmp`; if the reviewer prefers a dedicated single-runner `drift-check` job, that's a trivial restructure.

## Test plan
- [x] `python3 -c "yaml.safe_load(...)"` — `installer.yaml` parses as valid YAML.
- [x] `make install-sh-check` exits 0 and prints "install.sh mirror in sync" when the two files match.
- [x] Verified drift detection: appended a line to `docs/site/install.sh`, `make install-sh-check` exited 2 with the "out of sync; run 'make install-sh-sync'" message; restored the mirror byte-identical (`cmp -s` clean) afterward.

Closes #435