### PR TITLE
fix: prefer EvCmdExited over benign PTY-read EvError in Serve cause

### DIFF
--- a/pkg/terminal/server/adapter_internal_test.go
+++ b/pkg/terminal/server/adapter_internal_test.go
@@ -23,7 +23,9 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -290,6 +292,39 @@ func TestServer_runLoop_TerminalEvents(t *testing.T) {
 	ev2 <- terminalrunner.Event{Type: terminalrunner.EvCmdExited}
 	if err := srv.runLoop(context.Background(), ev2, make(chan error)); err == nil {
 		t.Fatal("runLoop EvCmdExited: expected non-nil exit error")
+	}
+}
+
+func TestServer_runLoop_PTYReadErrorPrefersCmdExited(t *testing.T) {
+	srv := newAdapterServer(t)
+
+	// A benign PTY-master read error (the EIO the child's tty-close triggers)
+	// reliably preempts the authoritative EvCmdExited on the shared channel.
+	// runLoop must return the EvCmdExited cause, not the benign read error.
+	eioErr := fmt.Errorf("terminalManagerReader pty read error: %w: %w",
+		terminalrunner.ErrPipeRead, syscall.EIO)
+	exitErr := errors.New("shell process exited: code=0")
+
+	ev := make(chan terminalrunner.Event, 2)
+	ev <- terminalrunner.Event{Type: terminalrunner.EvError, Err: eioErr}
+	ev <- terminalrunner.Event{Type: terminalrunner.EvCmdExited, Err: exitErr}
+	if err := srv.runLoop(context.Background(), ev, make(chan error)); !errors.Is(err, exitErr) {
+		t.Fatalf("runLoop pty-EIO then EvCmdExited = %v, want %v", err, exitErr)
+	}
+}
+
+func TestServer_runLoop_PTYReadErrorWithoutExitReturnsError(t *testing.T) {
+	srv := newAdapterServer(t)
+
+	// A genuine PTY read error with no EvCmdExited following (the child is
+	// still alive) must fall back to returning that error once the grace
+	// window elapses — the preference only applies when an exit actually races.
+	eioErr := fmt.Errorf("terminalManagerReader pty read error: %w: %w",
+		terminalrunner.ErrPipeRead, syscall.EIO)
+	ev := make(chan terminalrunner.Event, 1)
+	ev <- terminalrunner.Event{Type: terminalrunner.EvError, Err: eioErr}
+	if err := srv.runLoop(context.Background(), ev, make(chan error)); !errors.Is(err, eioErr) {
+		t.Fatalf("runLoop pty-EIO alone = %v, want %v", err, eioErr)
 	}
 }
 

--- a/pkg/terminal/server/server.go
+++ b/pkg/terminal/server/server.go
@@ -34,6 +34,7 @@ import (
 	"log/slog"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/eminwux/sbsh/internal/terminal/terminalrpc"
 	"github.com/eminwux/sbsh/internal/terminal/terminalrunner"
@@ -212,10 +213,7 @@ func (s *Server) runLoop(
 			return ctx.Err()
 		case ev := <-eventsCh:
 			if ev.Type == terminalrunner.EvError || ev.Type == terminalrunner.EvCmdExited {
-				if ev.Err != nil {
-					return ev.Err
-				}
-				return errors.New("server: terminal exited")
+				return s.terminalCause(ctx, ev, eventsCh)
 			}
 		case err := <-rpcDoneCh:
 			if err != nil {
@@ -233,6 +231,61 @@ func (s *Server) runLoop(
 			return errors.New("server: Stop called")
 		}
 	}
+}
+
+// ptyExitGrace bounds how long terminalCause waits for the authoritative
+// EvCmdExited after a benign PTY-read EvError. On a clean workload exit in
+// PID-1/init mode the PTY-master Read returns EIO — the immediate kernel
+// side-effect of the child closing its tty — and that EvError reliably
+// preempts the reaper's EvCmdExited on the shared eventsCh. The events
+// arrive back-to-back, so a short window suffices. See #438.
+const ptyExitGrace = 250 * time.Millisecond
+
+// terminalCause maps a terminating terminal event to the Serve cause. A
+// PTY-read EvError (ErrPipeRead) racing a clean child exit is benign: the
+// master read only failed because the workload closed its tty, and the
+// authoritative cause is the EvCmdExited the reaper publishes immediately
+// after. Without this preference Serve would return
+// "read /dev/ptmx: input/output error" instead of "shell process exited:
+// code=N", so a supervisor classifying the cause cannot tell a clean exit
+// from a wrapper failure (eminwux/kukeon#1282). Wait up to ptyExitGrace for
+// the EvCmdExited and return its cause; if none follows (a genuine PTY error
+// with the child still alive), fall back to the original EvError unchanged.
+// See #438.
+func (s *Server) terminalCause(
+	ctx context.Context,
+	ev terminalrunner.Event,
+	eventsCh <-chan terminalrunner.Event,
+) error {
+	if ev.Type == terminalrunner.EvError && errors.Is(ev.Err, terminalrunner.ErrPipeRead) {
+		timer := time.NewTimer(ptyExitGrace)
+		defer timer.Stop()
+		for {
+			select {
+			case ev2 := <-eventsCh:
+				if ev2.Type == terminalrunner.EvCmdExited {
+					return eventCause(ev2)
+				}
+				// Another benign reader/writer EvError can land ahead of the
+				// exit; keep waiting within the window rather than returning it.
+				continue
+			case <-timer.C:
+				return eventCause(ev)
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	}
+	return eventCause(ev)
+}
+
+// eventCause extracts the cause carried by a terminating event, falling
+// back to a generic message when the event carries no error.
+func eventCause(ev terminalrunner.Event) error {
+	if ev.Err != nil {
+		return ev.Err
+	}
+	return errors.New("server: terminal exited")
 }
 
 // Stop initiates graceful shutdown. Safe to call from another


### PR DESCRIPTION
## Summary

- `server.Server.Serve` returned whichever terminating event reached `runLoop` first, merging `EvError` and `EvCmdExited` into one branch. On a clean workload exit in PID-1/init mode the PTY-master read returns EIO — the immediate kernel side-effect of the child closing its tty — and that `EvError` reliably preempts the reaper's `EvCmdExited`, so `Serve` returned `read /dev/ptmx: input/output error` instead of `shell process exited: code=N`. A supervisor classifying the Serve cause (kukeon's `kuketty`, eminwux/kukeon#1282) could not tell a clean exit from a wrapper failure.
- Implements suggested fix #2: `runLoop` now routes terminating terminal events through a new `terminalCause` helper. When the event is a benign PTY-read `EvError` (`errors.Is(err, terminalrunner.ErrPipeRead)`), it waits up to a short grace window (`ptyExitGrace = 250ms`) for the authoritative `EvCmdExited` and returns that cause instead. If no exit follows (a genuine PTY error with the child still alive), it falls back to the original `EvError` unchanged.

## Why this approach (notes for the reviewer)

- **Server-facade-only, lowest blast radius.** The defect site the issue names is `pkg/terminal/server/server.go`'s merged branch, and kukeon consumes exactly this facade. The internal controller (`internal/terminal/controller.go:244`) already handles `EvError`/`EvCmdExited` in *separate* `switch` cases, so it is not affected and is left untouched. Suggested fix #1 (suppress the EIO in `terminalManagerReader`) and #3 (new typed exit API) both touch the shared runner event semantics other in-tree consumers rely on; #2 confines the change to the affected boundary.
- **Robust to the race rather than racing back.** The EIO fires *before* the reaper marks the child done, so suppressing at emit-time (#1) would itself race. Waiting at the consumer side for the authoritative event is deterministic.
- **Gate on `ErrPipeRead`, not narrowly on `syscall.EIO`.** The issue describes the EIO instance, but the same `terminalManagerReader` path also emits an `EvError` wrapping `ErrPipeRead` on the EOF variant of a tty-close. Gating on the `ErrPipeRead` sentinel covers both and is safe: when no `EvCmdExited` actually follows (a real PTY error, child still alive), the grace window simply expires and the original `EvError` is returned — so there are no false positives, only a bounded delay on the genuine-error path. Reviewer can push back if the narrower EIO-only gate is preferred.

## Test plan

- [x] `make test` (full CI suite incl. e2e) — pass (exit 0)
- [x] `go build ./...` — pass
- [x] `go vet ./...` — pass
- [x] `make sbsh-sb` — produces ELF executable (verified `7f 45 4c 46` magic + exec bit)
- [x] New unit tests in `adapter_internal_test.go`:
  - `TestServer_runLoop_PTYReadErrorPrefersCmdExited` — benign EIO `EvError` followed by `EvCmdExited` returns the exit cause.
  - `TestServer_runLoop_PTYReadErrorWithoutExitReturnsError` — a lone PTY read error falls back to that error after the grace window.

Closes #438