### PR TITLE
ci: trigger docs deploy on mkdocs.yml and workflow changes

### DIFF
--- a/.github/workflows/mkdocs.yaml
+++ b/.github/workflows/mkdocs.yaml
@@ -10,6 +10,8 @@ on:
       - main
     paths:
       - "docs/site/**"
+      - "mkdocs.yml"
+      - ".github/workflows/mkdocs.yaml"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

The docs deploy workflow only fired on pushes touching `docs/site/**`. Changes to `mkdocs.yml` (theme, plugins, analytics) or to the workflow file itself never triggered a rebuild, so the published site silently drifted from the repo config.

This brings the trigger in line with the [kukeon docs pipeline](https://github.com/eminwux/kukeon/blob/main/.github/workflows/mkdocs.yaml):

```yaml
    paths:
      - "docs/site/**"
      - "mkdocs.yml"
      - ".github/workflows/mkdocs.yaml"
```

## Notes

- Directly affects PR #440 (Google Analytics) — that change lives in `mkdocs.yml` and would not have deployed without this fix.
- `workflow_dispatch` was already present as a manual escape hatch, but config changes should rebuild automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)