### PR TITLE
docs: enable Google Analytics 4 via Material analytics config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,9 @@ nav:
   - FAQ: faq.md
 
 extra:
+  analytics:
+    provider: google
+    property: G-NEXJDHW96D
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/eminwux/sbsh


### PR DESCRIPTION
## Summary

Enables Google Analytics 4 on the docs site by wiring the GA4 property `G-NEXJDHW96D` through mkdocs-material's native `extra.analytics` block. Material renders the standard `gtag.js` snippet from this config, so no raw HTML override is needed, and we get built-in site-search tracking for free.

```yaml
extra:
  analytics:
    provider: google
    property: G-NEXJDHW96D
```

## Notes

- No cookie-consent banner is configured (`extra.consent` is absent), so the tag fires on every page load once deployed. A consent gate can be added separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)