### PR TITLE
docs(discovery): correct orphan client socket path to clients/<id>/socket

### DIFF
--- a/internal/discovery/orphans.go
+++ b/internal/discovery/orphans.go
@@ -54,7 +54,7 @@ func pruneOrphanTerminalDirs(ctx context.Context, logger *slog.Logger, runPath s
 // pruneOrphanClientDirs removes client directories whose metadata.json is
 // missing or unparseable — the clients-side counterpart of
 // pruneOrphanTerminalDirs (see #422). The live-socket guard covers the
-// client control socket (clients/<id>/client.sock — see pkg/attach).
+// client control socket (clients/<id>/socket — see pkg/builder).
 func pruneOrphanClientDirs(ctx context.Context, logger *slog.Logger, runPath string, w io.Writer) error {
 	orphans, err := pkgdiscovery.OrphanClientDirs(ctx, logger, runPath)
 	if err != nil {
@@ -102,7 +102,7 @@ func pruneOrphanDirs(ctx context.Context, logger *slog.Logger, w io.Writer, orph
 // a connection. Best-effort: a terminal whose control socket was placed
 // outside its run dir (custom Spec.SocketFile) is not detected, but the
 // default layouts (runPath/terminals/<id>/socket,
-// runPath/clients/<id>/client.sock) are covered.
+// runPath/clients/<id>/socket) are covered.
 func hasLiveSocket(ctx context.Context, dir string) bool {
 	entries, err := os.ReadDir(dir)
 	if err != nil {

--- a/internal/discovery/orphans_test.go
+++ b/internal/discovery/orphans_test.go
@@ -211,7 +211,7 @@ func TestScanAndPruneClients_SkipsOrphanWithLiveSocket(t *testing.T) {
 	if err := os.MkdirAll(clientDir, 0o700); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	ln, err := net.Listen("unix", filepath.Join(clientDir, "client.sock"))
+	ln, err := net.Listen("unix", filepath.Join(clientDir, "socket"))
 	if err != nil {
 		t.Fatalf("listen unix: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Followup-nit from PR #423: the orphan-client live-socket docstrings and test named the client control socket `clients/<id>/client.sock — see pkg/attach`, but that path exists in neither location.
- Standalone clients create `clients/<id>/socket` (`pkg/builder/client.go:165`, docstring at `:132`); `pkg/attach` does create `client.sock` (`pkg/attach/attach.go:134`) but inside an ephemeral `/tmp/sbsh-attach-*` dir — never under `clients/`.
- Corrected `client.sock` → `socket` and `pkg/attach` → `pkg/builder` at the three sites the issue named:
  - `internal/discovery/orphans.go:57` — `pruneOrphanClientDirs` docstring
  - `internal/discovery/orphans.go:105` — `hasLiveSocket` docstring
  - `internal/discovery/orphans_test.go:214` — test now listens on `socket` to match the production filename
- Behavior is unchanged: the live-socket guard dials any unix socket directly inside the dir regardless of name, so the test still passes. Doc/test fidelity only.

Note: the issue cited `pkg/builder/client.go:146` and `pkg/attach/attach.go:121`; both line numbers have since shifted (`:165` / `:134`) but the substance is unchanged and verified against current `origin/main`.

## Test plan
- [x] `make sbsh-sb` (canonical build; binary verified ELF via magic bytes — `file` not installed)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `make test` (full CI suite, exit 0 — includes e2e)
- [x] `git grep -n 'client\.sock' -- internal/discovery/` returns no matches

Closes #424